### PR TITLE
Fix endpoints allowing strings where numbers should be

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ docker-compose build && docker-compose up
 [What is each environmental variable?](docs/ENVIRONMENT_VARIABLES.md)
 [TaskQuestions/Demos/Assignments/TaskProgress Help](docs/taskQuestions_Demos_Assignments_TaskProgress_help.md)
 [Toggle Course Features Help](docs/toggle_course_features_help.md)
+[Backfill Vs Migrations](packages/server/src/backfill/README.md)
 
 ## License
 GPL-3.0

--- a/docs/taskQuestions_Demos_Assignments_TaskProgress_help.md
+++ b/docs/taskQuestions_Demos_Assignments_TaskProgress_help.md
@@ -1,4 +1,5 @@
 # Intro
+
 These features (listed below) are a list of features that work together to allow users to have "checkable" questions (i.e. questions that can be "checked off" aka demos).
 
 The primary way for professors to define tasks (right now) is through the "queueConfig", which is just a json that profs can write. This also stores other queue-specific settings (see example json below), and should be used to store any new settings that are queue-specific.

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -2122,6 +2122,7 @@ export const ERROR_MESSAGES = {
     insightUnathorized: 'User is not authorized to view this insight',
     insightNameNotFound: 'The insight requested was not found',
     insightsDisabled: 'Insights are currently unavailable, sorry :(',
+    invalidDateRange: 'Invalid date range. Start and End must be valid dates',
   },
   roleGuard: {
     notLoggedIn: 'Must be logged in',

--- a/packages/server/src/alerts/alerts.controller.ts
+++ b/packages/server/src/alerts/alerts.controller.ts
@@ -11,6 +11,7 @@ import {
   Controller,
   Get,
   Param,
+  ParseIntPipe,
   Patch,
   Post,
   UseGuards,
@@ -30,7 +31,7 @@ export class AlertsController {
 
   @Get(':courseId')
   async getAlerts(
-    @Param('courseId') courseId: number,
+    @Param('courseId', ParseIntPipe) courseId: number,
     @User() user: UserModel,
   ): Promise<GetAlertsResponse> {
     const alerts = await AlertModel.find({
@@ -84,7 +85,9 @@ export class AlertsController {
 
   @Patch(':alertId')
   @Roles(Role.STUDENT, Role.TA, Role.PROFESSOR)
-  async closeAlert(@Param('alertId') alertId: number): Promise<void> {
+  async closeAlert(
+    @Param('alertId', ParseIntPipe) alertId: number,
+  ): Promise<void> {
     const alert = await AlertModel.findOne({
       where: {
         id: alertId,

--- a/packages/server/src/asyncQuestion/asyncQuestion.controller.ts
+++ b/packages/server/src/asyncQuestion/asyncQuestion.controller.ts
@@ -13,6 +13,7 @@ import {
   HttpStatus,
   NotFoundException,
   Param,
+  ParseIntPipe,
   Patch,
   Post,
   Res,
@@ -38,8 +39,8 @@ export class asyncQuestionController {
   @Post(':qid/:vote')
   @Roles(Role.STUDENT, Role.TA, Role.PROFESSOR)
   async voteQuestion(
-    @Param('qid') qid: number,
-    @Param('vote') vote: number,
+    @Param('qid', ParseIntPipe) qid: number,
+    @Param('vote', ParseIntPipe) vote: number,
     @User() user: UserModel,
     @Res() res: Response,
   ): Promise<Response> {
@@ -98,7 +99,7 @@ export class asyncQuestionController {
   @Roles(Role.STUDENT)
   async createQuestion(
     @Body() body: CreateAsyncQuestions,
-    @Param('cid') cid: number,
+    @Param('cid', ParseIntPipe) cid: number,
     @User() user: UserModel,
     @Res() res: Response,
   ): Promise<any> {
@@ -152,7 +153,7 @@ export class asyncQuestionController {
 
   @Patch(':questionId')
   async updateQuestion(
-    @Param('questionId') questionId: number,
+    @Param('questionId', ParseIntPipe) questionId: number,
     @Body() body: UpdateAsyncQuestions,
     @User() user: UserModel,
   ): Promise<AsyncQuestionParams> {

--- a/packages/server/src/auth/auth.controller.ts
+++ b/packages/server/src/auth/auth.controller.ts
@@ -9,6 +9,7 @@ import {
   Post,
   Body,
   UseGuards,
+  ParseIntPipe,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
 import { ConfigService } from '@nestjs/config';
@@ -54,7 +55,7 @@ export class AuthController {
   async shibbolethAuth(
     @Req() req: Request,
     @Res() res: Response,
-    @Param('oid') organizationId: number,
+    @Param('oid', ParseIntPipe) organizationId: number,
   ): Promise<any> {
     const organization = await OrganizationModel.findOne({
       where: { id: organizationId },
@@ -96,7 +97,7 @@ export class AuthController {
   auth(
     @Res() res: Response,
     @Param('method') auth_method: string,
-    @Param('oid') organizationId: number,
+    @Param('oid', ParseIntPipe) organizationId: number,
   ): Response<{ redirectUri: string }> {
     res.cookie('organization.id', organizationId, {
       httpOnly: true,

--- a/packages/server/src/calendar/calendar.controller.ts
+++ b/packages/server/src/calendar/calendar.controller.ts
@@ -8,6 +8,7 @@ import {
   HttpException,
   HttpStatus,
   Delete,
+  ParseIntPipe,
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../guards/jwt-auth.guard';
 import { CalendarModel } from './calendar.entity';
@@ -52,7 +53,9 @@ export class CalendarController {
   }
 
   @Get(':cid')
-  async getAllEvents(@Param('cid') cid: number): Promise<CalendarModel[]> {
+  async getAllEvents(
+    @Param('cid', ParseIntPipe) cid: number,
+  ): Promise<CalendarModel[]> {
     const events = await CalendarModel.find({
       where: {
         course: cid,
@@ -71,7 +74,7 @@ export class CalendarController {
 
   @Delete(':id/delete')
   async deleteCalendarEvent(
-    @Param('id') eventId: number,
+    @Param('id', ParseIntPipe) eventId: number,
   ): Promise<CalendarModel> {
     const event = await CalendarModel.findOne(eventId);
     if (!event) {

--- a/packages/server/src/chatbot/chatbot.controller.ts
+++ b/packages/server/src/chatbot/chatbot.controller.ts
@@ -8,6 +8,7 @@ import {
   Param,
   Query,
   Get,
+  ParseIntPipe,
 } from '@nestjs/common';
 import { ChatDocument, ChatQuestion, ChatbotService } from './chatbot.service';
 import { JwtAuthGuard } from '../guards/jwt-auth.guard';
@@ -69,10 +70,10 @@ export class ChatbotController {
 
   @Get(':courseId/document')
   async getDocuments(
-    @Param('courseId') courseId: number,
+    @Param('courseId', ParseIntPipe) courseId: number,
     @Query('searchText') searchText: string,
-    @Query('pageSize') pageSize: number,
-    @Query('currentPage') currentPage: number,
+    @Query('pageSize', ParseIntPipe) pageSize: number,
+    @Query('currentPage', ParseIntPipe) currentPage: number,
   ): Promise<{ chatDocuments: ChatDocument[]; total: number }> {
     return await this.ChatbotService.getDocuments(
       courseId,

--- a/packages/server/src/course/course.controller.ts
+++ b/packages/server/src/course/course.controller.ts
@@ -36,6 +36,7 @@ import {
   UnauthorizedException,
   UseGuards,
   UseInterceptors,
+  ParseIntPipe,
 } from '@nestjs/common';
 import async from 'async';
 import { Response, Request } from 'express';
@@ -79,7 +80,7 @@ export class CourseController {
   @UseGuards(JwtAuthGuard, EmailVerifiedGuard)
   async getOrganizationCourses(
     @Res() res: Response,
-    @Param('oid') oid: number,
+    @Param('oid', ParseIntPipe) oid: number,
   ): Promise<Response<[]>> {
     const courses = await OrganizationCourseModel.find({
       where: {
@@ -108,7 +109,7 @@ export class CourseController {
   @Get(':cid/asyncQuestions')
   @UseGuards(JwtAuthGuard, EmailVerifiedGuard)
   async getAsyncQuestions(
-    @Param('cid') cid: number,
+    @Param('cid', ParseIntPipe) cid: number,
     @User() user: UserModel,
     @Res() res: Response,
   ): Promise<AsyncQuestionModel[]> {
@@ -219,7 +220,7 @@ export class CourseController {
 
   @Get('limited/:id/:code')
   async getLimitedCourseResponse(
-    @Param('id') id: number,
+    @Param('id', ParseIntPipe) id: number,
     @Param('code') code: string,
     @Res() res: Response,
   ): Promise<Response<GetLimitedCourseResponse>> {
@@ -265,7 +266,7 @@ export class CourseController {
   @UseGuards(JwtAuthGuard, CourseRolesGuard, EmailVerifiedGuard)
   @Roles(Role.PROFESSOR, Role.STUDENT, Role.TA)
   async get(
-    @Param('id') id: number,
+    @Param('id', ParseIntPipe) id: number,
     @User() user: UserModel,
   ): Promise<GetCourseResponse> {
     // TODO: for all course endpoint, check if they're a student or a TA
@@ -387,7 +388,7 @@ export class CourseController {
   @UseGuards(JwtAuthGuard, CourseRolesGuard, EmailVerifiedGuard)
   @Roles(Role.PROFESSOR, Role.TA)
   async editCourseInfo(
-    @Param('id') courseId: number,
+    @Param('id', ParseIntPipe) courseId: number,
     @Body() coursePatch: EditCourseInfoParams,
   ): Promise<void> {
     await this.courseService.editCourse(courseId, coursePatch);
@@ -397,7 +398,7 @@ export class CourseController {
   @UseGuards(JwtAuthGuard, CourseRolesGuard, EmailVerifiedGuard)
   @Roles(Role.PROFESSOR, Role.TA)
   async checkIn(
-    @Param('id') courseId: number,
+    @Param('id', ParseIntPipe) courseId: number,
     @Param('room') room: string,
     @User() user: UserModel,
   ): Promise<QueuePartial> {
@@ -513,7 +514,7 @@ export class CourseController {
   @UseGuards(JwtAuthGuard, CourseRolesGuard, EmailVerifiedGuard)
   @Roles(Role.PROFESSOR, Role.TA)
   async createQueue(
-    @Param('id') courseId: number,
+    @Param('id', ParseIntPipe) courseId: number,
     @Param('room') room: string,
     @User() user: UserModel,
     @Body()
@@ -628,7 +629,7 @@ export class CourseController {
   @UseGuards(JwtAuthGuard, CourseRolesGuard, EmailVerifiedGuard)
   @Roles(Role.PROFESSOR, Role.TA)
   async checkOut(
-    @Param('id') courseId: number,
+    @Param('id', ParseIntPipe) courseId: number,
     @Param('room') room: string,
     @User() user: UserModel,
   ): Promise<TACheckoutResponse> {
@@ -709,7 +710,7 @@ export class CourseController {
   @UseGuards(JwtAuthGuard, CourseRolesGuard, EmailVerifiedGuard)
   @Roles(Role.STUDENT, Role.PROFESSOR, Role.TA)
   async withdrawCourse(
-    @Param('id') courseId: number,
+    @Param('id', ParseIntPipe) courseId: number,
     @UserId() userId: number,
   ): Promise<void> {
     const userCourse = await UserCourseModel.findOne({
@@ -722,7 +723,7 @@ export class CourseController {
   @UseGuards(JwtAuthGuard, CourseRolesGuard, EmailVerifiedGuard)
   @Roles(Role.PROFESSOR)
   async taCheckinTimes(
-    @Param('id') courseId: number,
+    @Param('id', ParseIntPipe) courseId: number,
     @Query('startDate') startDate: string,
     @Query('endDate') endDate: string,
   ): Promise<TACheckinTimesResponse> {
@@ -745,8 +746,8 @@ export class CourseController {
   @UseGuards(JwtAuthGuard, CourseRolesGuard, EmailVerifiedGuard)
   @Roles(Role.PROFESSOR)
   async getUserInfo(
-    @Param('id') courseId: number,
-    @Param('page') page: number,
+    @Param('id', ParseIntPipe) courseId: number,
+    @Param('page', ParseIntPipe) page: number,
     @Param('role') role?: Role,
     @Query('search') search?: string,
   ): Promise<GetCourseUserInfoResponse> {
@@ -829,8 +830,8 @@ export class CourseController {
   async addStudent(
     @Res() res: Response,
     @Req() req: Request,
-    @Param('id') courseId: number,
-    @Param('sid') studentId: number,
+    @Param('id', ParseIntPipe) courseId: number,
+    @Param('sid', ParseIntPipe) studentId: number,
   ): Promise<Response<void>> {
     const user = await UserModel.findOne({
       where: { sid: studentId },
@@ -892,8 +893,8 @@ export class CourseController {
   @UseGuards(JwtAuthGuard, CourseRolesGuard)
   @Roles(Role.PROFESSOR)
   async updateUserRole(
-    @Param('id') courseId: number,
-    @Param('uid') userId: number,
+    @Param('id', ParseIntPipe) courseId: number,
+    @Param('uid', ParseIntPipe) userId: number,
     @Param('role') role: Role,
     @Res() res: Response,
   ): Promise<void> {
@@ -920,7 +921,7 @@ export class CourseController {
   @UseGuards(JwtAuthGuard, CourseRolesGuard, EmailVerifiedGuard)
   @Roles(Role.PROFESSOR)
   async enableDisableFeature(
-    @Param('id') courseId: number,
+    @Param('id', ParseIntPipe) courseId: number,
     @Body() body: CourseSettingsRequestBody,
   ): Promise<void> {
     // fetch existing course settings
@@ -966,7 +967,7 @@ export class CourseController {
   @UseGuards(JwtAuthGuard, CourseRolesGuard)
   @Roles(Role.PROFESSOR, Role.STUDENT, Role.TA)
   async getFeatures(
-    @Param('id') courseId: number,
+    @Param('id', ParseIntPipe) courseId: number,
   ): Promise<CourseSettingsResponse> {
     const courseSettings = await CourseSettingsModel.findOne({
       where: { courseId },
@@ -989,7 +990,7 @@ export class CourseController {
   @UseGuards(JwtAuthGuard, CourseRolesGuard)
   @Roles(Role.TA, Role.PROFESSOR)
   async getAllStudentsNotInQueue(
-    @Param('id') courseId: number,
+    @Param('id', ParseIntPipe) courseId: number,
     @Res() res: Response,
   ): Promise<UserTiny[]> {
     // have to do a manual query 'cause the current version of typeORM we're using is crunked and creates syntax errors in postgres queries
@@ -1025,7 +1026,7 @@ export class CourseController {
   @UseGuards(JwtAuthGuard, CourseRolesGuard)
   @Roles(Role.PROFESSOR, Role.TA)
   async getAllQuestionTypes(
-    @Param('id') courseId: number,
+    @Param('id', ParseIntPipe) courseId: number,
   ): Promise<QuestionTypeModel[]> {
     return QuestionTypeModel.find({ where: { cid: courseId } });
   }

--- a/packages/server/src/course/course.service.ts
+++ b/packages/server/src/course/course.service.ts
@@ -234,8 +234,8 @@ export class CourseService {
       )
       .where('"UserCourseModel"."courseId" = :courseId', { courseId });
 
-    // check if searching for specific role
-    if (role) {
+    // check if searching for specific role and ensure it is a valid role
+    if (role && role in Role) {
       query.andWhere('"UserCourseModel".role = :role', { role });
     }
     // check if searching for specific name

--- a/packages/server/src/course/course.service.ts
+++ b/packages/server/src/course/course.service.ts
@@ -235,7 +235,7 @@ export class CourseService {
       .where('"UserCourseModel"."courseId" = :courseId', { courseId });
 
     // check if searching for specific role and ensure it is a valid role
-    if (role && role in Role) {
+    if (role && Object.values(Role).includes(role)) {
       query.andWhere('"UserCourseModel".role = :role', { role });
     }
     // check if searching for specific name

--- a/packages/server/src/question/question.controller.ts
+++ b/packages/server/src/question/question.controller.ts
@@ -21,6 +21,7 @@ import {
   HttpStatus,
   NotFoundException,
   Param,
+  ParseIntPipe,
   Patch,
   Post,
   UnauthorizedException,
@@ -62,7 +63,9 @@ export class QuestionController {
   ) {}
 
   @Get('allQuestions/:cid')
-  async getAllQuestions(@Param('cid') cid: number): Promise<questions[]> {
+  async getAllQuestions(
+    @Param('cid', ParseIntPipe) cid: number,
+  ): Promise<questions[]> {
     const questions = await QuestionModel.find({
       relations: ['queue', 'creator', 'taHelped'],
       where: {
@@ -100,7 +103,7 @@ export class QuestionController {
   @Post('TAcreate/:userId')
   async TAcreateQuestion(
     @Body() body: CreateQuestionParams,
-    @Param('userId') userId: number,
+    @Param('userId', ParseIntPipe) userId: number,
   ): Promise<any> {
     const { text, questionTypes, groupable, isTaskQuestion, queueId, force } =
       body;
@@ -318,7 +321,7 @@ export class QuestionController {
   @Roles(Role.STUDENT, Role.TA, Role.PROFESSOR)
   // TODO: Use queueRole decorator, but we need to fix its performance first
   async updateQuestion(
-    @Param('questionId') questionId: number,
+    @Param('questionId', ParseIntPipe) questionId: number,
     @Body() body: UpdateQuestionParams,
     @UserId() userId: number,
   ): Promise<UpdateQuestionResponse> {
@@ -517,7 +520,9 @@ export class QuestionController {
 
   @Post(':questionId/notify')
   @Roles(Role.TA, Role.PROFESSOR)
-  async notify(@Param('questionId') questionId: number): Promise<void> {
+  async notify(
+    @Param('questionId', ParseIntPipe) questionId: number,
+  ): Promise<void> {
     const question = await QuestionModel.findOne(questionId, {
       relations: ['queue'],
     });

--- a/packages/server/src/questionType/questionType.controller.ts
+++ b/packages/server/src/questionType/questionType.controller.ts
@@ -11,6 +11,7 @@ import {
   Post,
   Res,
   HttpStatus,
+  ParseIntPipe,
 } from '@nestjs/common';
 import { Roles } from 'decorators/roles.decorator';
 import { JwtAuthGuard } from 'guards/jwt-auth.guard';
@@ -35,7 +36,7 @@ export class QuestionTypeController {
   @Roles(Role.TA, Role.PROFESSOR)
   async addQuestionType(
     @Res() res: Response,
-    @Param('courseId') courseId: number,
+    @Param('courseId', ParseIntPipe) courseId: number,
     @Body() newQuestionType: QuestionTypeParams,
   ): Promise<void> {
     let queueId = newQuestionType.queueId;
@@ -82,7 +83,7 @@ export class QuestionTypeController {
   @Roles(Role.STUDENT, Role.TA, Role.PROFESSOR)
   async getQuestionTypes(
     @Res() res: Response,
-    @Param('courseId') courseId: number,
+    @Param('courseId', ParseIntPipe) courseId: number,
     @Param('queueId') queueIdString: string,
   ): Promise<QuestionTypeModel[]> {
     let queueId: null | number = null;

--- a/packages/server/src/queue/queue.controller.ts
+++ b/packages/server/src/queue/queue.controller.ts
@@ -21,6 +21,7 @@ import {
   HttpStatus,
   NotFoundException,
   Param,
+  ParseIntPipe,
   Patch,
   Post,
   Res,
@@ -54,7 +55,9 @@ export class QueueController {
 
   @Get(':queueId')
   @Roles(Role.TA, Role.PROFESSOR, Role.STUDENT)
-  async getQueue(@Param('queueId') queueId: number): Promise<GetQueueResponse> {
+  async getQueue(
+    @Param('queueId', ParseIntPipe) queueId: number,
+  ): Promise<GetQueueResponse> {
     try {
       return this.queueService.getQueue(queueId);
     } catch (err) {
@@ -109,7 +112,7 @@ export class QueueController {
   @Patch(':queueId')
   @Roles(Role.TA, Role.PROFESSOR)
   async updateQueue(
-    @Param('queueId') queueId: number,
+    @Param('queueId', ParseIntPipe) queueId: number,
     @Body() body: UpdateQueueParams,
   ): Promise<QueueModel> {
     const queue = await this.queueService.getQueue(queueId);
@@ -132,7 +135,9 @@ export class QueueController {
 
   @Post(':queueId/clean')
   @Roles(Role.TA, Role.PROFESSOR)
-  async cleanQueue(@Param('queueId') queueId: number): Promise<void> {
+  async cleanQueue(
+    @Param('queueId', ParseIntPipe) queueId: number,
+  ): Promise<void> {
     // Clean up queue if necessary
     try {
       setTimeout(async () => {
@@ -152,7 +157,7 @@ export class QueueController {
   // Endpoint to send frontend receive server-sent events when queue changes
   @Get(':queueId/sse')
   sendEvent(
-    @Param('queueId') queueId: number,
+    @Param('queueId', ParseIntPipe) queueId: number,
     @QueueRole() role: Role,
     @UserId() userId: number,
     @Res() res: Response,
@@ -174,7 +179,7 @@ export class QueueController {
   @Delete(':queueId')
   @Roles(Role.TA, Role.PROFESSOR)
   async disableQueue(
-    @Param('queueId') queueId: number,
+    @Param('queueId', ParseIntPipe) queueId: number,
     @QueueRole() role: Role,
   ): Promise<void> {
     // disable a queue
@@ -226,7 +231,7 @@ export class QueueController {
   @Patch(':queueId/config')
   @Roles(Role.TA, Role.PROFESSOR)
   async setConfig(
-    @Param('queueId') queueId: number,
+    @Param('queueId', ParseIntPipe) queueId: number,
     @Body() newConfig: QueueConfig,
     @Res() res: Response,
   ): Promise<Response<setQueueConfigResponse>> {

--- a/packages/server/src/studentTaskProgress/studentTaskProgress.controller.ts
+++ b/packages/server/src/studentTaskProgress/studentTaskProgress.controller.ts
@@ -2,7 +2,6 @@ import {
   AllStudentAssignmentProgress,
   Role,
   StudentAssignmentProgress,
-  StudentTaskProgress,
   StudentTaskProgressWithUser,
   UserPartial,
 } from '@koh/common';
@@ -13,6 +12,7 @@ import {
   ClassSerializerInterceptor,
   Get,
   Param,
+  ParseIntPipe,
 } from '@nestjs/common';
 import { Roles } from 'decorators/roles.decorator';
 import { JwtAuthGuard } from 'guards/jwt-auth.guard';
@@ -32,8 +32,8 @@ export class StudentTaskProgressController {
   @Get('student/:userId/:courseId/:assignmentName')
   @Roles(Role.STUDENT, Role.TA, Role.PROFESSOR)
   async getStudentAssignmentProgress(
-    @Param('userId') userId: number,
-    @Param('courseId') courseId: number,
+    @Param('userId', ParseIntPipe) userId: number,
+    @Param('courseId', ParseIntPipe) courseId: number,
     @Param('assignmentName') assignmentName: string,
   ): Promise<StudentAssignmentProgress | null> {
     const studentTaskProgress = await StudentTaskProgressModel.findOne({
@@ -72,8 +72,8 @@ export class StudentTaskProgressController {
   @UseGuards(QueueRolesGuard)
   @Roles(Role.TA, Role.PROFESSOR)
   async getAllAssignmentProgressForQueue(
-    @Param('queueId') queueId: number,
-    @Param('courseId') courseId: number,
+    @Param('queueId', ParseIntPipe) queueId: number,
+    @Param('courseId', ParseIntPipe) courseId: number,
     @Param('assignmentName') assignmentName: string,
   ): Promise<AllStudentAssignmentProgress> {
     // this returns the entire StudentTaskProgress for all students (which includes the assignment progress for stuff we don't care about)
@@ -126,7 +126,7 @@ export class StudentTaskProgressController {
   @Get('course/:courseId')
   @Roles(Role.TA, Role.PROFESSOR)
   async getAllStudentTaskProgressForCourse(
-    @Param('courseId') courseId: number,
+    @Param('courseId', ParseIntPipe) courseId: number,
   ): Promise<StudentTaskProgressWithUser[]> {
     // doing a left join with userCourse first so that it only gets the students in the course
     // we want to get all students since some may have never made any progress (e.g. if they never attended a lab, they would have no task progress)

--- a/packages/server/test/organization.integration.ts
+++ b/packages/server/test/organization.integration.ts
@@ -408,8 +408,17 @@ describe('Organization Integration', () => {
         `/organization/${organization.id}`,
       );
 
-      expect(res.status).toBe(200);
       expect(res.body).toMatchSnapshot();
+      expect(res.status).toBe(200);
+    });
+
+    it('should throw an error if oid is NaN', async () => {
+      const user = await UserFactory.create();
+      const res = await supertest({ userId: user.id }).get(
+        `/organization/thisisnotanumber`,
+      );
+
+      expect(res.status).toBe(400);
     });
   });
 


### PR DESCRIPTION
# Description

Adds ParseIntPipe to all endpoints that use `@Param` with an id/number of some kind. Without this pipe, `@Param` will allow strings and can cause backend stuff to error or crash.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`

# How Has This Been Tested?

I don't want to add like a million new tests but i did add one

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Any UI changes have been checked to work on desktop, tablet, and mobile
