### PR TITLE
Backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ yarn-error.log*
 husky.sh
 
 .vscode/
+
+# ignore backups 
+/backups/**/*.gz

--- a/backups/daily/daily-backups.md
+++ b/backups/daily/daily-backups.md
@@ -1,0 +1,1 @@
+see [Backups](../../docs/backups.md) 

--- a/backups/monthly/monthly-backups.md
+++ b/backups/monthly/monthly-backups.md
@@ -1,0 +1,1 @@
+see [Backups](../../docs/backups.md) 

--- a/backups/semi-hourly/semi-hourly-backups.md
+++ b/backups/semi-hourly/semi-hourly-backups.md
@@ -1,0 +1,1 @@
+see [Backups](../../docs/backups.md) 

--- a/docs/BACKUPS.md
+++ b/docs/BACKUPS.md
@@ -13,8 +13,9 @@ We are using `pg_dumpall` which back ups both our `prod` as well as our `chatbot
 
 ## Restoring a backup
 
-To restore a backup, you must first delete all the data in the database. You can do this by running the following command (make sure to change it to the database you want to drop):
+NOTE: my database container name is `helpme-postgresql-1`, you may need to change that in the commands.
 
+To restore a backup, you must first delete all the data in the database. You can do this by running the following command (make sure to change it to the database you want to drop):
 `docker exec -i helpme-postgresql-1 psql -U postgres -c "DROP DATABASE IF EXISTS dev/prod/chatbot/etc.;"`
 
 To restore a backup, you can navigate to backups/[daily/semi-hourly/monthly] and use the following command (change the backup file name to the one you want to restore):

--- a/docs/BACKUPS.md
+++ b/docs/BACKUPS.md
@@ -1,0 +1,26 @@
+# Backups
+
+## Saving backups
+
+There are three types of backups:
+- **Semi-Hourly**: Every 3 hours. These are rolling (we only keep 5 days of these). We also only take these from 7am to 10pm.
+- **Daily**: Every day at midnight. These are rolling (we only keep 1 month of these)
+- **Monthly**: The first of every month at midnight. These are kept indefinitely.
+
+All of these can be adjusted easily in backup.service.ts
+
+We are using `pg_dumpall` which back ups both our `prod` as well as our `chatbot` databases.
+
+## Restoring a backup
+
+To restore a backup, you must first delete all the data in the database. You can do this by running the following command (make sure to change it to the database you want to drop):
+
+`docker exec -i helpme-postgresql-1 psql -U postgres -c "DROP DATABASE IF EXISTS dev/prod/chatbot/etc.;"`
+
+To restore a backup, you can navigate to backups/[daily/semi-hourly/monthly] and use the following command (change the backup file name to the one you want to restore):
+`gunzip -c backup-2024-09-30.sql.gz | docker exec -i helpme-postgresql-1 psql -U postgres`
+This will restore any deleted databases. Any non-deleted database will just tell you some warnings that data already exists etc. and won't actually do anything.
+
+Don't forget to enter the redis container ("Exec" tab), run `redis-cli` and run `flushall` so that redis doesn't have the old data!
+
+Note: You might want to restart the server since routing can get a little messed up after restoring?

--- a/packages/server/src/app.module.ts
+++ b/packages/server/src/app.module.ts
@@ -30,6 +30,7 @@ import { QuestionTypeModule } from './questionType/questionType.module';
 import { StudentTaskProgressModule } from './studentTaskProgress/studentTaskProgress.module';
 import { RedisQueueModule } from 'redisQueue/redis-queue.module';
 import { ApplicationConfigModule } from 'config/application_config.module';
+import { BackupModule } from 'backup/backup.module';
 
 @Module({
   imports: [
@@ -73,6 +74,7 @@ import { ApplicationConfigModule } from 'config/application_config.module';
     QuestionTypeModule,
     StudentTaskProgressModule,
     RedisQueueModule,
+    BackupModule,
   ],
 })
 export class AppModule {}

--- a/packages/server/src/backup/backup.module.ts
+++ b/packages/server/src/backup/backup.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { BackupService } from './backup.service';
+
+@Module({
+  providers: [BackupService],
+})
+export class BackupModule {}

--- a/packages/server/src/backup/backup.service.spec.ts
+++ b/packages/server/src/backup/backup.service.spec.ts
@@ -1,0 +1,205 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { Test, TestingModule } from '@nestjs/testing';
+import { BackupService } from './backup.service';
+import * as fs from 'fs';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+jest.mock('fs');
+jest.mock('child_process', () => ({
+  exec: jest.fn(), // Mock exec from child_process
+}));
+
+describe('BackupService', () => {
+  let service: BackupService;
+  let execMock: jest.Mock;
+  let consoleLogSpy: jest.SpyInstance;
+  let consoleErrorSpy: jest.SpyInstance;
+
+  const now = new Date();
+  const todayFormatted = now.toISOString().split('T')[0];
+  const hour = String(now.getHours()).padStart(2, '0');
+  const backupFile = `backup-${todayFormatted}.sql.gz`;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [BackupService],
+    }).compile();
+
+    service = module.get<BackupService>(BackupService);
+
+    // Mock exec function and its promisified version
+    execMock = exec as unknown as jest.Mock;
+
+    // Mock the fs methods
+    const mockFiles = ['backup-old.sql.gz', 'backup-new.sql.gz'];
+
+    // Mocking readdir
+    (fs.readdir as unknown as jest.Mock).mockImplementation((dir, cb) =>
+      cb(null, mockFiles),
+    );
+
+    // Mocking stat
+    (fs.stat as unknown as jest.Mock).mockImplementation((filePath, cb) =>
+      cb(null, {
+        mtime: new Date(Date.now() - 31 * 24 * 60 * 60 * 1000), // Older than 30 days
+      }),
+    );
+
+    // Mocking unlink
+    (fs.unlink as unknown as jest.Mock).mockImplementation((filePath, cb) =>
+      cb(null),
+    );
+
+    // Spy on console methods
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe('handleDailyBackup', () => {
+    it('should create a daily backup when there is sufficient disk space', async () => {
+      jest.spyOn(service, 'checkDiskSpace').mockResolvedValue(true);
+      execMock.mockImplementation((command, callback) => {
+        callback(null, { stdout: 'success' }); // Simulate successful pg_dump
+      });
+
+      await service.handleDailyBackup();
+
+      expect(execMock).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `pg_dumpall | gzip > /backups/daily/backup-${todayFormatted}.sql.gz`,
+        ),
+        expect.any(Function), // Mock function
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining(`Daily backup saved: ${backupFile}`),
+      );
+    });
+
+    it('should not create a backup if there is insufficient disk space', async () => {
+      jest.spyOn(service, 'checkDiskSpace').mockResolvedValue(false);
+
+      await service.handleDailyBackup();
+
+      expect(execMock).not.toHaveBeenCalled(); // Backup shouldn't run
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Insufficient disk space for backup.'),
+      );
+    });
+
+    it('should delete old backups older than 30 days', async () => {
+      jest.spyOn(service, 'checkDiskSpace').mockResolvedValue(true);
+      execMock.mockImplementation((command, callback) => {
+        callback(null, { stdout: 'success' });
+      });
+
+      await service.handleDailyBackup();
+
+      expect(fs.unlink).toHaveBeenCalledWith(
+        expect.stringContaining('backup-old.sql.gz'),
+        expect.any(Function),
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Deleted old backup: backup-old.sql.gz'),
+      );
+    });
+  });
+
+  describe('handleSemiHourlyBackup', () => {
+    it('should create a semi-hourly backup when there is sufficient disk space', async () => {
+      jest.spyOn(service, 'checkDiskSpace').mockResolvedValue(true);
+      execMock.mockImplementation((command, callback) => {
+        callback(null, { stdout: 'success' }); // Simulate successful pg_dump
+      });
+
+      await service.handleSemiHourlyBackup();
+
+      expect(execMock).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `pg_dumpall | gzip > /backups/semi-hourly/semi-hourly-backup-${todayFormatted}-${hour}.sql.gz`,
+        ),
+        expect.any(Function), // Mock function
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining(`Semi-hourly backup saved: ${backupFile}`),
+      );
+    });
+
+    it('should not create a backup if there is insufficient disk space', async () => {
+      jest.spyOn(service, 'checkDiskSpace').mockResolvedValue(false);
+
+      await service.handleSemiHourlyBackup();
+
+      expect(execMock).not.toHaveBeenCalled(); // Backup shouldn't run
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Insufficient disk space for backup.'),
+      );
+    });
+  });
+
+  describe('handleMonthlyBackup', () => {
+    it('should create a monthly backup when there is sufficient disk space', async () => {
+      jest.spyOn(service, 'checkDiskSpace').mockResolvedValue(true);
+      execMock.mockImplementation((command, callback) => {
+        callback(null, { stdout: 'success' }); // Simulate successful pg_dump
+      });
+
+      await service.handleMonthlyBackup();
+
+      expect(execMock).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `pg_dumpall | gzip > /backups/monthly/monthly-backup-${todayFormatted}.sql.gz`,
+        ),
+        expect.any(Function), // Mock function
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `Monthly backup saved: monthly-backup-${todayFormatted}.sql.gz`,
+        ),
+      );
+    });
+
+    it('should not create a backup if there is insufficient disk space', async () => {
+      jest.spyOn(service, 'checkDiskSpace').mockResolvedValue(false);
+
+      await service.handleMonthlyBackup();
+
+      expect(execMock).not.toHaveBeenCalled(); // Backup shouldn't run
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Insufficient disk space for backup.'),
+      );
+    });
+  });
+
+  describe('checkDiskSpace', () => {
+    it('should return true if there is enough disk space', async () => {
+      execMock.mockImplementation((command, callback) => {
+        callback(null, { stdout: '2000' }); // Simulate 2000 MB free space
+      });
+
+      const hasSpace = await service.checkDiskSpace('/backups/daily');
+      expect(hasSpace).toBe(true);
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Free space in /backups/daily: 2000 MB'),
+      );
+    });
+
+    it('should return false if there is not enough disk space', async () => {
+      execMock.mockImplementation((command, callback) => {
+        callback(null, { stdout: '500' }); // Simulate 500 MB free space
+      });
+
+      const hasSpace = await service.checkDiskSpace('/backups/daily');
+      expect(hasSpace).toBe(false);
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Free space in /backups/daily: 500 MB'),
+      );
+    });
+  });
+});

--- a/packages/server/src/backup/backup.service.spec.ts
+++ b/packages/server/src/backup/backup.service.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { Test, TestingModule } from '@nestjs/testing';
-import { BackupService } from './backup.service';
+import { BackupService, baseBackupCommand } from './backup.service';
 import * as fs from 'fs';
 import { exec } from 'child_process';
 import { promisify } from 'util';
@@ -73,7 +73,7 @@ describe('BackupService', () => {
 
       expect(execMock).toHaveBeenCalledWith(
         expect.stringContaining(
-          `pg_dumpall | gzip > backups/daily/backup-${todayFormatted}.sql.gz`,
+          `${baseBackupCommand} backups/daily/backup-${todayFormatted}.sql.gz`,
         ),
         expect.any(Function), // Mock function
       );
@@ -122,13 +122,13 @@ describe('BackupService', () => {
 
       expect(execMock).toHaveBeenCalledWith(
         expect.stringContaining(
-          `pg_dumpall | gzip > backups/semi-hourly/semi-hourly-backup-${todayFormatted}-${hour}.sql.gz`,
+          `${baseBackupCommand} backups/semi-hourly/backup-${todayFormatted}-${hour}.sql.gz`,
         ),
         expect.any(Function), // Mock function
       );
       expect(consoleLogSpy).toHaveBeenCalledWith(
         expect.stringContaining(
-          `Semi-hourly backup saved: semi-hourly-backup-${todayFormatted}-${hour}.sql.gz`,
+          `Semi-hourly backup saved: backup-${todayFormatted}-${hour}.sql.gz`,
         ),
       );
     });
@@ -173,13 +173,13 @@ describe('BackupService', () => {
 
       expect(execMock).toHaveBeenCalledWith(
         expect.stringContaining(
-          `pg_dumpall | gzip > backups/monthly/monthly-backup-${todayFormatted}.sql.gz`,
+          `${baseBackupCommand} backups/monthly/backup-${todayFormatted}.sql.gz`,
         ),
         expect.any(Function), // Mock function
       );
       expect(consoleLogSpy).toHaveBeenCalledWith(
         expect.stringContaining(
-          `Monthly backup saved: monthly-backup-${todayFormatted}.sql.gz`,
+          `Monthly backup saved: backup-${todayFormatted}.sql.gz`,
         ),
       );
     });

--- a/packages/server/src/backup/backup.service.spec.ts
+++ b/packages/server/src/backup/backup.service.spec.ts
@@ -73,7 +73,7 @@ describe('BackupService', () => {
 
       expect(execMock).toHaveBeenCalledWith(
         expect.stringContaining(
-          `${baseBackupCommand} backups/daily/backup-${todayFormatted}.sql.gz`,
+          `${baseBackupCommand} ../../backups/daily/backup-${todayFormatted}.sql.gz`,
         ),
         expect.any(Function), // Mock function
       );
@@ -122,7 +122,7 @@ describe('BackupService', () => {
 
       expect(execMock).toHaveBeenCalledWith(
         expect.stringContaining(
-          `${baseBackupCommand} backups/semi-hourly/backup-${todayFormatted}-${hour}.sql.gz`,
+          `${baseBackupCommand} ../../backups/semi-hourly/backup-${todayFormatted}-${hour}.sql.gz`,
         ),
         expect.any(Function), // Mock function
       );
@@ -173,7 +173,7 @@ describe('BackupService', () => {
 
       expect(execMock).toHaveBeenCalledWith(
         expect.stringContaining(
-          `${baseBackupCommand} backups/monthly/backup-${todayFormatted}.sql.gz`,
+          `${baseBackupCommand} ../../backups/monthly/backup-${todayFormatted}.sql.gz`,
         ),
         expect.any(Function), // Mock function
       );

--- a/packages/server/src/backup/backup.service.ts
+++ b/packages/server/src/backup/backup.service.ts
@@ -7,23 +7,26 @@ import { promisify } from 'util';
 
 const execPromise = promisify(exec);
 
+export const baseBackupCommand =
+  'docker exec -u postgres helpme-postgresql-1 pg_dumpall -U postgres | gzip >';
+
 @Injectable()
 export class BackupService {
   private readonly MINIMUM_FREE_SPACE_MB = 1000; // Minimum space (in MB) required for backup
 
   // Daily Backup Task - Keeps rolling backups for 30 days
-  // @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
-  @Cron(CronExpression.EVERY_MINUTE)
+  //   @Cron(CronExpression.EVERY_MINUTE)
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
   async handleDailyBackup() {
     const date = new Date().toISOString().split('T')[0];
     const backupFile = `backup-${date}.sql.gz`;
-    const backupDir = '/backups/daily';
+    const backupDir = '../../backups/daily/';
 
     const hasSpace = await this.checkDiskSpace(backupDir);
 
     if (hasSpace) {
       exec(
-        `pg_dumpall | gzip > ${backupDir}/${backupFile}`,
+        `${baseBackupCommand} ${backupDir}/${backupFile}`,
         (error, stdout, stderr) => {
           if (error) {
             console.error(`Backup failed: ${stderr}`);
@@ -44,14 +47,14 @@ export class BackupService {
     const now = new Date();
     const date = now.toISOString().split('T')[0];
     const hour = String(now.getHours()).padStart(2, '0');
-    const backupFile = `semi-hourly-backup-${date}-${hour}.sql.gz`;
-    const backupDir = '/backups/semi-hourly';
+    const backupFile = `backup-${date}-${hour}.sql.gz`;
+    const backupDir = '../../backups/semi-hourly';
 
     const hasSpace = await this.checkDiskSpace(backupDir);
 
     if (hasSpace) {
       exec(
-        `pg_dumpall | gzip > ${backupDir}/${backupFile}`,
+        `${baseBackupCommand} ${backupDir}/${backupFile}`,
         (error, stdout, stderr) => {
           if (error) {
             console.error(`Semi-hourly backup failed: ${stderr}`);
@@ -70,14 +73,14 @@ export class BackupService {
   @Cron(CronExpression.EVERY_1ST_DAY_OF_MONTH_AT_MIDNIGHT)
   async handleMonthlyBackup() {
     const date = new Date().toISOString().split('T')[0];
-    const backupFile = `monthly-backup-${date}.sql.gz`;
-    const backupDir = '/backups/monthly';
+    const backupFile = `backup-${date}.sql.gz`;
+    const backupDir = '../../backups/monthly';
 
     const hasSpace = await this.checkDiskSpace(backupDir);
 
     if (hasSpace) {
       exec(
-        `pg_dumpall | gzip > ${backupDir}/${backupFile}`,
+        `${baseBackupCommand} ${backupDir}/${backupFile}`,
         (error, stdout, stderr) => {
           if (error) {
             console.error(`Monthly backup failed: ${stderr}`);

--- a/packages/server/src/backup/backup.service.ts
+++ b/packages/server/src/backup/backup.service.ts
@@ -19,7 +19,7 @@ export class BackupService {
   async handleDailyBackup() {
     const date = new Date().toISOString().split('T')[0];
     const backupFile = `backup-${date}.sql.gz`;
-    const backupDir = '../../backups/daily/';
+    const backupDir = '../../backups/daily';
 
     const hasSpace = await this.checkDiskSpace(backupDir);
 

--- a/packages/server/src/backup/backup.service.ts
+++ b/packages/server/src/backup/backup.service.ts
@@ -15,7 +15,6 @@ export class BackupService {
   private readonly MINIMUM_FREE_SPACE_MB = 1000; // Minimum space (in MB) required for backup
 
   // Daily Backup Task - Keeps rolling backups for 30 days
-  //   @Cron(CronExpression.EVERY_MINUTE)
   @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
   async handleDailyBackup() {
     const date = new Date().toISOString().split('T')[0];

--- a/packages/server/src/backup/backup.service.ts
+++ b/packages/server/src/backup/backup.service.ts
@@ -1,0 +1,129 @@
+import { Injectable } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { exec } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { promisify } from 'util';
+
+const execPromise = promisify(exec);
+
+@Injectable()
+export class BackupService {
+  private readonly MINIMUM_FREE_SPACE_MB = 1000; // Minimum space (in MB) required for backup
+
+  // Daily Backup Task - Keeps rolling backups for 30 days
+  // @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  @Cron(CronExpression.EVERY_MINUTE)
+  async handleDailyBackup() {
+    const date = new Date().toISOString().split('T')[0];
+    const backupFile = `backup-${date}.sql.gz`;
+    const backupDir = '/backups/daily';
+
+    const hasSpace = await this.checkDiskSpace(backupDir);
+
+    if (hasSpace) {
+      exec(
+        `pg_dumpall | gzip > ${backupDir}/${backupFile}`,
+        (error, stdout, stderr) => {
+          if (error) {
+            console.error(`Backup failed: ${stderr}`);
+          } else {
+            console.log(`Daily backup saved: ${backupFile}`);
+            this.deleteOldBackups(backupDir, 30);
+          }
+        },
+      );
+    } else {
+      console.error('Insufficient disk space for backup.');
+    }
+  }
+
+  // Semi-Hourly backup task - Backup every 3 hours and keep for 5 days, between 7am to 10pm (the daily backup is the 12am one)
+  @Cron('0 7-22/3 * * *')
+  async handleSemiHourlyBackup() {
+    const now = new Date();
+    const date = now.toISOString().split('T')[0];
+    const hour = String(now.getHours()).padStart(2, '0');
+    const backupFile = `semi-hourly-backup-${date}-${hour}.sql.gz`;
+    const backupDir = '/backups/semi-hourly';
+
+    const hasSpace = await this.checkDiskSpace(backupDir);
+
+    if (hasSpace) {
+      exec(
+        `pg_dumpall | gzip > ${backupDir}/${backupFile}`,
+        (error, stdout, stderr) => {
+          if (error) {
+            console.error(`Semi-hourly backup failed: ${stderr}`);
+          } else {
+            console.log(`Semi-hourly backup saved: ${backupFile}`);
+            this.deleteOldBackups(backupDir, 5);
+          }
+        },
+      );
+    } else {
+      console.error('Insufficient disk space for backup.');
+    }
+  }
+
+  // Monthly Backup Task - Keeps all backups
+  @Cron(CronExpression.EVERY_1ST_DAY_OF_MONTH_AT_MIDNIGHT)
+  async handleMonthlyBackup() {
+    const date = new Date().toISOString().split('T')[0];
+    const backupFile = `monthly-backup-${date}.sql.gz`;
+    const backupDir = '/backups/monthly';
+
+    const hasSpace = await this.checkDiskSpace(backupDir);
+
+    if (hasSpace) {
+      exec(
+        `pg_dumpall | gzip > ${backupDir}/${backupFile}`,
+        (error, stdout, stderr) => {
+          if (error) {
+            console.error(`Monthly backup failed: ${stderr}`);
+          } else {
+            console.log(`Monthly backup saved: ${backupFile}`);
+          }
+        },
+      );
+    } else {
+      console.error('Insufficient disk space for backup.');
+    }
+  }
+
+  // Delete backups older than N days
+  private deleteOldBackups(directory: string, days: number) {
+    const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+    fs.readdir(directory, (err, files) => {
+      if (err) throw err;
+      files.forEach((file) => {
+        const filePath = path.join(directory, file);
+        fs.stat(filePath, (err, stats) => {
+          if (err) throw err;
+          if (stats.mtime.getTime() < cutoff) {
+            fs.unlink(filePath, (err) => {
+              if (err) throw err;
+              console.log(`Deleted old backup: ${file}`);
+            });
+          }
+        });
+      });
+    });
+  }
+
+  // Check if there is sufficient free space before creating a backup
+  async checkDiskSpace(directory: string): Promise<boolean> {
+    try {
+      const { stdout } = await execPromise(
+        `df -m ${directory} | tail -1 | awk '{print $4}'`,
+      );
+      const freeSpaceMb = parseInt(stdout.trim(), 10);
+
+      console.log(`Free space in ${directory}: ${freeSpaceMb} MB`);
+      return freeSpaceMb > this.MINIMUM_FREE_SPACE_MB;
+    } catch (error) {
+      console.error('Error checking disk space:', error);
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
# Description

Adds a backup system with docs for restoring backups. NOTE: this works for both chatbot and helpme databases (i think, since they're both using postgres).

There are three types of backups:
- **Semi-Hourly**: Every 3 hours. These are rolling (we only keep 5 days of these). We also only take these from 7am to 10pm.
- **Daily**: Every day at midnight. These are rolling (we only keep 1 month of these)
- **Monthly**: The first of every month at midnight. These are kept indefinitely.

Closes #52 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] This requires a run of `yarn install`

# How Has This Been Tested?

I added a bunch of tests for it:

describe('handleDailyBackup'
it('should create a daily backup when there is sufficient disk space'
it('should not create a backup if there is insufficient disk space'
it('should delete old backups older than 30 days'
describe('handleSemiHourlyBackup'
it('should create a semi-hourly backup when there is sufficient disk space'
it('should not create a backup if there is insufficient disk space'
it('should delete old backups older than 5 days'
describe('handleMonthlyBackup'
it('should create a monthly backup when there is sufficient disk space'
it('should not create a backup if there is insufficient disk space'
describe('checkDiskSpace'
it('should return true if there is enough disk space'
it('should return false if there is not enough disk space'

I have also tested making the interval 1minute, and then restoring one of those backups, which works fine.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [ ] Any UI changes have been checked to work on desktop, tablet, and mobile
