### PR TITLE
Fix bug where users cannot update a course if a user is promoted to a professor through the course roster page

### DIFF
--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -1037,6 +1037,7 @@ export type OrganizationProfessor = {
   organizationUser: {
     id: number
     name: string
+    lacksProfOrgRole?: boolean
   }
   userId: number
 }

--- a/packages/frontend/app/api/index.ts
+++ b/packages/frontend/app/api/index.ts
@@ -679,8 +679,12 @@ class APIClient {
       ),
     getProfessors: async (
       organizationId: number,
+      courseId?: number,
     ): Promise<OrganizationProfessor[]> =>
-      this.req('GET', `/api/v1/organization/${organizationId}/get_professors`),
+      this.req(
+        'GET',
+        `/api/v1/organization/${organizationId}/get_professors/${courseId ?? '0'}`,
+      ),
   }
 
   constructor(baseURL = '') {


### PR DESCRIPTION
# Description

Before
![image](https://github.com/user-attachments/assets/b53ccc03-c8ba-4193-8337-83121cc8565c)

After (you can also now actually click the update button and it will work)
![image](https://github.com/user-attachments/assets/ba0421a3-99f4-46c2-a0e6-764318e081bf)
![image](https://github.com/user-attachments/assets/c99254fe-9ee7-4800-8b41-bb4a3b3832c8)

Closes #158 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`

# How Has This Been Tested?

Just a bit of manual testing with updating the course with some of these non-org profs and updating the course with only org profs


# Checklist:

- [ ] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [ ] Any UI changes have been checked to work on desktop, tablet, and mobile
