### PR TITLE
Pause Questions

### DIFF
--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -439,6 +439,9 @@ export class Question {
   helpedAt?: Date
 
   @Type(() => Date)
+  pausedAt?: Date
+
+  @Type(() => Date)
   closedAt?: Date
 
   @Type(() => QuestionTypeParams)
@@ -466,6 +469,7 @@ export enum OpenQuestionStatus {
   Queued = 'Queued',
   Helping = 'Helping',
   PriorityQueued = 'PriorityQueued',
+  Paused = 'Paused',
 }
 
 /**
@@ -510,6 +514,7 @@ export const StatusSentToCreator = [
   ...StatusInPriorityQueue,
   ...StatusInQueue,
   OpenQuestionStatus.Helping,
+  OpenQuestionStatus.Paused,
   LimboQuestionStatus.ReQueueing,
   LimboQuestionStatus.CantFind,
   LimboQuestionStatus.TADeleted,

--- a/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/CircleButton.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/CircleButton.tsx
@@ -2,7 +2,7 @@ import { cn } from '@/app/utils/generalUtils'
 import { Button, ButtonProps } from 'antd'
 
 interface CircleButtonProps extends ButtonProps {
-  variant?: 'default' | 'primary' | 'red' | 'orange' | 'green'
+  variant?: 'default' | 'primary' | 'red' | 'orange' | 'green' | 'gray'
 }
 
 const CircleButton: React.FC<CircleButtonProps> = ({
@@ -31,6 +31,8 @@ const CircleButton: React.FC<CircleButtonProps> = ({
         'bg-[#ff8c00] text-white hover:border-orange-400 hover:bg-[#ffa700] focus:bg-[#ffa700]',
       variant === 'green' &&
         'bg-[#66bb6a] text-white hover:border-green-500 hover:bg-[#82c985] focus:bg-[#82c985]',
+      variant === 'gray' &&
+        'bg-[#ababab] text-white hover:border-gray-400 hover:bg-[#c7c7c7] focus:bg-[#c7c7c7]',
       className,
     )}
     {...props}

--- a/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/QuestionCard.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/QuestionCard.tsx
@@ -73,185 +73,189 @@ const QuestionCard: React.FC<QuestionCardProps> = ({
   }, [isBeingHelped, question, isPaused])
 
   return (
-    <Card
-      className={cn(
-        'mb-2 self-stretch rounded-md px-2 text-gray-600 shadow-md ',
-        isBeingHelped || isPaused ? 'mt-3 border md:mt-2' : '',
-        isBeingHelped ? 'border-green-600/40 bg-green-50' : '',
-        isPaused ? 'border-amber-600/40 bg-amber-50' : '',
-        isMyQuestion ? 'bg-teal-50' : '',
-        isMyQuestion && isBeingHelped
-          ? 'bg-gradient-to-r from-teal-50 to-green-50'
-          : '',
-        isMyQuestion && isPaused
-          ? '-amber-50 bg-gradient-to-r from-teal-50'
-          : '',
-        className,
-      )}
-      classNames={{ body: 'px-0.5 py-1.5 md:px-2.5 md:py-2' }}
-    >
-      <Row className="items-center">
-        {isStaff && ( // only show avatar if staff for now. TODO: fix endpoint to allow queues to access student avatars and names if prof enabled it
-          <Col flex="0 1 auto" className="mr-2">
-            <UserAvatar
-              size={46}
-              username={question.creator.name}
-              photoURL={question.creator.photoURL}
-            />
-          </Col>
+    <Tooltip title={isMyQuestion ? 'This is your question.' : ''}>
+      <Card
+        className={cn(
+          'mb-2 self-stretch rounded-md px-2 text-gray-600 shadow-md ',
+          isBeingHelped || isPaused ? 'mt-3 border md:mt-2' : '',
+          isBeingHelped ? 'border-green-600/40 bg-green-50' : '',
+          isPaused ? 'border-amber-600/40 bg-amber-50' : '',
+          isMyQuestion ? 'bg-teal-100' : '',
+          isMyQuestion && isBeingHelped
+            ? 'bg-gradient-to-r from-teal-100 via-green-50 to-green-50'
+            : '',
+          isMyQuestion && isPaused
+            ? 'bg-gradient-to-r from-teal-100 via-amber-50 to-amber-50'
+            : '',
+          className,
         )}
-        <Col flex="1 1">
-          {question.status === 'Drafting' ? (
-            <div className="text-base text-gray-400">
-              {question.isTaskQuestion
-                ? 'Unfinished Demo'
-                : 'Unfinished Question'}
-            </div>
-          ) : // if it's a task question, parse the task items and display them instead of the question text
-          question.isTaskQuestion && tasks && configTasks ? (
-            <div>
-              {
-                // if the task is being helped, display it as a TaskMarkingSelector (to allow professors to choose which parts are good)
-                question.status === OpenQuestionStatus.Helping ? (
-                  <TaskMarkingSelector
-                    onChange={onMarkingTaskChange}
-                    tasksStudentWouldLikeMarked={tasks}
-                    configTasks={configTasks}
-                  />
-                ) : (
-                  // for every task defined in the config, display it but only highlight the ones that are in the question text
-                  Object.entries(configTasks).map(
-                    ([taskKey, taskValue], index) => (
-                      <QuestionTagElement
-                        key={index}
-                        tagName={
-                          isMyQuestion &&
-                          studentAssignmentProgress &&
-                          studentAssignmentProgress[taskKey] &&
-                          studentAssignmentProgress[taskKey].isDone
-                            ? '✔️'
-                            : taskValue.short_display_name
-                        }
-                        tagColor={
-                          tasks.includes(taskKey)
-                            ? taskValue.color_hex
-                            : '#f0f0f0'
-                        }
-                      />
-                    ),
+        classNames={{ body: 'px-0.5 py-1.5 md:px-2.5 md:py-2' }}
+      >
+        <Row className="items-center">
+          {isStaff && ( // only show avatar if staff for now. TODO: fix endpoint to allow queues to access student avatars and names if prof enabled it
+            <Col flex="0 1 auto" className="mr-2">
+              <UserAvatar
+                size={46}
+                username={question.creator.name}
+                photoURL={question.creator.photoURL}
+              />
+            </Col>
+          )}
+          <Col flex="1 1">
+            {question.status === 'Drafting' ? (
+              <div className="text-base text-gray-400">
+                {question.isTaskQuestion
+                  ? 'Unfinished Demo'
+                  : 'Unfinished Question'}
+              </div>
+            ) : // if it's a task question, parse the task items and display them instead of the question text
+            question.isTaskQuestion && tasks && configTasks ? (
+              <div>
+                {
+                  // if the task is being helped, display it as a TaskMarkingSelector (to allow professors to choose which parts are good)
+                  question.status === OpenQuestionStatus.Helping ? (
+                    <TaskMarkingSelector
+                      onChange={onMarkingTaskChange}
+                      tasksStudentWouldLikeMarked={tasks}
+                      configTasks={configTasks}
+                    />
+                  ) : (
+                    // for every task defined in the config, display it but only highlight the ones that are in the question text
+                    Object.entries(configTasks).map(
+                      ([taskKey, taskValue], index) => (
+                        <QuestionTagElement
+                          key={index}
+                          tagName={
+                            isMyQuestion &&
+                            studentAssignmentProgress &&
+                            studentAssignmentProgress[taskKey] &&
+                            studentAssignmentProgress[taskKey].isDone
+                              ? '✔️'
+                              : taskValue.short_display_name
+                          }
+                          tagColor={
+                            tasks.includes(taskKey)
+                              ? taskValue.color_hex
+                              : '#f0f0f0'
+                          }
+                        />
+                      ),
+                    )
                   )
-                )
-              }
-            </div>
-          ) : (
-            <Tooltip // only show tooltip if text is too long TODO: replace with expand card details feature
-              title={
-                question.text && question.text.length > 110 ? question.text : ''
-              }
-              overlayStyle={{ maxWidth: '60em' }}
-            >
-              <div
-                style={
-                  {
-                    // shorten question text dynamically
-                    display: '-webkit-box',
-                    WebkitLineClamp: 1,
-                    WebkitBoxOrient: 'vertical',
-                    textOverflow: 'ellipsis',
-                    overflow: 'hidden',
-                    maxWidth: '55em',
-                  } as React.CSSProperties
                 }
-              >
-                {question.text}
               </div>
-            </Tooltip>
-          )}
-          {isStaff && (
-            <div className="mr-1 mt-0.5 inline-block min-w-[120px] text-sm italic text-gray-600">
-              {question.creator.name}
-            </div>
-          )}
-
-          {question.questionTypes?.map((questionType, index) => (
-            <QuestionTagElement
-              key={index}
-              tagName={questionType.name}
-              tagColor={questionType.color}
-            />
-          ))}
-        </Col>
-        <Col flex={'0.1 1 auto'}>
-          {(isBeingHelped || isPaused) && !isStaff && (
-            <Row justify={'end'}>
-              <div
-                className={cn(
-                  'text-sm',
-                  isPaused ? 'text-amber-400' : '',
-                  isBeingHelped ? 'text-green-700' : '',
-                )}
+            ) : (
+              <Tooltip // only show tooltip if text is too long TODO: replace with expand card details feature
+                title={
+                  question.text && question.text.length > 110
+                    ? question.text
+                    : ''
+                }
+                overlayStyle={{ maxWidth: '60em' }}
               >
-                {isPaused && 'Currently Paused'}
-                {isBeingHelped && 'Currently Being Served'}
-              </div>
-            </Row>
-          )}
-          <Row
-            justify={'end'}
-            className={cn(
-              !isBeingHelped && !isPaused ? 'h-[2.5rem]' : '',
-              'gap-1',
-            )}
-          >
-            <Col flex="1 0 3rem">
-              {isStaff && (
-                <div className="flex justify-end text-sm text-gray-600">
-                  {getWaitTime(question)}
+                <div
+                  style={
+                    {
+                      // shorten question text dynamically
+                      display: '-webkit-box',
+                      WebkitLineClamp: 1,
+                      WebkitBoxOrient: 'vertical',
+                      textOverflow: 'ellipsis',
+                      overflow: 'hidden',
+                      maxWidth: '55em',
+                    } as React.CSSProperties
+                  }
+                >
+                  {question.text}
                 </div>
-              )}
-              {(isBeingHelped || isPaused) && (
+              </Tooltip>
+            )}
+            {isStaff && (
+              <div className="mr-1 mt-0.5 inline-block min-w-[120px] text-sm italic text-gray-600">
+                {question.creator.name}
+              </div>
+            )}
+
+            {question.questionTypes?.map((questionType, index) => (
+              <QuestionTagElement
+                key={index}
+                tagName={questionType.name}
+                tagColor={questionType.color}
+              />
+            ))}
+          </Col>
+          <Col flex={'0.1 1 auto'}>
+            {(isBeingHelped || isPaused) && !isStaff && (
+              <Row justify={'end'}>
                 <div
                   className={cn(
-                    isBeingHelped ? 'text-green-700' : '',
+                    'text-sm',
                     isPaused ? 'text-amber-400' : '',
-                    'font-md flex justify-end text-sm',
+                    isBeingHelped ? 'text-green-700' : '',
                   )}
                 >
-                  {isPaused && (
-                    <>
-                      <div className={'text-gray-600'}>
-                        {getOriginalPausedTime(question)}
-                      </div>
-                      <div>{isPaused ? ' +' + pausedTime : ''}</div>
-                    </>
-                  )}
-                  {isBeingHelped && servedTime}
+                  {isPaused && 'Currently Paused'}
+                  {isBeingHelped && 'Currently Being Served'}
                 </div>
-              )}
-            </Col>
-            {!isStaff && (
-              <Col flex="0 0 3rem">
-                <div className="flex justify-end text-sm text-gray-600">
-                  {getWaitTime(question)}
-                </div>
-              </Col>
+              </Row>
             )}
-          </Row>
-        </Col>
-        {isStaff && (
-          <Col className="w-full sm:w-auto">
-            <TAQuestionCardButtons
-              courseId={cid}
-              queueId={qid}
-              question={question}
-              hasUnresolvedRephraseAlert={false}
-              tasksSelectedForMarking={tasksSelectedForMarking}
-              className="align-center flex items-center justify-around"
-            />
+            <Row
+              justify={'end'}
+              className={cn(
+                !isBeingHelped && !isPaused ? 'h-[2.5rem]' : '',
+                'gap-1',
+              )}
+            >
+              <Col flex="1 0 3rem">
+                {isStaff && (
+                  <div className="flex justify-end text-sm text-gray-600">
+                    {getWaitTime(question)}
+                  </div>
+                )}
+                {(isBeingHelped || isPaused) && (
+                  <div
+                    className={cn(
+                      isBeingHelped ? 'text-green-700' : '',
+                      isPaused ? 'text-amber-400' : '',
+                      'font-md flex justify-end text-sm',
+                    )}
+                  >
+                    {isPaused && (
+                      <>
+                        <div className={'text-gray-600'}>
+                          {getOriginalPausedTime(question)}
+                        </div>
+                        <div>{isPaused ? ' +' + pausedTime : ''}</div>
+                      </>
+                    )}
+                    {isBeingHelped && servedTime}
+                  </div>
+                )}
+              </Col>
+              {!isStaff && (
+                <Col flex="0 0 3rem">
+                  <div className="flex justify-end text-sm text-gray-600">
+                    {getWaitTime(question)}
+                  </div>
+                </Col>
+              )}
+            </Row>
           </Col>
-        )}
-      </Row>
-    </Card>
+          {isStaff && (
+            <Col className="w-full sm:w-auto">
+              <TAQuestionCardButtons
+                courseId={cid}
+                queueId={qid}
+                question={question}
+                hasUnresolvedRephraseAlert={false}
+                tasksSelectedForMarking={tasksSelectedForMarking}
+                className="align-center flex items-center justify-around"
+              />
+            </Col>
+          )}
+        </Row>
+      </Card>
+    </Tooltip>
   )
 }
 

--- a/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/QuestionCard.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/QuestionCard.tsx
@@ -195,7 +195,7 @@ const QuestionCard: React.FC<QuestionCardProps> = ({
                   )}
                 >
                   {isPaused && 'Currently Paused'}
-                  {isBeingHelped && 'Currently Being Served'}
+                  {isBeingHelped && 'Being Served'}
                 </div>
               </Row>
             )}
@@ -206,7 +206,7 @@ const QuestionCard: React.FC<QuestionCardProps> = ({
                 'gap-1',
               )}
             >
-              <Col flex="1 0 3rem">
+              <Col flex="1 0 2rem">
                 {isStaff && (
                   <div className="flex justify-end text-sm text-gray-600">
                     {getWaitTime(question)}
@@ -233,7 +233,7 @@ const QuestionCard: React.FC<QuestionCardProps> = ({
                 )}
               </Col>
               {!isStaff && (
-                <Col flex="0 0 3rem">
+                <Col flex="0 0 2rem">
                   <div className="flex justify-end text-sm text-gray-600">
                     {getWaitTime(question)}
                   </div>

--- a/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/QueueQuestions.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/QueueQuestions.tsx
@@ -25,6 +25,7 @@ const Panel = Collapse.Panel
 interface QueueQuestionsProps {
   questions: Question[]
   questionsGettingHelp: Question[]
+  pausedQuestions: Question[]
   cid: number
   qid: number
   isStaff: boolean
@@ -66,6 +67,7 @@ interface QueueQuestionsProps {
 const QueueQuestions: React.FC<QueueQuestionsProps> = ({
   questions,
   questionsGettingHelp,
+  pausedQuestions,
   cid,
   qid,
   isStaff,
@@ -310,10 +312,16 @@ const QueueQuestions: React.FC<QueueQuestionsProps> = ({
         </Collapse>
       ) : (
         <>
-          {!isStaff &&
-            questionsGettingHelp.map((question: Question) =>
-              renderQuestion(question),
-            )}
+          {!isStaff && (
+            <>
+              {questionsGettingHelp.map((question: Question) =>
+                renderQuestion(question),
+              )}
+              {pausedQuestions.map((question: Question) =>
+                renderQuestion(question),
+              )}
+            </>
+          )}
           {questions.map((question: Question) => renderQuestion(question))}
         </>
       )}

--- a/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/QueueQuestions.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/QueueQuestions.tsx
@@ -13,6 +13,7 @@ import {
   Task,
   TaskTree,
   QuestionTypeParams,
+  OpenQuestionStatus,
 } from '@koh/common'
 import { QuestionTagElement } from '../../../components/QuestionTagElement'
 import QuestionCard from './QuestionCard'
@@ -130,12 +131,34 @@ const QueueQuestions: React.FC<QueueQuestionsProps> = ({
     [taskTree],
   )
 
+  const renderQuestion = (question: Question) => {
+    const isMyQuestion =
+      question.id === studentDemoId || question.id === studentQuestionId
+    const isPaused = question.status === OpenQuestionStatus.Paused
+    const isBeingHelped = question.status === OpenQuestionStatus.Helping
+
+    return (
+      <QuestionCard
+        key={question.id}
+        question={question}
+        cid={cid}
+        qid={qid}
+        isStaff={isStaff}
+        configTasks={configTasks}
+        studentAssignmentProgress={studentAssignmentProgress}
+        isMyQuestion={isMyQuestion}
+        isPaused={isPaused}
+        isBeingHelped={isBeingHelped}
+      />
+    )
+  }
+
   // TODO: this does still needs to be updated to the newest version of Collapse from antd, where it uses the 'items' prop instead of Collapse.Panel.
   // This will help with all the console deprecation warnings.
   // However, this is kind of a difficult task as the Divider will need to be separate and there will likely need to be two Collapse components instead, which may mess with things.
   return (
     <div className="mb-32 md:mb-0">
-      <div className="flex items-center justify-between">
+      <div className="my-2 flex items-center justify-between">
         {questions?.length === 0 ? (
           <div className="text-xl font-medium text-gray-900">
             There are no questions in the queue
@@ -221,25 +244,9 @@ const QueueQuestions: React.FC<QueueQuestionsProps> = ({
                       </div>
                     }
                   >
-                    {filteredQuestions.map((question: Question) => {
-                      const isMyQuestion = question.id === studentDemoId
-                      const background_color = isMyQuestion
-                        ? 'bg-teal-200/25'
-                        : 'bg-white'
-                      return (
-                        <QuestionCard
-                          key={question.id}
-                          question={question}
-                          cid={cid}
-                          qid={qid}
-                          isStaff={isStaff}
-                          configTasks={configTasks}
-                          studentAssignmentProgress={studentAssignmentProgress}
-                          isMyQuestion={isMyQuestion}
-                          className={background_color}
-                        />
-                      )
-                    })}
+                    {filteredQuestions.map((question: Question) =>
+                      renderQuestion(question),
+                    )}
                   </Panel>
                 )
               )
@@ -293,25 +300,9 @@ const QueueQuestions: React.FC<QueueQuestionsProps> = ({
                     </div>
                   }
                 >
-                  {filteredQuestions.map((question: Question) => {
-                    const isMyQuestion = question.id === studentQuestionId
-                    const background_color = isMyQuestion
-                      ? 'bg-teal-200/25'
-                      : 'bg-white'
-                    return (
-                      <QuestionCard
-                        key={question.id}
-                        question={question}
-                        cid={cid}
-                        qid={qid}
-                        isStaff={isStaff}
-                        configTasks={configTasks}
-                        studentAssignmentProgress={studentAssignmentProgress}
-                        isMyQuestion={isMyQuestion}
-                        className={background_color}
-                      />
-                    )
-                  })}
+                  {filteredQuestions.map((question: Question) =>
+                    renderQuestion(question),
+                  )}
                 </Panel>
               )
             )
@@ -320,48 +311,10 @@ const QueueQuestions: React.FC<QueueQuestionsProps> = ({
       ) : (
         <>
           {!isStaff &&
-            questionsGettingHelp.map((question: Question) => {
-              const isMyQuestion =
-                question.id === studentQuestionId ||
-                question.id === studentDemoId
-              const background_color = isMyQuestion
-                ? 'bg-teal-200/25'
-                : 'bg-white'
-              return (
-                <QuestionCard
-                  key={question.id}
-                  question={question}
-                  cid={cid}
-                  qid={qid}
-                  isStaff={isStaff}
-                  configTasks={configTasks}
-                  studentAssignmentProgress={studentAssignmentProgress}
-                  isMyQuestion={isMyQuestion}
-                  className={background_color}
-                  isBeingHelped={true}
-                />
-              )
-            })}
-          {questions.map((question: Question) => {
-            const isMyQuestion =
-              question.id === studentQuestionId || question.id === studentDemoId
-            const background_color = isMyQuestion
-              ? 'bg-teal-200/25'
-              : 'bg-white'
-            return (
-              <QuestionCard
-                key={question.id}
-                question={question}
-                cid={cid}
-                qid={qid}
-                isStaff={isStaff}
-                configTasks={configTasks}
-                studentAssignmentProgress={studentAssignmentProgress}
-                isMyQuestion={isMyQuestion}
-                className={background_color}
-              />
-            )
-          })}
+            questionsGettingHelp.map((question: Question) =>
+              renderQuestion(question),
+            )}
+          {questions.map((question: Question) => renderQuestion(question))}
         </>
       )}
     </div>

--- a/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/StaffList.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/StaffList.tsx
@@ -1,4 +1,4 @@
-import { Question } from '@koh/common'
+import { OpenQuestionStatus, Question } from '@koh/common'
 import { Badge, Col, Row } from 'antd'
 import { useQuestions } from '@/app/hooks/useQuestions'
 import { useQueue } from '@/app/hooks/useQueue'
@@ -26,7 +26,11 @@ const StaffList: React.FC<StaffListProps> = ({ queueId }) => {
   const groups = queueQuestions.groups
   // for each TA, give them an array of questions that they are helping
   for (const question of helpingQuestions) {
-    if (question.taHelped && taIds.includes(question.taHelped.id)) {
+    if (
+      question.taHelped &&
+      question.status !== OpenQuestionStatus.Paused &&
+      taIds.includes(question.taHelped.id)
+    ) {
       if (!taToQuestions[question.taHelped.id]) {
         taToQuestions[question.taHelped.id] = []
       }

--- a/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/StudentBanner.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/StudentBanner.tsx
@@ -66,7 +66,7 @@ const StudentBanner: React.FC<StudentBannerProps> = ({
           studentQuestion?.taHelped?.name
         )
       case 'Paused':
-        return `Your Questions - Your question is currently paused, you will be helped later.`
+        return `Your Questions - Your question is currently paused by staff, you will be helped soon.`
       default:
         switch (demoStatus) {
           case 'Drafting':

--- a/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/StudentBanner.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/StudentBanner.tsx
@@ -65,6 +65,8 @@ const StudentBanner: React.FC<StudentBannerProps> = ({
           'Your Questions - You are now in a priority queue, you will be helped soon. Last helped by: ' +
           studentQuestion?.taHelped?.name
         )
+      case 'Paused':
+        return `Your Questions - Your question is currently paused, you will be helped later.`
       default:
         switch (demoStatus) {
           case 'Drafting':
@@ -192,6 +194,8 @@ const QuestionDetailCard: React.FC<QuestionDetailCardProps> = ({
         return 'border-[#faad14]'
       case 'Helping':
         return 'border-[#4dc186]'
+      case 'Paused':
+        return 'border-amber-200'
       case 'ReQueueing':
         return 'border-[#66BB6A]'
       case 'PriorityQueued':

--- a/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/TAQuestionCardButtons.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/TAQuestionCardButtons.tsx
@@ -293,7 +293,11 @@ const TAQuestionCardButtons: React.FC<TAQuestionCardButtonsProps> = ({
               variant="green"
               icon={<CheckOutlined />}
               loading={finishHelpingButtonLoading}
-              disabled={cantFindButtonLoading || requeueButtonLoading}
+              disabled={
+                cantFindButtonLoading ||
+                requeueButtonLoading ||
+                pauseButtonLoading
+              }
               onClick={() => {
                 // setCheckOutTimer()
                 setFinishHelpingButtonLoading(true)
@@ -314,30 +318,26 @@ const TAQuestionCardButtons: React.FC<TAQuestionCardButtonsProps> = ({
           </Tooltip>
         )}
         {question.status === OpenQuestionStatus.Paused ? (
-          <div className="relative ml-3 inline-flex items-center justify-center">
-            <div className="absolute inset-0 animate-ping rounded-[50%] bg-green-300 opacity-50 before:content-['']"></div>
-            <Tooltip title="Resume Helping">
-              <CircleButton
-                className={'!ml-0'}
-                variant="green"
-                icon={<Play size={22} className="shrink-0 pl-1" />}
-                loading={pauseButtonLoading}
-                disabled={
-                  cantFindButtonLoading ||
-                  requeueButtonLoading ||
-                  finishHelpingButtonLoading
-                }
-                onClick={() => {
-                  setPauseButtonLoading(true)
-                  changeStatus(OpenQuestionStatus.Helping).then(() =>
-                    setPauseButtonLoading(false),
-                  )
-                }}
-              />
-            </Tooltip>
-          </div>
+          <Tooltip title="Resume Helping">
+            <CircleButton
+              variant="green"
+              icon={<Play size={22} className="shrink-0 pl-1" />}
+              loading={pauseButtonLoading}
+              disabled={
+                cantFindButtonLoading ||
+                requeueButtonLoading ||
+                finishHelpingButtonLoading
+              }
+              onClick={() => {
+                setPauseButtonLoading(true)
+                changeStatus(OpenQuestionStatus.Helping).then(() =>
+                  setPauseButtonLoading(false),
+                )
+              }}
+            />
+          </Tooltip>
         ) : (
-          <Tooltip title="Help Later">
+          <Tooltip title="Pause Helping">
             <CircleButton
               variant="gray"
               icon={<PauseOutlined />}

--- a/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/TAQuestionCardButtons.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/TAQuestionCardButtons.tsx
@@ -2,6 +2,7 @@ import {
   CheckOutlined,
   CloseOutlined,
   DeleteOutlined,
+  PauseOutlined,
   QuestionOutlined,
   UndoOutlined,
 } from '@ant-design/icons'
@@ -60,6 +61,7 @@ const TAQuestionCardButtons: React.FC<TAQuestionCardButtonsProps> = ({
     useState(false)
   const [cantFindButtonLoading, setCantFindButtonLoading] = useState(false)
   const [requeueButtonLoading, setRequeueButtonLoading] = useState(false)
+  const [pauseButtonLoading, setPauseButtonLoading] = useState(false)
 
   // let timerCheckout=useRef(null);
   const changeStatus = useCallback(
@@ -218,7 +220,10 @@ const TAQuestionCardButtons: React.FC<TAQuestionCardButtonsProps> = ({
     return () => clearTimeout(timer)
   }, [tasksSelectedForMarking, previousTasksSelectedForMarking])
 
-  if (question.status === OpenQuestionStatus.Helping) {
+  if (
+    question.status === OpenQuestionStatus.Helping ||
+    question.status === OpenQuestionStatus.Paused
+  ) {
     return (
       <div className={className}>
         <Popconfirm
@@ -237,7 +242,11 @@ const TAQuestionCardButtons: React.FC<TAQuestionCardButtonsProps> = ({
             <CircleButton
               icon={<UndoOutlined />}
               loading={requeueButtonLoading}
-              disabled={cantFindButtonLoading || finishHelpingButtonLoading}
+              disabled={
+                pauseButtonLoading ||
+                cantFindButtonLoading ||
+                finishHelpingButtonLoading
+              }
             />
           </Tooltip>
         </Popconfirm>
@@ -259,45 +268,94 @@ const TAQuestionCardButtons: React.FC<TAQuestionCardButtonsProps> = ({
               variant="red"
               icon={<CloseOutlined />}
               loading={cantFindButtonLoading}
-              disabled={requeueButtonLoading || finishHelpingButtonLoading}
+              disabled={
+                pauseButtonLoading ||
+                requeueButtonLoading ||
+                finishHelpingButtonLoading
+              }
             />
           </Tooltip>
         </Popconfirm>
-        <Tooltip
-          title={
-            question.isTaskQuestion
-              ? tasksSelectedForMarking.length > 0
-                ? 'Mark ' + tasksSelectedForMarking.join(', ') + ' as Done'
-                : 'Mark All as Done'
-              : 'Finish Helping'
-          }
-          open={isFinishHelpingTooltipVisible}
-        >
-          <CircleButton
-            onMouseEnter={() => setIsFinishHelpingTooltipVisible(true)}
-            onMouseLeave={() => setIsFinishHelpingTooltipVisible(false)}
-            variant="green"
-            icon={<CheckOutlined />}
-            loading={finishHelpingButtonLoading}
-            disabled={cantFindButtonLoading || requeueButtonLoading}
-            onClick={() => {
-              // setCheckOutTimer()
-              setFinishHelpingButtonLoading(true)
-              if (
-                question.isTaskQuestion &&
-                tasksSelectedForMarking.length > 0
-              ) {
-                markSelected().then(() => {
-                  setFinishHelpingButtonLoading(false)
-                })
-              } else {
-                changeStatus(ClosedQuestionStatus.Resolved).then(() => {
-                  setFinishHelpingButtonLoading(false)
-                })
+        {question.status !== OpenQuestionStatus.Paused && (
+          <Tooltip
+            title={
+              question.isTaskQuestion
+                ? tasksSelectedForMarking.length > 0
+                  ? 'Mark ' + tasksSelectedForMarking.join(', ') + ' as Done'
+                  : 'Mark All as Done'
+                : 'Finish Helping'
+            }
+            open={isFinishHelpingTooltipVisible}
+          >
+            <CircleButton
+              onMouseEnter={() => setIsFinishHelpingTooltipVisible(true)}
+              onMouseLeave={() => setIsFinishHelpingTooltipVisible(false)}
+              variant="green"
+              icon={<CheckOutlined />}
+              loading={finishHelpingButtonLoading}
+              disabled={cantFindButtonLoading || requeueButtonLoading}
+              onClick={() => {
+                // setCheckOutTimer()
+                setFinishHelpingButtonLoading(true)
+                if (
+                  question.isTaskQuestion &&
+                  tasksSelectedForMarking.length > 0
+                ) {
+                  markSelected().then(() => {
+                    setFinishHelpingButtonLoading(false)
+                  })
+                } else {
+                  changeStatus(ClosedQuestionStatus.Resolved).then(() => {
+                    setFinishHelpingButtonLoading(false)
+                  })
+                }
+              }}
+            />
+          </Tooltip>
+        )}
+        {question.status === OpenQuestionStatus.Paused ? (
+          <div className="relative ml-3 inline-flex items-center justify-center">
+            <div className="absolute inset-0 animate-ping rounded-[50%] bg-green-300 opacity-50 before:content-['']"></div>
+            <Tooltip title="Resume Helping">
+              <CircleButton
+                className={'!ml-0'}
+                variant="green"
+                icon={<Play size={22} className="shrink-0 pl-1" />}
+                loading={pauseButtonLoading}
+                disabled={
+                  cantFindButtonLoading ||
+                  requeueButtonLoading ||
+                  finishHelpingButtonLoading
+                }
+                onClick={() => {
+                  setPauseButtonLoading(true)
+                  changeStatus(OpenQuestionStatus.Helping).then(() =>
+                    setPauseButtonLoading(false),
+                  )
+                }}
+              />
+            </Tooltip>
+          </div>
+        ) : (
+          <Tooltip title="Help Later">
+            <CircleButton
+              variant="gray"
+              icon={<PauseOutlined />}
+              loading={pauseButtonLoading}
+              disabled={
+                cantFindButtonLoading ||
+                requeueButtonLoading ||
+                finishHelpingButtonLoading
               }
-            }}
-          />
-        </Tooltip>
+              onClick={() => {
+                setPauseButtonLoading(true)
+                changeStatus(OpenQuestionStatus.Paused).then(() =>
+                  setPauseButtonLoading(false),
+                )
+              }}
+            />
+          </Tooltip>
+        )}
       </div>
     )
   } else {

--- a/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/utils/commonQueueFunctions.ts
+++ b/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/utils/commonQueueFunctions.ts
@@ -1,4 +1,4 @@
-import { ListQuestionsResponse, Role } from '@koh/common'
+import { ListQuestionsResponse, OpenQuestionStatus, Role } from '@koh/common'
 
 export function getHelpingQuestions(
   queueQuestions: ListQuestionsResponse | undefined,
@@ -10,7 +10,9 @@ export function getHelpingQuestions(
   }
   const helpingQuestions =
     queueQuestions?.questionsGettingHelp.filter(
-      (question) => question.taHelped?.id === userId,
+      (question) =>
+        question.status == OpenQuestionStatus.Paused ||
+        question.taHelped?.id === userId,
     ) ?? []
   const isHelping = helpingQuestions.length > 0
   return { helpingQuestions, isHelping }

--- a/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/utils/commonQueueFunctions.ts
+++ b/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/utils/commonQueueFunctions.ts
@@ -11,9 +11,23 @@ export function getHelpingQuestions(
   const helpingQuestions =
     queueQuestions?.questionsGettingHelp.filter(
       (question) =>
-        question.status == OpenQuestionStatus.Paused ||
+        question.status != OpenQuestionStatus.Paused &&
         question.taHelped?.id === userId,
     ) ?? []
   const isHelping = helpingQuestions.length > 0
   return { helpingQuestions, isHelping }
+}
+
+export function getPausedQuestions(
+  queueQuestions: ListQuestionsResponse | undefined,
+  role: Role,
+) {
+  if (role !== Role.TA && role !== Role.PROFESSOR) {
+    return { pausedQuestions: [] }
+  }
+  const pausedQuestions =
+    queueQuestions?.questionsGettingHelp.filter(
+      (question) => question.status == OpenQuestionStatus.Paused,
+    ) ?? []
+  return { pausedQuestions }
 }

--- a/packages/frontend/app/qi/[qid]/components/QuestionCardSimple.tsx
+++ b/packages/frontend/app/qi/[qid]/components/QuestionCardSimple.tsx
@@ -4,7 +4,11 @@ import {
   Question,
 } from '@koh/common'
 import { Card, Col, Row, Tooltip } from 'antd'
-import { getServedTime, getWaitTime } from '@/app/utils/timeFormatUtils'
+import {
+  getPausedTime,
+  getServedTime,
+  getWaitTime,
+} from '@/app/utils/timeFormatUtils'
 import { QuestionTagElement } from '@/app/(dashboard)/course/[cid]/components/QuestionTagElement'
 import { useState, useEffect } from 'react'
 import { cn } from '@/app/utils/generalUtils'
@@ -12,6 +16,7 @@ import { cn } from '@/app/utils/generalUtils'
 interface QuestionCardSimpleProps {
   question: Question
   isBeingHelped?: boolean
+  isPaused?: boolean
   configTasks?: ConfigTasks
   className?: string // used to highlight questions or add other classes
 }
@@ -22,6 +27,7 @@ interface QuestionCardSimpleProps {
 const QuestionCardSimple: React.FC<QuestionCardSimpleProps> = ({
   question,
   isBeingHelped,
+  isPaused,
   configTasks,
   className,
 }) => {
@@ -30,21 +36,28 @@ const QuestionCardSimple: React.FC<QuestionCardSimpleProps> = ({
     : [] // gives an array of "part1","part2",etc.
 
   const [servedTime, setServedTime] = useState(getServedTime(question))
-
+  const [pausedTime, setPausedTime] = useState(getPausedTime(question))
   useEffect(() => {
-    if (isBeingHelped && question.helpedAt) {
+    if (isBeingHelped && question.helpedAt && !isPaused) {
       const interval = setInterval(() => {
         setServedTime(getServedTime(question))
       }, 1000)
       return () => clearInterval(interval)
+    } else if (isPaused && question.pausedAt) {
+      const interval = setInterval(() => {
+        setPausedTime(getPausedTime(question))
+      }, 1000)
+      return () => clearInterval(interval)
     }
-  }, [isBeingHelped, question])
+  }, [isBeingHelped, question, isPaused])
 
   return (
     <Card
       className={cn(
-        'my-1 w-full rounded-md bg-white px-2 text-gray-600 shadow-md',
-        isBeingHelped ? 'border border-green-600/40' : '',
+        'my-1 w-full rounded-md bg-white px-2 text-gray-600 shadow-md ',
+        isBeingHelped ? 'border' : '',
+        isBeingHelped && !isPaused ? 'border-green-600/40 bg-green-50' : '',
+        isPaused ? 'border-amber-600/40 bg-amber-50' : '',
         className,
       )}
       classNames={{ body: 'px-0.5 py-1.5 md:px-2.5 md:py-2' }}
@@ -109,22 +122,45 @@ const QuestionCardSimple: React.FC<QuestionCardSimpleProps> = ({
             />
           ))}
         </Col>
-        {isBeingHelped && question.helpedAt && (
-          <Col flex="0 0 3rem">
-            <div className="text-sm font-medium text-green-700">
-              {servedTime}
-            </div>
-          </Col>
-        )}
-        <Col flex="0 0 3rem">
-          <div className="text-sm text-gray-600">{getWaitTime(question)}</div>
-        </Col>
-        <div
-          className={`absolute left-auto right-1 ${question.text && question.questionTypes && question.questionTypes.length > 0 ? '-mt-16' : '-mt-12'}`}
-        >
-          {isBeingHelped && (
-            <div className="text-sm text-green-700">Currently Being Served</div>
+        <div>
+          {(isBeingHelped || isPaused) && (
+            <Row justify={'center'}>
+              <div
+                className={cn(
+                  'text-sm',
+                  isPaused ? 'text-amber-400' : '',
+                  isBeingHelped ? 'text-green-700' : '',
+                )}
+              >
+                {isPaused && 'Helping Paused'}
+                {isBeingHelped && 'Currently Being Served'}
+              </div>
+            </Row>
           )}
+          <Row
+            justify={'end'}
+            className={cn(!isBeingHelped && !isPaused ? 'h-[2.5rem]' : '')}
+          >
+            <Col flex="0 0 3rem">
+              {(isBeingHelped || isPaused) && (
+                <div
+                  className={cn(
+                    isBeingHelped ? 'text-green-700' : '',
+                    isPaused ? 'text-amber-400' : '',
+                    'text-sm font-medium',
+                  )}
+                >
+                  {isPaused && pausedTime}
+                  {isBeingHelped && servedTime}
+                </div>
+              )}
+            </Col>
+            <Col flex="0 0 3rem">
+              <div className="text-sm text-gray-600">
+                {getWaitTime(question)}
+              </div>
+            </Col>
+          </Row>
         </div>
       </Row>
     </Card>

--- a/packages/frontend/app/qi/[qid]/components/QuestionCardSimple.tsx
+++ b/packages/frontend/app/qi/[qid]/components/QuestionCardSimple.tsx
@@ -133,7 +133,7 @@ const QuestionCardSimple: React.FC<QuestionCardSimpleProps> = ({
                 )}
               >
                 {isPaused && 'Helping Paused'}
-                {isBeingHelped && 'Currently Being Served'}
+                {isBeingHelped && 'Being Served'}
               </div>
             </Row>
           )}
@@ -141,7 +141,7 @@ const QuestionCardSimple: React.FC<QuestionCardSimpleProps> = ({
             justify={'end'}
             className={cn(!isBeingHelped && !isPaused ? 'h-[2.5rem]' : '')}
           >
-            <Col flex="0 0 3rem">
+            <Col flex="0 0 2rem">
               {(isBeingHelped || isPaused) && (
                 <div
                   className={cn(
@@ -155,7 +155,7 @@ const QuestionCardSimple: React.FC<QuestionCardSimpleProps> = ({
                 </div>
               )}
             </Col>
-            <Col flex="0 0 3rem">
+            <Col flex="0 0 2rem">
               <div className="text-sm text-gray-600">
                 {getWaitTime(question)}
               </div>

--- a/packages/frontend/app/qi/[qid]/page.tsx
+++ b/packages/frontend/app/qi/[qid]/page.tsx
@@ -14,6 +14,7 @@ import { ReactElement, useCallback, useEffect, useRef, useState } from 'react'
 import {
   decodeBase64,
   encodeBase64,
+  OpenQuestionStatus,
   parseTaskIdsFromQuestionText,
   PublicQueueInvite,
   Question,
@@ -248,6 +249,18 @@ export default function QueueInvitePage({
     }
   }, [tagGroupsEnabled, configTasks])
 
+  const renderQuestion = (question: Question) => {
+    return (
+      <QuestionCardSimple
+        key={question.id}
+        question={question}
+        configTasks={configTasks}
+        isBeingHelped={question.status == OpenQuestionStatus.Helping}
+        isPaused={question.status == OpenQuestionStatus.Paused}
+      />
+    )
+  }
+
   if (pageLoading) {
     return <CenteredSpinner tip="Loading..." />
   } else if (hasFetchErrorOccurred) {
@@ -450,15 +463,9 @@ export default function QueueInvitePage({
                                 </div>
                               }
                             >
-                              {filteredQuestions.map((question: Question) => {
-                                return (
-                                  <QuestionCardSimple
-                                    key={question.id}
-                                    question={question}
-                                    configTasks={configTasks}
-                                  />
-                                )
-                              })}
+                              {filteredQuestions.map((question: Question) =>
+                                renderQuestion(question),
+                              )}
                             </Panel>
                           )
                         )
@@ -505,15 +512,9 @@ export default function QueueInvitePage({
                                 </div>
                               }
                             >
-                              {filteredQuestions.map((question: Question) => {
-                                return (
-                                  <QuestionCardSimple
-                                    key={question.id}
-                                    question={question}
-                                    configTasks={configTasks}
-                                  />
-                                )
-                              })}
+                              {filteredQuestions.map((question: Question) =>
+                                renderQuestion(question),
+                              )}
                             </Panel>
                           )
                         )
@@ -529,19 +530,16 @@ export default function QueueInvitePage({
                             question={question}
                             configTasks={configTasks}
                             isBeingHelped={true}
+                            isPaused={
+                              question.status === OpenQuestionStatus.Paused
+                            }
                           />
                         )
                       },
                     )}
-                    {queueQuestions.questions.map((question: Question) => {
-                      return (
-                        <QuestionCardSimple
-                          key={question.id}
-                          question={question}
-                          configTasks={configTasks}
-                        />
-                      )
-                    })}
+                    {queueQuestions.questions.map((question: Question) =>
+                      renderQuestion(question),
+                    )}
                   </>
                 )}
               </div>

--- a/packages/frontend/app/utils/timeFormatUtils.ts
+++ b/packages/frontend/app/utils/timeFormatUtils.ts
@@ -59,6 +59,39 @@ export function getServedTime(question: Question): string {
   return formatServeTime(difference / 1000)
 }
 
+export function getPausedTime(question: Question): string {
+  if (!question.pausedAt || !question.createdAt) {
+    return ''
+  }
+  const now = new Date()
+
+  if (typeof question.pausedAt === 'string') {
+    const tempDate = new Date(Date.parse(question.pausedAt))
+    const difference = now.getTime() - tempDate.getTime()
+    return formatWaitTime(difference / 60000)
+  }
+  const difference = now.getTime() - question.pausedAt.getTime()
+  return formatWaitTime(difference / 60000)
+}
+
+export function getOriginalPausedTime(question: Question): string {
+  if (!question.pausedAt || !question.createdAt) {
+    return ''
+  }
+
+  const created =
+    typeof question.createdAt === 'string'
+      ? new Date(Date.parse(question.createdAt))
+      : question.createdAt
+  const paused =
+    typeof question.pausedAt === 'string'
+      ? new Date(Date.parse(question.pausedAt))
+      : question.pausedAt
+
+  const difference = paused.getTime() - created.getTime()
+  return formatServeTime(difference / 1000)
+}
+
 /**
  * Formats time as 0:11 (minutes:seconds)
  */

--- a/packages/server/migration/1729450514047-paused-at-property-question-model.ts
+++ b/packages/server/migration/1729450514047-paused-at-property-question-model.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class pausedAtPropertyQuestionModel1729450514047
+  implements MigrationInterface
+{
+  name = 'pausedAtPropertyQuestionModel1729450514047';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "question_model" ADD "pausedAt" TIMESTAMP`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "question_model" DROP COLUMN "pausedAt"`,
+    );
+  }
+}

