### PR TITLE
Hopefully fix redirect to queue invite page after registering with google

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -62,15 +62,15 @@
 
 ###### GOOGLE_CLIENT_ID
 
-**Purpose:** used for "Log in with Google" feature.
+**Purpose:** used for "Log in with Google" feature. Not needed if you don't plan on using it.
 
-**How to get:** Can get it from https://console.developers.google.com/apis/credentials probably. Not needed if you're just testing. 
+**How to get:** Can get it from https://developers.google.com/identity/sign-in/web/sign-in 
 
 ###### GOOGLE_REDIRECT_URI
 
 **Purpose:** same as GOOGLE_CLIENT_ID
 
-**How to get:** same as GOOGLE_CLIENT_ID
+**How to get:** `domain` + `/api/v1/auth/callback/google` (e.g. `http://localhost:3000/api/v1/auth/callback/google`)
 
 ###### GOOGLE_CLIENT_SECRET
 

--- a/packages/frontend/app/api/cookieApi.ts
+++ b/packages/frontend/app/api/cookieApi.ts
@@ -47,7 +47,7 @@ export async function setQueueInviteCookie(
         secure: true,
         maxAge: 3600, // 1 hour
         path: '/',
-        sameSite: 'strict', // Helps mitigate CSRF attacks
+        sameSite: 'none', // setting it to Strict helps mitigate CSRF attacks, but we need it as none to allow for third-party authentication (login with google)
       },
     )
   } catch (error) {


### PR DESCRIPTION
# Description

The system won't redirect you to the queue invite page after registering with google for some reason. 

I am unsure if this actually fixes it, I am unable to test if google oath works on localhost

