### PR TITLE
Queue invite code base64 encoding

### DIFF
--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -2076,6 +2076,14 @@ export function transformIntoTaskTree(
   return taskTree
 }
 
+export function encodeBase64(str: string) {
+  return Buffer.from(str, 'utf-8').toString('base64')
+}
+
+export function decodeBase64(str: string) {
+  return Buffer.from(str, 'base64').toString('utf-8')
+}
+
 export const ERROR_MESSAGES = {
   common: {
     pageOutOfBounds: "Can't retrieve out of bounds page.",

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/queue_invites/components/QueueInvite.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/queue_invites/components/QueueInvite.tsx
@@ -11,7 +11,11 @@ import {
   Tooltip,
   message,
 } from 'antd'
-import type { QueueInvite, QueueInviteParams } from '@koh/common'
+import {
+  encodeBase64,
+  type QueueInvite,
+  type QueueInviteParams,
+} from '@koh/common'
 import { getErrorMessage } from '@/app/utils/generalUtils'
 import { API } from '@/app/api'
 import { CopyOutlined, DeleteOutlined, QrcodeOutlined } from '@ant-design/icons'
@@ -38,7 +42,7 @@ const QueueInviteListItem: React.FC<QueueInviteProps> = ({
   const [copyLinkText, setCopyLinkText] = useState('Copy Link')
   const [hasValuesChanged, setHasValuesChanged] = useState(false)
   const [isSaveLoading, setIsSaveLoading] = useState(false)
-  const inviteURL = `${baseURL}/qi/${queueInvite.queueId}?c=${encodeURIComponent(queueInvite.inviteCode)}`
+  const inviteURL = `${baseURL}/qi/${queueInvite.queueId}?c=${encodeBase64(queueInvite.inviteCode)}`
   const handleCopy = () => {
     navigator.clipboard.writeText(inviteURL).then(() => {
       setCopyLinkText('Copied!')
@@ -84,7 +88,7 @@ const QueueInviteListItem: React.FC<QueueInviteProps> = ({
             <div className="flex items-center gap-2">
               <Link
                 target="_blank" // open in new tab
-                href={`/qi/${queueInvite.queueId}?c=${encodeURIComponent(queueInvite.inviteCode)}`}
+                href={`/qi/${queueInvite.queueId}?c=${encodeBase64(queueInvite.inviteCode)}`}
               >
                 {inviteURL}
               </Link>

--- a/packages/server/src/queue/queue-invite.controller.ts
+++ b/packages/server/src/queue/queue-invite.controller.ts
@@ -1,4 +1,5 @@
 import {
+  decodeBase64,
   ERROR_MESSAGES,
   GetQueueResponse,
   ListQuestionsResponse,
@@ -115,10 +116,11 @@ export class QueueInviteController {
     @Param('inviteCode') inviteCode: string,
     @Res() res: Response,
   ): Promise<Response<PublicQueueInvite>> {
+    const decodedInviteCode = decodeBase64(inviteCode);
     try {
       const invite = await this.queueService.getQueueInvite(
         queueId,
-        inviteCode,
+        decodedInviteCode,
       );
       res.status(HttpStatus.OK).send(invite);
       return;

--- a/packages/server/src/queue/queue.service.ts
+++ b/packages/server/src/queue/queue.service.ts
@@ -1,4 +1,5 @@
 import {
+  decodeBase64,
   ListQuestionsResponse,
   OpenQuestionStatus,
   PublicQueueInvite,
@@ -471,8 +472,16 @@ export class QueueService {
 
   async verifyQueueInviteCodeAndCheckIfQuestionsVisible(
     queueId: number,
-    inviteCode: string,
+    encodedInviteCode: string,
   ): Promise<boolean> {
+    let inviteCode = '';
+    try {
+      inviteCode = decodeBase64(encodedInviteCode);
+    } catch (err) {
+      console.error('Error while decoding invite code:');
+      console.error(err);
+      throw new BadRequestException('Invalid invite code');
+    }
     const queueInvite = await QueueInviteModel.findOne({
       where: {
         queueId,

--- a/packages/server/test/queue-invite.integration.ts
+++ b/packages/server/test/queue-invite.integration.ts
@@ -1,4 +1,4 @@
-import { QueueInviteParams } from '@koh/common';
+import { encodeBase64, QueueInviteParams } from '@koh/common';
 import { QueueModule } from '../src/queue/queue.module';
 import {
   CourseFactory,
@@ -250,7 +250,7 @@ describe('Queue Invite Integration', () => {
       const invite = await QueueInviteFactory.create({ queue: queue });
 
       await supertest({ userId: publicUser.id })
-        .get(`/queueInvites/${queue.id}/${invite.inviteCode}`)
+        .get(`/queueInvites/${queue.id}/${encodeBase64(invite.inviteCode)}`)
         .expect(200);
     });
     it('returns 404 when the queue does not exist', async () => {
@@ -292,7 +292,9 @@ describe('Queue Invite Integration', () => {
       });
 
       await supertest({ userId: publicUser.id })
-        .get(`/queueInvites/${queue.id}/${invite.inviteCode}/questions`)
+        .get(
+          `/queueInvites/${queue.id}/${encodeBase64(invite.inviteCode)}/questions`,
+        )
         .expect(200);
     });
     it('returns 404 when the queue does not exist', async () => {
@@ -355,7 +357,9 @@ describe('Queue Invite Integration', () => {
       });
 
       await supertest({ userId: publicUser.id })
-        .get(`/queueInvites/${queue.id}/${invite.inviteCode}/queue`)
+        .get(
+          `/queueInvites/${queue.id}/${encodeBase64(invite.inviteCode)}/queue`,
+        )
         .expect(200);
     });
     it('returns 404 when the queue does not exist', async () => {


### PR DESCRIPTION
# Description

This changes queue invite codes to be encoded in base64 rather than simple encodeURIComponent.

Why? So that professors can put special characters inside the queue invite code without a bunch of stuff breaking.

I also fixed a bug where it wasn't enrolling the person if they were already logged in.

**I need this merged before anyone makes any links**

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`

# How Has This Been Tested?

I did some manual testing and everything seems to work fine.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [ ] Any UI changes have been checked to work on desktop, tablet, and mobile
