### PR TITLE
add courseId filter when editing questions

### DIFF
--- a/packages/server/src/asyncQuestion/asyncQuestion.controller.ts
+++ b/packages/server/src/asyncQuestion/asyncQuestion.controller.ts
@@ -185,11 +185,12 @@ export class asyncQuestionController {
       question.taHelpedId = user.id;
     }
     // if creator, can update question anytime
-    // otherwise has to be TA/PROF of course
+    // otherwise has to be TA/PROF of the course
     if (question.creatorId !== user.id) {
       const requester = await UserCourseModel.findOne({
         where: {
           userId: user.id,
+          courseId: courseId,
         },
       });
       if (requester.role === Role.STUDENT) {


### PR DESCRIPTION
# Description
 Describe the bug
Professors can't edit async questions

To Reproduce
Steps to reproduce the behavior:

Have an account with a student role in course 2 and a professor role in course 1.
Attempt to edit async questions in course 1 as a professor.
Observe that the edit operation fails.

Expected behavior
Being able to edit async questions as professors in course 1

Current behavior
Can't edit course 1, because it's not searching for role in course.

Closes # 36

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 

- [ ] Test A
- [ ] Test B


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any UI changes have been checked to work on desktop, tablet, and mobile
