### PR TITLE
fix chat_token limit bug

### DIFF
--- a/packages/server/src/organization/organization.controller.ts
+++ b/packages/server/src/organization/organization.controller.ts
@@ -78,14 +78,22 @@ export class OrganizationController {
     @Res() res: Response,
     @Param('oid') oid: number,
   ): Promise<Response<void>> {
-    return ChatTokenModel.query(`
+    await ChatTokenModel.query(`
       UPDATE public.chat_token_model
       SET used = 0, max_uses = CASE
-        WHEN (SELECT user_course_model.role FROM user_course_model WHERE "userId" = public.chat_token_model.user) = 'professor' THEN 300
+        WHEN EXISTS (
+          SELECT 1 
+          FROM user_course_model 
+          WHERE "userId" = public.chat_token_model.user 
+          AND role = 'professor'
+        ) THEN 300
         ELSE 30
       END
     `);
+
+    return res.sendStatus(200);
   }
+
   @Post(':oid/populate_subscription_table')
   @UseGuards(
     JwtAuthGuard,


### PR DESCRIPTION
# Description

more than one row returned by a subquery used as an expression" error. It sets the max_uses to 300 if the user has a professor role in any course, and to 30 otherwise.
Closes # (issue number)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 

- [ ] Test A
- [ ] Test B


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any UI changes have been checked to work on desktop, tablet, and mobile
