### PR TITLE
Fix login with google not working with multiple organizations

### DIFF
--- a/packages/server/src/auth/auth.service.ts
+++ b/packages/server/src/auth/auth.service.ts
@@ -122,7 +122,7 @@ export class AuthService {
         );
       }
 
-      if (user && user.organizationUser.organizationId === organizationId) {
+      if (user) {
         return user.id;
       }
 

--- a/packages/server/src/auth/auth.service.ts
+++ b/packages/server/src/auth/auth.service.ts
@@ -100,7 +100,15 @@ export class AuthService {
         throw new BadRequestException('Email not verified');
       }
 
-      const user = await UserModel.findOne({ email: payload.email });
+      const user = await UserModel.findOne({
+        where: {
+          email: payload.email,
+          organizationUser: {
+            organizationId: organizationId,
+          },
+        },
+        relations: ['organizationUser'],
+      });
 
       if (user && user.password) {
         throw new BadRequestException(
@@ -114,7 +122,7 @@ export class AuthService {
         );
       }
 
-      if (user) {
+      if (user && user.organizationUser.organizationId === organizationId) {
         return user.id;
       }
 


### PR DESCRIPTION
# Description

Right now, if you login with google to org A and then try to login with google (same account) to org B, you just get logged into org A again.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`

# How Has This Been Tested?

Can't really test this on dev that well so we're gonna test it on prod later tonight

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] Any UI changes have been checked to work on desktop, tablet, and mobile