--- a/packages/server/src/notification/notification.service.ts
+++ b/packages/server/src/notification/notification.service.ts
@@ -12,6 +12,8 @@ export const NotifMsgs = {
     THIRD_PLACE: `You're 3rd in the queue. Be ready for a TA to call you soon!`,
     TA_HIT_HELPED: (taName: string): string =>
       `${taName} is ready for you now!`,
+    PAUSED: (taName: string): string =>
+      `${taName} has paused your question for the time being.`,
     REMOVED: `You've been removed from the queue. Please return to the app for more information.`,
   },
   ta: {

--- a/packages/server/src/question/question-fsm.ts
+++ b/packages/server/src/question/question-fsm.ts
@@ -16,22 +16,32 @@ const QUEUE_TRANSITIONS: AllowableTransitions = {
   student: [ClosedQuestionStatus.ConfirmedDeleted],
 };
 
-const QUESTION_STATES: Record<QuestionStatus, AllowableTransitions> = {
+const HELPING_TRANSITIONS: AllowableTransitions = {
+  ta: [
+    LimboQuestionStatus.CantFind,
+    LimboQuestionStatus.ReQueueing,
+    ClosedQuestionStatus.Resolved,
+    OpenQuestionStatus.Paused,
+    LimboQuestionStatus.TADeleted,
+  ],
+  student: [ClosedQuestionStatus.ConfirmedDeleted],
+};
+
+export const QUESTION_STATES: Record<QuestionStatus, AllowableTransitions> = {
   [OpenQuestionStatus.Drafting]: {
     student: [OpenQuestionStatus.Queued, ClosedQuestionStatus.ConfirmedDeleted],
     ta: [OpenQuestionStatus.Helping, ClosedQuestionStatus.DeletedDraft],
   },
   [OpenQuestionStatus.Queued]: QUEUE_TRANSITIONS,
   [OpenQuestionStatus.PriorityQueued]: QUEUE_TRANSITIONS,
-  [OpenQuestionStatus.Helping]: {
+  [OpenQuestionStatus.Paused]: {
     ta: [
-      LimboQuestionStatus.CantFind,
-      LimboQuestionStatus.ReQueueing,
-      ClosedQuestionStatus.Resolved,
-      LimboQuestionStatus.TADeleted,
+      ...HELPING_TRANSITIONS.ta.filter((t) => t != OpenQuestionStatus.Paused),
+      OpenQuestionStatus.Helping,
     ],
-    student: [ClosedQuestionStatus.ConfirmedDeleted],
+    student: HELPING_TRANSITIONS.student,
   },
+  [OpenQuestionStatus.Helping]: HELPING_TRANSITIONS,
   [LimboQuestionStatus.CantFind]: {
     student: [
       OpenQuestionStatus.PriorityQueued,

--- a/packages/server/src/question/question.entity.ts
+++ b/packages/server/src/question/question.entity.ts
@@ -58,6 +58,9 @@ export class QuestionModel extends BaseEntity {
   @Exclude()
   firstHelpedAt: Date;
 
+  @Column({ nullable: true })
+  pausedAt: Date;
+
   // When the question was last helped (getting help again on priority queue overwrites)
   @Column({ nullable: true })
   helpedAt: Date;

--- a/packages/server/src/queue/queue.service.spec.ts
+++ b/packages/server/src/queue/queue.service.spec.ts
@@ -77,7 +77,7 @@ describe('QueueService', () => {
       );
       expect(statuses).toEqual({
         priorityQueue: ['PriorityQueued'],
-        questionsGettingHelp: ['Helping'],
+        questionsGettingHelp: ['Helping', 'Paused'],
         questions: ['Queued', 'Drafting'],
         groups: [],
         unresolvedAlerts: [],

--- a/packages/server/src/queue/queue.service.ts
+++ b/packages/server/src/queue/queue.service.ts
@@ -71,7 +71,12 @@ export class QueueService {
 
     const questionsFromDb = await QuestionModel.inQueueWithStatus(
       queueId,
-      [...StatusInPriorityQueue, ...StatusInQueue, OpenQuestionStatus.Helping],
+      [
+        ...StatusInPriorityQueue,
+        ...StatusInQueue,
+        OpenQuestionStatus.Helping,
+        OpenQuestionStatus.Paused,
+      ],
       this.appConfig.get('max_questions_per_queue'),
     )
       .leftJoinAndSelect('question.questionTypes', 'questionTypes')
@@ -90,7 +95,9 @@ export class QueueService {
 
     queueQuestions.questionsGettingHelp = questionsFromDb.filter(
       (question) =>
-        question.status === OpenQuestionStatus.Helping && !question.groupId,
+        (question.status === OpenQuestionStatus.Helping ||
+          question.status === OpenQuestionStatus.Paused) &&
+        !question.groupId,
     );
 
     // Also remove sensitive data from taHelped inside questionsGettingHelp


### PR DESCRIPTION
# Description

Added ability for queue staff to 'pause' questions after they've been helped, in order to help more high-priority questions.
The question itself remains considered to be being helped - it is not moved back into the queue. While paused, a timer indicating how much time has elapsed since the question was paused is visible.
Additionally, other queue staff can pick up paused questions in case they clear up. This provides a method for queue staff to delay responding to certain questions in case of higher priority ones entering the queue, while also keeping the student on the top of the heap of questions to handle.
Changes to the 'helpedAt' column are made. Question entity now has an attribute 'pausedAt' that is essentially a temporary time-tracker and removed after the question is unpaused.

Closes #161 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [x] _This requires a database migration update_

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 

- [x] Integration test for the pausing process.
- [x] Manual testing with clients on different browser windows to ensure that relationships are retained and no unintended errors come about:
  - 1 queue staff, 1 student: pausing/unpausing
  - 1 queue staff, 2 students: ensuring that the 'help all' button is no longer present on pause
  - 1 queue staff, 3 students: ensuring that the 'help all' button is present when only 1 question is paused
  - 2 queue staff, 1 student: ensuring that the 'paused' question becomes visible to the other queue staff

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [x] Any UI changes have been checked to work on desktop, tablet, and mobile
