### PR TITLE
added prefers-reduced-motion blue border for the queue card

### DIFF
--- a/packages/app/styles/global.css
+++ b/packages/app/styles/global.css
@@ -190,6 +190,14 @@ body {
 	filter: blur(1.5px);
 }
 
+/* make the border a static blue if the person has prefers-reduce-motion on their system */
+@media (prefers-reduced-motion: reduce) {
+    .glowy:before, .glowy:after {
+        background: #0000ff;
+        animation: none;
+    }
+}
+
 /* make selected links (i.e. the page you are currently on) hover a different colour (hovering on a selected link would appear the same)
 .ant-menu-horizontal > .ant-menu-item-selected.ant-menu-item a {
     transition: text-shadow 0.3s ease;


### PR DESCRIPTION
# Description

Rainbow border might be irritating for some users, so this adds a media query for `prefers-reduced-motion` that makes it a static blue border.

It will remain the same for most users.

Note: This actually applies to all uses of the `glowy` class (the class that adds the glowy border), but it's only used on the queue cards right now.

With prefers-reduced-motion on (static)
![image](https://github.com/ubco-db/helpme/assets/13655728/a6db96ad-32e6-4f14-bd95-1b429f3ed6a5)

With prefers-reduced-motion off (default). Same rainbow border as before
![image](https://github.com/ubco-db/helpme/assets/13655728/ba642f5f-3c7a-4832-9215-2b20304c4a4a)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`

# How Has This Been Tested?

Manual testing. I used chrome dev tools' "emulate prefers-reduced-motion environment" to see what it would look like.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any UI changes have been checked to work on desktop, tablet, and mobile
