### PR TITLE
Async Centre fixes

### DIFF
--- a/packages/app/components/Questions/AsyncQuestions/AsyncCard.tsx
+++ b/packages/app/components/Questions/AsyncQuestions/AsyncCard.tsx
@@ -169,6 +169,7 @@ export default function AsyncCard({
                       question={question}
                       hasUnresolvedRephraseAlert={false}
                       setIsExpandedTrue={setIsExpandedTrue}
+                      onStatusChange={onStatusChange}
                     />
                   </>
                 )}

--- a/packages/app/components/Questions/AsyncQuestions/TAanswerQuestionModal.tsx
+++ b/packages/app/components/Questions/AsyncQuestions/TAanswerQuestionModal.tsx
@@ -4,6 +4,8 @@ import { Input, Form, Button, message, Switch } from 'antd'
 import { API } from '@koh/api-client'
 import { AsyncQuestion, asyncQuestionStatus } from '@koh/common'
 import { default as React } from 'react'
+import { useAsnycQuestions } from '../../../hooks/useAsyncQuestions'
+import { useRouter } from 'next/router'
 
 interface EditQueueModalProps {
   visible: boolean
@@ -18,6 +20,9 @@ export function AnswerQuestionModal({
 }: EditQueueModalProps): ReactElement {
   const [form] = Form.useForm()
   const [visibleStatus, setVisibleStatus] = useState(false)
+  const router = useRouter()
+  const { cid } = router.query
+  const { mutateQuestions } = useAsnycQuestions(Number(cid))
   //use questions for form validation
   useEffect(() => {
     form.setFieldsValue(question)
@@ -33,6 +38,7 @@ export function AnswerQuestionModal({
       .then((value) => {
         if (value) {
           message.success('Response posted/edited')
+          mutateQuestions()
         } else {
           message.error("Couldn't post response")
         }

--- a/packages/app/components/Questions/AsyncQuestions/TAquestionDetailButtons.tsx
+++ b/packages/app/components/Questions/AsyncQuestions/TAquestionDetailButtons.tsx
@@ -18,7 +18,11 @@ export function TAquestionDetailButtons({
   const [answerQuestionVisible, setAnswerQuestionVisbile] = useState(false)
 
   return (
-    <>
+    <div
+      onClick={(e) => {
+        e.stopPropagation()
+      }}
+    >
       <Popconfirm
         title="Are you sure you want to delete the question?"
         okText="Yes"
@@ -56,6 +60,6 @@ export function TAquestionDetailButtons({
         question={question}
         onClose={() => setAnswerQuestionVisbile(false)}
       />
-    </>
+    </div>
   )
 }

--- a/packages/server/src/asyncQuestion/asyncQuestion.controller.ts
+++ b/packages/server/src/asyncQuestion/asyncQuestion.controller.ts
@@ -202,7 +202,10 @@ export class asyncQuestionController {
     }
     const updatedQuestion = await question.save();
 
-    if (!body?.visible) {
+    if (
+      body.status === asyncQuestionStatus.TADeleted ||
+      body.status === asyncQuestionStatus.StudentDeleted
+    ) {
       await this.redisQueueService.deleteAsyncQuestion(
         `c:${courseId}:aq`,
         updatedQuestion,

--- a/packages/server/src/asyncQuestion/asyncQuestion.controller.ts
+++ b/packages/server/src/asyncQuestion/asyncQuestion.controller.ts
@@ -190,9 +190,10 @@ export class asyncQuestionController {
       const requester = await UserCourseModel.findOne({
         where: {
           userId: user.id,
+          courseId: courseId,
         },
       });
-      if (requester.role === Role.STUDENT) {
+      if (!requester || requester.role === Role.STUDENT) {
         throw new HttpException(
           'No permission to update question.',
           HttpStatus.UNAUTHORIZED,

--- a/packages/server/test/asyncQuestion.integration.ts
+++ b/packages/server/test/asyncQuestion.integration.ts
@@ -54,7 +54,10 @@ describe('AsyncQuestion Integration', () => {
       role: Role.STUDENT,
     });
 
-    asyncQuestion = await AsyncQuestionFactory.create({ creator: studentUser });
+    asyncQuestion = await AsyncQuestionFactory.create({
+      creator: studentUser,
+      course: course,
+    });
   });
   describe('Async question creation', () => {
     it('Student can create a question', async () => {
@@ -121,6 +124,31 @@ describe('AsyncQuestion Integration', () => {
           status: 'HumanAnswered',
         })
         .expect(401);
+    });
+
+    it('Allows professors to modify a question even if they are a student in another course', async () => {
+      const prof = await UserFactory.create();
+      const otherCourse = await CourseFactory.create();
+      await UserCourseFactory.create({
+        user: prof,
+        course: otherCourse,
+        role: Role.STUDENT,
+      });
+      await UserCourseFactory.create({
+        user: prof,
+        course,
+        role: Role.PROFESSOR,
+      });
+      await supertest({ userId: prof.id })
+        .patch(`/asyncQuestions/${asyncQuestion.id}`)
+        .send({
+          status: 'HumanAnswered',
+        })
+        .expect(200)
+        .then((response) => {
+          expect(response.body).toHaveProperty('status', 'HumanAnswered');
+          expect(response.body.status).toBe('HumanAnswered');
+        });
     });
   });
 


### PR DESCRIPTION
- Fixes async questions getting banished from redis when updated
- Fixed async questions not getting refreshed when a response is posted
- Fixed TA deleting a question calling an undefined function
- Fixed clicking anywhere on the "post response" card causing the async question card to expand/unexpand
- Fixed professors from being unable to update an async question if they are a student in another course (with a new test to check for that)