### PR TITLE
Image Resource Desync (Uploads Directory and Database Image URLs)

### DIFF
--- a/packages/server/src/organization/organization.controller.ts
+++ b/packages/server/src/organization/organization.controller.ts
@@ -790,13 +790,14 @@ export class OrganizationController {
     if (organization.bannerUrl) {
       fs.unlink(
         process.env.UPLOAD_LOCATION + '/' + organization.bannerUrl,
-        (err) => {
-          if (err) {
-            const errMessage =
+        (e) => {
+          if (e) {
+            console.error(
               'Error deleting previous picture at : ' +
-              organization.logoUrl +
-              'the previous image was at an invalid location?';
-            console.error(errMessage);
+                organization.bannerUrl +
+                '\n Perhaps the previous image was deleted or the database is out of sync with the uploads directory for some reason.' +
+                '\n Will remove this entry from the database and continue.',
+            );
           }
         },
       );
@@ -874,13 +875,14 @@ export class OrganizationController {
     if (organization.logoUrl) {
       fs.unlink(
         process.env.UPLOAD_LOCATION + '/' + organization.logoUrl,
-        (err) => {
-          if (err) {
-            const errMessage =
+        (e) => {
+          if (e) {
+            console.error(
               'Error deleting previous picture at : ' +
-              organization.logoUrl +
-              'the previous image was at an invalid location?';
-            console.error(errMessage);
+                organization.bannerUrl +
+                '\n Perhaps the previous image was deleted or the database is out of sync with the uploads directory for some reason.' +
+                '\n Will remove this entry from the database and continue.',
+            );
           }
         },
       );

--- a/packages/server/src/organization/organization.controller.ts
+++ b/packages/server/src/organization/organization.controller.ts
@@ -879,7 +879,7 @@ export class OrganizationController {
           if (e) {
             console.error(
               'Error deleting previous picture at : ' +
-                organization.bannerUrl +
+                organization.logoUrl +
                 '\n Perhaps the previous image was deleted or the database is out of sync with the uploads directory for some reason.' +
                 '\n Will remove this entry from the database and continue.',
             );

--- a/packages/server/src/profile/profile.controller.ts
+++ b/packages/server/src/profile/profile.controller.ts
@@ -207,11 +207,19 @@ export class ProfileController {
   ): Promise<void> {
     try {
       /*
-       * The second check below may be redundant but will remain for now in case
-       * we allow for third-party images may be used in the future for profile avatars
+       * The second check is for google accounts, which have a photoURL that is a external link
        */
       if (user.photoURL && !user.photoURL.startsWith('http')) {
-        fs.unlinkSync(path.join(process.env.UPLOAD_LOCATION, user.photoURL));
+        try {
+          fs.unlinkSync(path.join(process.env.UPLOAD_LOCATION, user.photoURL));
+        } catch (e) {
+          console.error(
+            'Error deleting previous picture at : ' +
+              user.photoURL +
+              '\n Perhaps the previous image was deleted or the database is out of sync with the uploads directory for some reason.' +
+              '\n Will remove this entry from the database and continue.',
+          );
+        }
       }
 
       const spaceLeft = await checkDiskSpace(path.parse(process.cwd()).root);


### PR DESCRIPTION
# Description

Just a small patch to allow for users and organizations with out-of-sync database references to images in the ```./uploads``` directory to still change their avatars and organization banners and logos.

This is what gets logged when this occurs in the backend's console (should still never happen, but if it does, there's a way to track it down):
![image](https://github.com/user-attachments/assets/2b3cadd6-2872-4ea2-97e6-569e9fe7f98b)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 

- [x] Manually tested by deleting photos from the ```./uploads``` directory known to still be referred to by entries in the database.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [x] Any UI changes have been checked to work on desktop, tablet, and mobile
