### PR TITLE
disable sentry when NODE_ENV === production

### DIFF
--- a/packages/app/next.config.js
+++ b/packages/app/next.config.js
@@ -45,7 +45,7 @@ const config = {
     if (
       (SERVICE_VERSION,
         SENTRY_DSN,
-        SENTRY_AUTH_TOKEN && NODE_ENV === "production")
+        SENTRY_AUTH_TOKEN && NODE_ENV === "sentryEnabled")
     ) {
       config.plugins.push(
         new SentryWebpackPlugin({

--- a/packages/app/pages/_app.tsx
+++ b/packages/app/pages/_app.tsx
@@ -9,9 +9,9 @@ import { ErrorBoundary } from '../components/common/ErrorBoundary'
 import { ChatbotContextProvider } from '../providers/chatbotProvider'
 import * as Sentry from '@sentry/node'
 
-if (process.env.NODE_ENV === 'production' && typeof window !== 'undefined') {
+if (process.env.NODE_ENV === 'sentryEnabled' && typeof window !== 'undefined') {
   Sentry.init({
-    enabled: process.env.NODE_ENV === 'production',
+    enabled: process.env.NODE_ENV === 'sentryEnabled',
     dsn: 'https://9cfb47804c93495ba3a66a9d79cec084@o440615.ingest.sentry.io/5557379',
     tracesSampleRate: 0.2,
   })

--- a/packages/server/src/bootstrap.ts
+++ b/packages/server/src/bootstrap.ts
@@ -18,7 +18,7 @@ export async function bootstrap(hot: any): Promise<void> {
     logger: ['error', 'warn', 'log', 'debug', 'verbose'],
   });
 
-  if (process.env.NODE_ENV === 'production') {
+  if (process.env.NODE_ENV === 'sentryEnabled') {
     setupAPM(app);
   }
   app.enableShutdownHooks(); // So we can clean up SSE.


### PR DESCRIPTION
We're not using sentry right now, so we're disabling it temporarily