### PR TITLE
[Don't Merge] Base64 encoding on course invite codes

### DIFF
--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -2076,6 +2076,14 @@ export function transformIntoTaskTree(
   return taskTree
 }
 
+export function encodeBase64(str: string) {
+  return Buffer.from(str, 'utf-8').toString('base64')
+}
+
+export function decodeBase64(str: string) {
+  return Buffer.from(str, 'base64').toString('utf-8')
+}
+
 export const ERROR_MESSAGES = {
   common: {
     pageOutOfBounds: "Can't retrieve out of bounds page.",

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -2076,6 +2076,11 @@ export function transformIntoTaskTree(
   return taskTree
 }
 
+/**
+ * Rather than using encodeURIComponent and decodeURIComponent,
+ * we can encode/decode to/from base 64, which also doesn't need to be encoded/decoded
+ * from to/from URI component
+ */
 export function encodeBase64(str: string) {
   return Buffer.from(str, 'utf-8').toString('base64')
 }

--- a/packages/frontend/app/(dashboard)/components/CourseInviteCode.tsx
+++ b/packages/frontend/app/(dashboard)/components/CourseInviteCode.tsx
@@ -4,7 +4,7 @@ import { API } from '@/app/api'
 import { getErrorMessage } from '@/app/utils/generalUtils'
 import printQRCode from '@/app/utils/QRCodePrintUtils'
 import { CopyOutlined, QrcodeOutlined } from '@ant-design/icons'
-import { OrganizationCourseResponse } from '@koh/common'
+import { encodeBase64, OrganizationCourseResponse } from '@koh/common'
 import { Button, Form, Input, message } from 'antd'
 import { useCallback, useState } from 'react'
 
@@ -54,7 +54,7 @@ const CourseInviteCode: React.FC<CourseInviteCodeProps> = ({
   const inviteURL =
     courseCode === null || courseCode === undefined
       ? 'No invite code set. No students can join the course'
-      : `${baseURL}/invite?cid=${courseData.course?.id}&code=${encodeURIComponent(courseCode)}`
+      : `${baseURL}/invite?cid=${courseData.course?.id}&code=${encodeBase64(courseCode)}`
 
   const handleCopy = () => {
     if (courseCode === null) {

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/queue_invites/components/QueueInvite.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/queue_invites/components/QueueInvite.tsx
@@ -11,7 +11,11 @@ import {
   Tooltip,
   message,
 } from 'antd'
-import type { QueueInvite, QueueInviteParams } from '@koh/common'
+import {
+  encodeBase64,
+  type QueueInvite,
+  type QueueInviteParams,
+} from '@koh/common'
 import { getErrorMessage } from '@/app/utils/generalUtils'
 import { API } from '@/app/api'
 import { CopyOutlined, DeleteOutlined, QrcodeOutlined } from '@ant-design/icons'
@@ -38,7 +42,7 @@ const QueueInviteListItem: React.FC<QueueInviteProps> = ({
   const [copyLinkText, setCopyLinkText] = useState('Copy Link')
   const [hasValuesChanged, setHasValuesChanged] = useState(false)
   const [isSaveLoading, setIsSaveLoading] = useState(false)
-  const inviteURL = `${baseURL}/qi/${queueInvite.queueId}?c=${encodeURIComponent(queueInvite.inviteCode)}`
+  const inviteURL = `${baseURL}/qi/${queueInvite.queueId}?c=${encodeBase64(queueInvite.inviteCode)}`
   const handleCopy = () => {
     navigator.clipboard.writeText(inviteURL).then(() => {
       setCopyLinkText('Copied!')
@@ -84,7 +88,7 @@ const QueueInviteListItem: React.FC<QueueInviteProps> = ({
             <div className="flex items-center gap-2">
               <Link
                 target="_blank" // open in new tab
-                href={`/qi/${queueInvite.queueId}?c=${encodeURIComponent(queueInvite.inviteCode)}`}
+                href={`/qi/${queueInvite.queueId}?c=${encodeBase64(queueInvite.inviteCode)}`}
               >
                 {inviteURL}
               </Link>

--- a/packages/frontend/app/invite/page.tsx
+++ b/packages/frontend/app/invite/page.tsx
@@ -2,7 +2,12 @@
 
 import { message } from 'antd'
 import { ReactElement, Suspense, useEffect, useState } from 'react'
-import { GetLimitedCourseResponse, UBCOuserParam, User } from '@koh/common'
+import {
+  decodeBase64,
+  GetLimitedCourseResponse,
+  UBCOuserParam,
+  User,
+} from '@koh/common'
 import { API } from '@/app/api'
 import { userApi } from '../api/userApi'
 import { useRouter, useSearchParams } from 'next/navigation'
@@ -15,7 +20,8 @@ export default function CourseInvitePage(): ReactElement {
   const searchParams = useSearchParams()
   const router = useRouter()
   const cid = Number(searchParams.get('cid'))
-  const code = decodeURIComponent(searchParams.get('code') ?? '')
+  const encodedCode = searchParams.get('code') ?? ''
+  const code = decodeBase64(encodedCode)
   const [errorGettingCourse, setErrorGettingCourse] = useState(false)
   const [errorGettingUser, setErrorGettingUser] = useState(false)
 
@@ -37,7 +43,7 @@ export default function CourseInvitePage(): ReactElement {
   useEffect(() => {
     const fetchData = async () => {
       await API.course
-        .getLimitedCourseResponse(cid, code)
+        .getLimitedCourseResponse(cid, encodedCode)
         .then((res) => {
           setCourse(res)
           // if the user is not found, redirect to login
@@ -53,14 +59,14 @@ export default function CourseInvitePage(): ReactElement {
     if (cid) {
       fetchData()
     }
-  }, [cid, code, errorGettingUser, router])
+  }, [cid, encodedCode, errorGettingUser, router])
 
   const cardMetaTitle = `You have been invited to join '${course?.name}'`
   const cardMetaDescription = `This course is managed by ${course?.organizationCourse?.name}`
 
   const addStudent = async (userData: UBCOuserParam) => {
     await API.course
-      .enrollByInviteCode(userData, code)
+      .enrollByInviteCode(userData, encodedCode)
       .then(() => {
         router.push(`/course/${cid}`)
       })

--- a/packages/server/src/course/course.controller.ts
+++ b/packages/server/src/course/course.controller.ts
@@ -2,6 +2,7 @@ import {
   asyncQuestionStatus,
   CourseSettingsRequestBody,
   CourseSettingsResponse,
+  decodeBase64,
   EditCourseInfoParams,
   ERROR_MESSAGES,
   GetCourseResponse,
@@ -225,10 +226,11 @@ export class CourseController {
     @Param('code') code: string,
     @Res() res: Response,
   ): Promise<Response<GetLimitedCourseResponse>> {
+    const decodedCode = decodeBase64(code);
     const courseWithOrganization = await CourseModel.findOne({
       where: {
         id: id,
-        courseInviteCode: code,
+        courseInviteCode: decodedCode,
       },
       relations: ['organizationCourse', 'organizationCourse.organization'],
     });
@@ -773,6 +775,7 @@ export class CourseController {
     @Body() body: UBCOuserParam,
     @Res() res: Response,
   ): Promise<Response<void>> {
+    const decodedCode = decodeBase64(code);
     const user = await UserModel.findOne({
       where: {
         email: body.email,
@@ -802,7 +805,7 @@ export class CourseController {
 
     if (
       course.course.courseInviteCode === null ||
-      course.course.courseInviteCode !== code
+      course.course.courseInviteCode !== decodedCode
     ) {
       res.status(HttpStatus.BAD_REQUEST).send({
         message: ERROR_MESSAGES.courseController.invalidInviteCode,

--- a/packages/server/src/queue/queue-invite.controller.ts
+++ b/packages/server/src/queue/queue-invite.controller.ts
@@ -1,4 +1,5 @@
 import {
+  decodeBase64,
   ERROR_MESSAGES,
   GetQueueResponse,
   ListQuestionsResponse,
@@ -115,10 +116,11 @@ export class QueueInviteController {
     @Param('inviteCode') inviteCode: string,
     @Res() res: Response,
   ): Promise<Response<PublicQueueInvite>> {
+    const decodedInviteCode = decodeBase64(inviteCode);
     try {
       const invite = await this.queueService.getQueueInvite(
         queueId,
-        inviteCode,
+        decodedInviteCode,
       );
       res.status(HttpStatus.OK).send(invite);
       return;

--- a/packages/server/src/queue/queue.service.ts
+++ b/packages/server/src/queue/queue.service.ts
@@ -1,4 +1,5 @@
 import {
+  decodeBase64,
   ListQuestionsResponse,
   OpenQuestionStatus,
   PublicQueueInvite,
@@ -471,8 +472,16 @@ export class QueueService {
 
   async verifyQueueInviteCodeAndCheckIfQuestionsVisible(
     queueId: number,
-    inviteCode: string,
+    encodedInviteCode: string,
   ): Promise<boolean> {
+    let inviteCode = '';
+    try {
+      inviteCode = decodeBase64(encodedInviteCode);
+    } catch (err) {
+      console.error('Error while decoding invite code:');
+      console.error(err);
+      throw new BadRequestException('Invalid invite code');
+    }
     const queueInvite = await QueueInviteModel.findOne({
       where: {
         queueId,


### PR DESCRIPTION
# Description

Why? Because right now profs are allowed to put special characters within the course invite codes. and doing so may break the course invite. This fixes this issue.

The reason it should not be merged right now is **this will break all current course invite links**, as they will all be turned into base64 rather than simple encodeURIcomponent.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`

# How Has This Been Tested?

I tried accepting an invite as a non-logged in student and it worked fine.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any work that this PR is dependent on has been merged into the main branch
- [ ] Any UI changes have been checked to work on desktop, tablet, and mobile
