### PR TITLE
[Bug Fix] Restrict passing an empty tag using space

### DIFF
--- a/packages/frontend/app/(dashboard)/course/[cid]/async_centre/components/modals/EditAsyncCentreModal.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/async_centre/components/modals/EditAsyncCentreModal.tsx
@@ -145,9 +145,15 @@ const EditAsyncCentreModal: React.FC<EditAsyncCentreModalProps> = ({
                         message: 'Tag name must be less than 20 characters',
                       },
                       {
-                        validator: (_, value) => {
+                        validator: (_: any, value: string) => {
+                          if (!value || value.trim() === '') {
+                            return Promise.reject(
+                              'Tag name cannot be empty or spaces only',
+                            )
+                          }
                           // make sure no other tags have the same name
-                          if (
+                          else if (
+                            value &&
                             questionTypes?.find((tag) => tag.name === value)
                           ) {
                             return Promise.reject('Duplicate tag name')

--- a/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/modals/EditQueueModal.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/modals/EditQueueModal.tsx
@@ -436,9 +436,15 @@ const EditQueueModal: React.FC<EditQueueModalProps> = ({
                         message: 'Tag name must be less than 20 characters',
                       },
                       {
-                        validator: (_, value) => {
+                        validator: (_: any, value: string) => {
+                          if (!value || value.trim() === '') {
+                            return Promise.reject(
+                              'Tag name cannot be empty or spaces only',
+                            )
+                          }
                           // make sure no other tags have the same name
-                          if (
+                          else if (
+                            value &&
                             questionTypes?.find((tag) => tag.name === value)
                           ) {
                             return Promise.reject('Duplicate tag name')

--- a/packages/server/src/questionType/questionType.controller.ts
+++ b/packages/server/src/questionType/questionType.controller.ts
@@ -44,12 +44,20 @@ export class QuestionTypeController {
       queueId = null;
     }
 
+    if (newQuestionType?.name?.trim() === '') {
+      res.status(HttpStatus.BAD_REQUEST).send({
+        message: 'Question type name cannot be empty',
+      });
+      return;
+    }
+
     const questionTypeCount = await QuestionTypeModel.count({
       where: {
         cid: courseId,
         queueId: queueId !== null ? queueId : IsNull(),
       },
     });
+
     if (
       questionTypeCount >= this.appConfig.get('max_question_types_per_queue')
     ) {


### PR DESCRIPTION
# Description

Fixes one of the issues where using "space" is allows to create a new tag

Closes # (issue number)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`

# How Has This Been Tested?

N/A


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any work that this PR is dependent on has been merged into the main branch
- [ ] Any UI changes have been checked to work on desktop, tablet, and mobile
