### PR TITLE
More loading states for buttons

### DIFF
--- a/packages/frontend/app/(dashboard)/layout.tsx
+++ b/packages/frontend/app/(dashboard)/layout.tsx
@@ -74,7 +74,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
           URLSegments[4] === 'chatbot_questions' ? (
             <div className="p-1">{children}</div>
           ) : (
-            <StandardPageContainer>
+            <StandardPageContainer className="flex-grow">
               {children}
             </StandardPageContainer>
           )}


### PR DESCRIPTION
# Description

Adds a few more loading states, which should make some buttons feel a bit more responsive to click for students.

![image](https://github.com/user-attachments/assets/2bc64b9c-d6bb-493d-8d51-92ca96ef73d1)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`

# How Has This Been Tested?

Manually tested each button that was changed. Also looked at every page again to make sure nothing broke by adding flex-grow.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [x] Any UI changes have been checked to work on desktop, tablet, and mobile
