### PR TITLE
Fix duplicate notifications and add unsubscribe option to all emails

### DIFF
--- a/packages/server/src/asyncQuestion/asyncQuestion.controller.ts
+++ b/packages/server/src/asyncQuestion/asyncQuestion.controller.ts
@@ -241,6 +241,7 @@ export class asyncQuestionController {
           serviceType: MailServiceType.ASYNC_QUESTION_FLAGGED,
         })
         .andWhere('subscription.isSubscribed = true')
+        .groupBy('user.id') // Add this line to group by user
         .getMany();
 
       // Send emails in parallel

--- a/packages/server/src/asyncQuestion/asyncQuestion.controller.ts
+++ b/packages/server/src/asyncQuestion/asyncQuestion.controller.ts
@@ -244,7 +244,6 @@ export class asyncQuestionController {
           serviceType: MailServiceType.ASYNC_QUESTION_FLAGGED,
         })
         .andWhere('subscription.isSubscribed = true')
-        .groupBy('user.id') // Add this line to group by user
         .getMany();
 
       // Send emails in parallel

--- a/packages/server/src/asyncQuestion/asyncQuestion.controller.ts
+++ b/packages/server/src/asyncQuestion/asyncQuestion.controller.ts
@@ -217,7 +217,10 @@ export class asyncQuestionController {
         HttpStatus.UNAUTHORIZED,
       );
     }
-    if (body.status === asyncQuestionStatus.AIAnsweredNeedsAttention) {
+    if (
+      body.status === asyncQuestionStatus.AIAnsweredNeedsAttention &&
+      question.status != asyncQuestionStatus.AIAnsweredNeedsAttention
+    ) {
       const courseId = question.course.id;
 
       // Step 1: Get all users in the course

--- a/packages/server/src/mail/mail.service.ts
+++ b/packages/server/src/mail/mail.service.ts
@@ -49,17 +49,17 @@ export class MailService {
       throw new HttpException('Mail type/name not found', HttpStatus.NOT_FOUND);
     }
 
+    const baseContent = emailPost.content || mail.content;
+    const fullContent = `
+    ${baseContent}
+    <br><br><a href="${process.env.DOMAIN}/courses">View Your Courses</a>
+    <br>Do you not want to receive these emails? <a href="${process.env.DOMAIN}/profile">Unsubscribe</a>
+  `;
     await this.mailerService.sendMail({
       to: emailPost.receiver,
       from: '"HelpMe Support"',
       subject: emailPost.subject,
-      html:
-        emailPost.content ||
-        `
-        ${mail.content}
-        <br><a href="${process.env.DOMAIN}/courses">View Your Courses</a>
-        <br>Do you not want to receive these emails? <a href="${process.env.DOMAIN}/profile">Unsubscribe</a>
-      `,
+      html: fullContent,
     });
   }
   async findAllSubscriptions(


### PR DESCRIPTION
# Description

This PR addresses two issues:

1. Prevent duplicate notifications for async questions:
   - Modified the user subscription query to group by user ID, ensuring each user receives only one notification per flagged question.
   - Added logging to track subscription counts and email sending for better debugging.
   - Removed redundant Redis queue update to prevent potential duplication.

2. Add unsubscribe option to all outgoing emails:
   - Updated the `sendEmail` function in the mail service to consistently append "View Your Courses" and unsubscribe links to all emails.

Changes:
- Updated `updateStudentQuestion` endpoint in async questions controller
- Modified `sendEmail` function in mail service

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any work that this PR is dependent on has been merged into the main branch
- [ ] Any UI changes have been checked to work on desktop, tablet, and mobile
