### PR TITLE
Redirection to notification page from queue page fix

### DIFF
--- a/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/page.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/page.tsx
@@ -451,7 +451,7 @@ export default function QueuePage({ params }: QueuePageProps): ReactElement {
                 onClick={() => {
                   notification.destroy()
                   setIsFirstQuestion(false)
-                  router.push(`/profile`)
+                  router.push(`/profile?page=notifications`)
                 }}
                 className="ml-2"
                 aria-describedby="enable-notifications-text"

--- a/packages/frontend/app/(dashboard)/profile/components/ProfileSettings.tsx
+++ b/packages/frontend/app/(dashboard)/profile/components/ProfileSettings.tsx
@@ -9,10 +9,22 @@ import EditProfile from './EditProfile'
 import NotificationsSettings from './NotificationsSettings'
 import CoursePreference from './CoursePreference'
 import EmailNotifications from './EmailNotifications'
+import { useSearchParams } from 'next/navigation';
 
 const ProfileSettings: React.FC = () => {
+  const params = useSearchParams()
+
   const [currentSettings, setCurrentSettings] = useState(
-    SettingsOptions.PROFILE,
+    () => {
+      switch(params.get("page")) {
+        case "notifications":
+          return SettingsOptions.NOTIFICATIONS
+        case "preferences":
+          return SettingsOptions.PREFERENCES
+        default:
+          return SettingsOptions.PROFILE
+      }
+    }
   )
 
   return (
@@ -22,7 +34,7 @@ const ProfileSettings: React.FC = () => {
         className="mx-auto mt-2 h-fit w-full max-w-max text-center md:mx-0 md:mt-0"
       >
         <AvatarSettings />
-        <SettingsMenu setCurrentSettings={setCurrentSettings} />
+        <SettingsMenu currentSettings={currentSettings} setCurrentSettings={setCurrentSettings} />
       </Col>
       <div className="mr-8 hidden border-r border-gray-300 md:mr-8 md:block md:border-r md:border-gray-300" />
       <Space

--- a/packages/frontend/app/(dashboard)/profile/components/SettingsMenu.tsx
+++ b/packages/frontend/app/(dashboard)/profile/components/SettingsMenu.tsx
@@ -9,10 +9,11 @@ import CoursePreference from './CoursePreference'
 import { useMediaQuery } from '@/app/hooks/useMediaQuery'
 import EmailNotifications from './EmailNotifications'
 interface SettingsMenuProps {
+  currentSettings: SettingsOptions;
   setCurrentSettings: (settings: SettingsOptions) => void
 }
 
-const SettingsMenu: React.FC<SettingsMenuProps> = ({ setCurrentSettings }) => {
+const SettingsMenu: React.FC<SettingsMenuProps> = ({ currentSettings, setCurrentSettings }) => {
   const isMobile = useMediaQuery('(max-width: 768px)')
 
   return isMobile ? (
@@ -46,7 +47,7 @@ const SettingsMenu: React.FC<SettingsMenuProps> = ({ setCurrentSettings }) => {
   ) : (
     <Menu
       className="mt-5 bg-transparent text-left"
-      defaultSelectedKeys={[SettingsOptions.PROFILE]}
+      defaultSelectedKeys={[currentSettings]}
       onClick={(e) => setCurrentSettings(e.key as SettingsOptions)}
       items={[
         {


### PR DESCRIPTION
# Description

Made redirect to notifications section of profile work as intended (opens the notification tab by default in profile page) when student asks their first question on the website and clicks on the associated dialog.
* Simple changes to `[qid]/page.tsx` to redirect to profile page directly to the notifications tab/subpage
* Support for this via use of search params in the profile page
  * Settings buttons now has parameter for the 'currentSettings' passed down so the correct button is highlighted
* Added same functionality for 'preferences' tab in case a redirect to that will be used in the future

Closes #60

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`

# How Has This Been Tested?

Manually tested by logging in on one browser as an instructor, opening a queue, then opening another browser as a student, joining the queue, and selecting the option to turn on notifications.

No unit tests were written for this issue.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Any UI changes have been checked to work on desktop, tablet, and mobile