### PR TITLE
made question type name, color, cid not nullable

### DIFF
--- a/packages/server/migration/1729547252435-question-type-not-nullable.ts
+++ b/packages/server/migration/1729547252435-question-type-not-nullable.ts
@@ -1,0 +1,49 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class questionTypeNotNullable1729547252435
+  implements MigrationInterface
+{
+  name = 'questionTypeNotNullable1729547252435';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "question_type_model" DROP CONSTRAINT "FK_a3ecde22b20f0416affdad4d0d3"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "question_type_model" ALTER COLUMN "cid" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "question_type_model" ALTER COLUMN "name" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "question_type_model" ALTER COLUMN "name" SET DEFAULT ''`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "question_type_model" ALTER COLUMN "color" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "question_type_model" ADD CONSTRAINT "FK_a3ecde22b20f0416affdad4d0d3" FOREIGN KEY ("cid") REFERENCES "course_model"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "question_type_model" DROP CONSTRAINT "FK_a3ecde22b20f0416affdad4d0d3"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "question_type_model" ALTER COLUMN "color" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "question_type_model" ALTER COLUMN "name" DROP DEFAULT`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "question_type_model" ALTER COLUMN "name" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "question_type_model" ALTER COLUMN "cid" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "question_type_model" ADD CONSTRAINT "FK_a3ecde22b20f0416affdad4d0d3" FOREIGN KEY ("cid") REFERENCES "course_model"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+}

--- a/packages/server/src/questionType/question-type.entity.ts
+++ b/packages/server/src/questionType/question-type.entity.ts
@@ -27,13 +27,13 @@ export class QuestionTypeModel extends BaseEntity {
   @Exclude()
   course: CourseModel;
 
-  @Column({ nullable: true })
+  @Column()
   cid: number;
 
-  @Column({ type: 'text', nullable: true })
+  @Column({ type: 'text', default: '' })
   name: string;
 
-  @Column({ type: 'text', nullable: true, default: '#000000' })
+  @Column({ type: 'text', default: '#000000' })
   color: string;
 
   @ManyToMany(() => QuestionModel, (question) => question.questionTypes)


### PR DESCRIPTION
# Description

Small change.

Note that before this gets put on production, the following command should be ran:
`UPDATE question_type_model SET name = 'was null', "deletedAt" = NOW() WHERE name IS NULL`

Normally we could just set up a migration for this. However, we don't actually have migrations set up on prod.