### PR TITLE
More Accurate waitTimes and helpTimes

### DIFF
--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -445,11 +445,13 @@ export class Question {
   @Type(() => Date)
   helpedAt?: Date
 
+  // in seconds
   helpTime!: number
 
   @Type(() => Date)
   lastReadyAt?: Date
 
+  // in seconds
   waitTime!: number
 
   @Type(() => Date)

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -445,8 +445,12 @@ export class Question {
   @Type(() => Date)
   helpedAt?: Date
 
+  helpTime!: number
+
   @Type(() => Date)
-  pausedAt?: Date
+  lastReadyAt?: Date
+
+  waitTime!: number
 
   @Type(() => Date)
   closedAt?: Date
@@ -494,6 +498,13 @@ export enum ClosedQuestionStatus {
   ConfirmedDeleted = 'ConfirmedDeleted',
   Stale = 'Stale',
 }
+
+/** waitingStatuses are statuses where the student waiting to be helped */
+export const waitingStatuses: ReadonlyArray<OpenQuestionStatus> = [
+  OpenQuestionStatus.Paused,
+  OpenQuestionStatus.Queued,
+  OpenQuestionStatus.PriorityQueued,
+]
 
 export enum asyncQuestionStatus {
   AIAnsweredNeedsAttention = 'AIAnsweredNeedsAttention', // AI has answered, but the answer is unsatisfactory.

--- a/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/QuestionCard.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/QuestionCard.tsx
@@ -12,12 +12,7 @@ import { useState, useEffect } from 'react'
 import UserAvatar from '@/app/components/UserAvatar'
 import TaskMarkingSelector from './TaskMarkingSelector'
 import { QuestionTagElement } from '../../../components/QuestionTagElement'
-import {
-  getOriginalPausedTime,
-  getPausedTime,
-  getServedTime,
-  getWaitTime,
-} from '@/app/utils/timeFormatUtils'
+import { getServedTime, getWaitTime } from '@/app/utils/timeFormatUtils'
 import TAQuestionCardButtons from './TAQuestionCardButtons'
 import { cn } from '@/app/utils/generalUtils'
 
@@ -62,7 +57,6 @@ const QuestionCard: React.FC<QuestionCardProps> = ({
   }
 
   const [servedTime, setServedTime] = useState(getServedTime(question))
-  const [pausedTime, setPausedTime] = useState(getPausedTime(question))
 
   useEffect(() => {
     if (isBeingHelped && question.helpedAt && !isPaused) {
@@ -70,11 +64,8 @@ const QuestionCard: React.FC<QuestionCardProps> = ({
         setServedTime(getServedTime(question))
       }, 1000)
       return () => clearInterval(interval)
-    } else if (isPaused && question.pausedAt) {
-      const interval = setInterval(() => {
-        setPausedTime(getPausedTime(question))
-      }, 1000)
-      return () => clearInterval(interval)
+    } else if (isPaused) {
+      setServedTime(getServedTime(question))
     }
   }, [isBeingHelped, question, isPaused])
 
@@ -254,15 +245,7 @@ const QuestionCard: React.FC<QuestionCardProps> = ({
                       'font-md flex justify-end text-sm',
                     )}
                   >
-                    {isPaused && (
-                      <>
-                        <div className={'text-gray-600'}>
-                          {getOriginalPausedTime(question)}
-                        </div>
-                        <div>{isPaused ? ' +' + pausedTime : ''}</div>
-                      </>
-                    )}
-                    {isBeingHelped && servedTime}
+                    {(isBeingHelped || isPaused) && servedTime}
                   </div>
                 )}
               </Col>

--- a/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/QuestionCard.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/QuestionCard.tsx
@@ -96,7 +96,7 @@ const QuestionCard: React.FC<QuestionCardProps> = ({
           isMyQuestion && !isBeingReQueued ? 'bg-teal-200/25' : 'bg-white',
           isBeingReQueued
             ? 'greyscale mt-3 border-gray-300 bg-gray-200/20 text-gray-400 md:mt-2'
-            : ' ',
+            : '',
           className,
         )}
         classNames={{ body: 'px-0.5 py-1.5 md:px-2.5 md:py-2' }}
@@ -211,12 +211,12 @@ const QuestionCard: React.FC<QuestionCardProps> = ({
                 <div
                   className={cn(
                     'text-sm',
-                    isPaused ? 'text-amber-400' : '',
+                    isPaused ? 'mr-6 text-amber-400' : '',
                     isBeingHelped ? 'text-green-700' : '',
                     isBeingReQueued ? 'italic' : '',
                   )}
                 >
-                  {isPaused && 'Currently Paused'}
+                  {isPaused && 'Paused'}
                   {isBeingHelped && 'Being Served'}
                   {isBeingReQueued && 'Not Ready'}
                 </div>
@@ -242,7 +242,7 @@ const QuestionCard: React.FC<QuestionCardProps> = ({
                     className={cn(
                       isBeingHelped ? 'text-green-700' : '',
                       isPaused ? 'text-amber-400' : '',
-                      'font-md flex justify-end text-sm',
+                      'flex justify-end text-sm font-medium',
                     )}
                   >
                     {(isBeingHelped || isPaused) && servedTime}

--- a/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/StudentBanner.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/StudentBanner.tsx
@@ -64,7 +64,7 @@ const StudentBanner: React.FC<StudentBannerProps> = ({
           studentQuestion?.taHelped?.name
         )
       case 'Paused':
-        return `Your Questions - Your question is currently paused by staff, you will be helped soon.`
+        return `Your Questions - Your question is currently paused by staff, you will be helped soon`
       default:
         switch (demoStatus) {
           case 'Drafting':

--- a/packages/frontend/app/qi/[qid]/components/QuestionCardSimple.tsx
+++ b/packages/frontend/app/qi/[qid]/components/QuestionCardSimple.tsx
@@ -4,11 +4,7 @@ import {
   Question,
 } from '@koh/common'
 import { Card, Col, Row, Tooltip } from 'antd'
-import {
-  getPausedTime,
-  getServedTime,
-  getWaitTime,
-} from '@/app/utils/timeFormatUtils'
+import { getServedTime, getWaitTime } from '@/app/utils/timeFormatUtils'
 import { QuestionTagElement } from '@/app/(dashboard)/course/[cid]/components/QuestionTagElement'
 import { useState, useEffect } from 'react'
 import { cn } from '@/app/utils/generalUtils'
@@ -36,18 +32,14 @@ const QuestionCardSimple: React.FC<QuestionCardSimpleProps> = ({
     : [] // gives an array of "part1","part2",etc.
 
   const [servedTime, setServedTime] = useState(getServedTime(question))
-  const [pausedTime, setPausedTime] = useState(getPausedTime(question))
   useEffect(() => {
     if (isBeingHelped && question.helpedAt && !isPaused) {
       const interval = setInterval(() => {
         setServedTime(getServedTime(question))
       }, 1000)
       return () => clearInterval(interval)
-    } else if (isPaused && question.pausedAt) {
-      const interval = setInterval(() => {
-        setPausedTime(getPausedTime(question))
-      }, 1000)
-      return () => clearInterval(interval)
+    } else if (isPaused) {
+      setServedTime(getServedTime(question))
     }
   }, [isBeingHelped, question, isPaused])
 
@@ -150,8 +142,7 @@ const QuestionCardSimple: React.FC<QuestionCardSimpleProps> = ({
                     'text-sm font-medium',
                   )}
                 >
-                  {isPaused && pausedTime}
-                  {isBeingHelped && servedTime}
+                  {(isBeingHelped || isPaused) && servedTime}
                 </div>
               )}
             </Col>

--- a/packages/frontend/app/qi/[qid]/components/QuestionCardSimple.tsx
+++ b/packages/frontend/app/qi/[qid]/components/QuestionCardSimple.tsx
@@ -13,6 +13,7 @@ interface QuestionCardSimpleProps {
   question: Question
   isBeingHelped?: boolean
   isPaused?: boolean
+  isBeingReQueued?: boolean
   configTasks?: ConfigTasks
   className?: string // used to highlight questions or add other classes
 }
@@ -24,6 +25,7 @@ const QuestionCardSimple: React.FC<QuestionCardSimpleProps> = ({
   question,
   isBeingHelped,
   isPaused,
+  isBeingReQueued,
   configTasks,
   className,
 }) => {
@@ -50,6 +52,9 @@ const QuestionCardSimple: React.FC<QuestionCardSimpleProps> = ({
         isBeingHelped ? 'border' : '',
         isBeingHelped && !isPaused ? 'border-green-600/40 bg-green-50' : '',
         isPaused ? 'border-amber-600/40 bg-amber-50' : '',
+        isBeingReQueued
+          ? 'greyscale mt-3 border-gray-300 bg-gray-200/20 text-gray-400 md:mt-2'
+          : '',
         className,
       )}
       classNames={{ body: 'px-0.5 py-1.5 md:px-2.5 md:py-2' }}
@@ -110,36 +115,43 @@ const QuestionCardSimple: React.FC<QuestionCardSimpleProps> = ({
             <QuestionTagElement
               key={index}
               tagName={questionType.name}
-              tagColor={questionType.color}
+              tagColor={!isBeingReQueued ? questionType.color : '#f0f0f0'}
             />
           ))}
         </Col>
-        <div>
-          {(isBeingHelped || isPaused) && (
-            <Row justify={'center'}>
+        <Col flex={'0.1 1 auto'}>
+          {(isBeingHelped || isPaused || isBeingReQueued) && (
+            <Row justify={'end'}>
               <div
                 className={cn(
                   'text-sm',
-                  isPaused ? 'text-amber-400' : '',
+                  isPaused ? 'mr-6 text-amber-400' : '',
                   isBeingHelped ? 'text-green-700' : '',
+                  isBeingReQueued ? 'italic' : '',
                 )}
               >
-                {isPaused && 'Helping Paused'}
+                {isPaused && 'Paused'}
                 {isBeingHelped && 'Being Served'}
+                {isBeingReQueued && 'Not Ready'}
               </div>
             </Row>
           )}
           <Row
             justify={'end'}
-            className={cn(!isBeingHelped && !isPaused ? 'h-[2.5rem]' : '')}
+            className={cn(
+              !isBeingHelped && !isPaused && !isBeingReQueued
+                ? 'h-[2.5rem]'
+                : '',
+              'gap-1',
+            )}
           >
-            <Col flex="0 0 2rem">
+            <Col flex="1 0 2rem">
               {(isBeingHelped || isPaused) && (
                 <div
                   className={cn(
                     isBeingHelped ? 'text-green-700' : '',
                     isPaused ? 'text-amber-400' : '',
-                    'text-sm font-medium',
+                    'flex justify-end text-sm font-medium',
                   )}
                 >
                   {(isBeingHelped || isPaused) && servedTime}
@@ -147,12 +159,12 @@ const QuestionCardSimple: React.FC<QuestionCardSimpleProps> = ({
               )}
             </Col>
             <Col flex="0 0 2rem">
-              <div className="text-sm text-gray-600">
+              <div className="flex justify-end text-nowrap text-sm text-gray-600">
                 {getWaitTime(question)}
               </div>
             </Col>
           </Row>
-        </div>
+        </Col>
       </Row>
     </Card>
   )

--- a/packages/frontend/app/qi/[qid]/page.tsx
+++ b/packages/frontend/app/qi/[qid]/page.tsx
@@ -14,6 +14,7 @@ import { ReactElement, useCallback, useEffect, useRef, useState } from 'react'
 import {
   decodeBase64,
   encodeBase64,
+  LimboQuestionStatus,
   OpenQuestionStatus,
   parseTaskIdsFromQuestionText,
   PublicQueueInvite,
@@ -257,6 +258,7 @@ export default function QueueInvitePage({
         configTasks={configTasks}
         isBeingHelped={question.status == OpenQuestionStatus.Helping}
         isPaused={question.status == OpenQuestionStatus.Paused}
+        isBeingReQueued={question.status === LimboQuestionStatus.ReQueueing}
       />
     )
   }
@@ -529,9 +531,14 @@ export default function QueueInvitePage({
                             key={question.id}
                             question={question}
                             configTasks={configTasks}
-                            isBeingHelped={true}
+                            isBeingHelped={
+                              question.status === OpenQuestionStatus.Helping
+                            }
                             isPaused={
                               question.status === OpenQuestionStatus.Paused
+                            }
+                            isBeingReQueued={
+                              question.status === LimboQuestionStatus.ReQueueing
                             }
                           />
                         )

--- a/packages/server/migration/1731187674872-accurate-helptimes-waittimes.ts
+++ b/packages/server/migration/1731187674872-accurate-helptimes-waittimes.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class accurateHelptimesWaittimes1731187674872
+  implements MigrationInterface
+{
+  name = 'accurateHelptimesWaittimes1731187674872';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "question_model" DROP COLUMN "pausedAt"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "question_model" ADD "lastReadyAt" TIMESTAMP`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "question_model" ADD "waitTime" integer NOT NULL DEFAULT '0'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "question_model" ADD "helpTime" integer NOT NULL DEFAULT '0'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "question_model" DROP COLUMN "helpTime"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "question_model" DROP COLUMN "waitTime"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "question_model" DROP COLUMN "lastReadyAt"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "question_model" ADD "pausedAt" TIMESTAMP`,
+    );
+  }
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -105,7 +105,7 @@
     "@types/connect-redis": "^0.0.16",
     "@types/express": "^4.17.3",
     "@types/express-session": "^1.17.3",
-    "@types/jest": "25.2.3",
+    "@types/jest": "^29.5.14",
     "@types/lodash": "^4.14.157",
     "@types/node": "^13.9.1",
     "@types/passport-jwt": "^3.0.3",

--- a/packages/server/src/insights/insights.service.spec.ts
+++ b/packages/server/src/insights/insights.service.spec.ts
@@ -103,18 +103,21 @@ describe('InsightsService', () => {
         queue: queue,
         createdAt: new Date(Date.now() - 30 * 60 * 1000),
         firstHelpedAt: new Date(Date.now() - 25 * 60 * 1000),
+        waitTime: 5 * 60,
       });
       await QuestionFactory.createList(20, {
         // 10 min
         queue: queue,
         createdAt: new Date(Date.now() - 30 * 60 * 1000),
         firstHelpedAt: new Date(Date.now() - 20 * 60 * 1000),
+        waitTime: 10 * 60,
       });
       await QuestionFactory.createList(20, {
         // 30 min
         queue: queue,
         createdAt: new Date(Date.now() - 60 * 60 * 1000),
         firstHelpedAt: new Date(Date.now() - 30 * 60 * 1000),
+        waitTime: 30 * 60,
       });
 
       const res = await service.computeOutput({
@@ -342,6 +345,8 @@ describe('InsightsService', () => {
         helpedAt: new Date(Date.parse(helptime)),
         firstHelpedAt: new Date(Date.parse(helptime)),
         closedAt: new Date(Date.parse(closetime)),
+        waitTime: duration * 60,
+        helpTime: 5 * 60,
       });
     }
 

--- a/packages/server/src/question/question.entity.ts
+++ b/packages/server/src/question/question.entity.ts
@@ -70,7 +70,7 @@ export class QuestionModel extends BaseEntity {
   // Stores how long the question has been waiting for help.
   // Only gets set on status change, so it will be fine to display this for done questions (e.g. in insights),
   // but for questions currently in the queue, you need to calculate the actual wait time as waitTime + (now - lastReadyAt)
-  @Column({ default: 0 })
+  @Column('integer', { default: 0 })
   waitTime: number; // in seconds
 
   // When the question was last helped (getting help again overwrites) - alterative name is lastHelpedAt
@@ -80,7 +80,7 @@ export class QuestionModel extends BaseEntity {
   // Stores how long the question has been helped for (since just doing closedAt - helpedAt is not accurate as a question can be helped multiple times)
   // Only gets set on status change, so it will be fine to display this for done questions (e.g. in insights),
   // but for questions currently in the queue, you need to calculate the actual help time as helpTime + (now - helpedAt)
-  @Column({ default: 0 })
+  @Column('integer', { default: 0 })
   helpTime: number; // in seconds
 
   // When the question leaves the queue

--- a/packages/server/src/question/question.entity.ts
+++ b/packages/server/src/question/question.entity.ts
@@ -58,17 +58,30 @@ export class QuestionModel extends BaseEntity {
   @Column()
   createdAt: Date;
 
-  // When the question was first helped (doesn't overwrite)
+  // When the question was first helped (doesn't overwrite) - probably don't need anymore (other than if we want to compare if a question has been helped multiple times by seeing if helpedAt == firstHelpedAt)
   @Column({ nullable: true })
   @Exclude()
   firstHelpedAt: Date;
 
+  // ready questions are questions that can be helped (i.e. queued or paused questions)
   @Column({ nullable: true })
-  pausedAt: Date;
+  lastReadyAt: Date;
 
-  // When the question was last helped (getting help again on priority queue overwrites)
+  // Stores how long the question has been waiting for help.
+  // Only gets set on status change, so it will be fine to display this for done questions (e.g. in insights),
+  // but for questions currently in the queue, you need to calculate the actual wait time as waitTime + (now - lastReadyAt)
+  @Column({ default: 0 })
+  waitTime: number; // in seconds
+
+  // When the question was last helped (getting help again overwrites) - alterative name is lastHelpedAt
   @Column({ nullable: true })
   helpedAt: Date;
+
+  // Stores how long the question has been helped for (since just doing closedAt - helpedAt is not accurate as a question can be helped multiple times)
+  // Only gets set on status change, so it will be fine to display this for done questions (e.g. in insights),
+  // but for questions currently in the queue, you need to calculate the actual help time as helpTime + (now - helpedAt)
+  @Column({ default: 0 })
+  helpTime: number; // in seconds
 
   // When the question leaves the queue
   @Column({ nullable: true })

--- a/packages/server/src/question/question.service.spec.ts
+++ b/packages/server/src/question/question.service.spec.ts
@@ -1,4 +1,4 @@
-import { QuestionStatusKeys } from '@koh/common';
+import { QuestionStatusKeys, Role } from '@koh/common';
 import { TestingModule, Test } from '@nestjs/testing';
 import { NotificationService } from 'notification/notification.service';
 import { Connection } from 'typeorm';
@@ -64,7 +64,12 @@ describe('QuestionService', () => {
         status: QuestionStatusKeys.Helping,
       });
 
-      await service.changeStatus(QuestionStatusKeys.CantFind, g1q2, ta.id);
+      await service.changeStatus(
+        QuestionStatusKeys.CantFind,
+        g1q2,
+        ta.id,
+        Role.TA,
+      );
 
       const updatedGroup = await QuestionGroupModel.findOne({
         where: { id: group.id },

--- a/packages/server/src/question/question.service.ts
+++ b/packages/server/src/question/question.service.ts
@@ -9,6 +9,7 @@ import {
   Role,
   StudentAssignmentProgress,
   StudentTaskProgress,
+  waitingStatuses,
 } from '@koh/common';
 import {
   BadRequestException,
@@ -64,23 +65,26 @@ export class QuestionService {
     }
 
     // Set TA as taHelped when the TA starts helping the student
-    const isHelped =
+    const isBecomingHelped =
       oldStatus !== OpenQuestionStatus.Helping &&
       newStatus === OpenQuestionStatus.Helping;
-    const isPaused =
+    const isDoneBeingHelped =
+      oldStatus === OpenQuestionStatus.Helping &&
+      newStatus !== OpenQuestionStatus.Helping;
+    const isBecomingPaused =
       oldStatus !== OpenQuestionStatus.Paused &&
       newStatus === OpenQuestionStatus.Paused;
-    const isHelpedFromPause =
-      oldStatus === OpenQuestionStatus.Paused &&
-      newStatus === OpenQuestionStatus.Helping;
+    const isBecomingWaiting =
+      !waitingStatuses.includes(oldStatus as OpenQuestionStatus) &&
+      waitingStatuses.includes(newStatus as OpenQuestionStatus);
 
-    if (isHelpedFromPause) {
-      // If a question was un-paused, remove the pausedAt property
-      question.pausedAt = null;
-    }
-    if (isHelped) {
+    const now = new Date();
+    if (isBecomingHelped) {
       question.taHelped = await UserModel.findOne({ where: { id: userId } });
-      question.helpedAt = new Date();
+      question.helpedAt = now;
+      question.waitTime =
+        question.waitTime +
+        Math.round((now.getTime() - question.lastReadyAt.getTime()) / 1000);
 
       // Set firstHelpedAt if it hasn't already
       if (!question.firstHelpedAt) {
@@ -91,10 +95,15 @@ export class QuestionService {
         NotifMsgs.queue.TA_HIT_HELPED(question.taHelped.name),
       );
     }
-    if (isPaused) {
-      // Remove the helpedAt property, but original help time is retained by firstHelped property
-      question.helpedAt = null;
-      question.pausedAt = new Date();
+    if (isBecomingWaiting) {
+      question.lastReadyAt = now;
+    }
+    if (isDoneBeingHelped) {
+      question.helpTime =
+        question.helpTime +
+        Math.round((now.getTime() - question.helpedAt.getTime()) / 1000);
+    }
+    if (isBecomingPaused) {
       if (question.taHelpedId != userId) {
         question.taHelped = await UserModel.findOne({ where: { id: userId } });
       }
@@ -105,7 +114,7 @@ export class QuestionService {
     }
 
     if (newStatus in ClosedQuestionStatus) {
-      question.closedAt = new Date();
+      question.closedAt = now;
     }
     if (newStatus in LimboQuestionStatus) {
       // depends on if the question was passed in with its group preloaded

--- a/packages/server/src/question/question.service.ts
+++ b/packages/server/src/question/question.service.ts
@@ -5,7 +5,6 @@ import {
   OpenQuestionStatus,
   parseTaskIdsFromQuestionText,
   QuestionStatus,
-  QuestionTypeParams,
   Role,
   StudentAssignmentProgress,
   StudentTaskProgress,
@@ -26,7 +25,6 @@ import { UserModel } from 'profile/user.entity';
 import { QuestionModel } from './question.entity';
 import { QueueModel } from '../queue/queue.entity';
 import { StudentTaskProgressModel } from 'studentTaskProgress/studentTaskProgress.entity';
-import { QuestionTypeModel } from 'questionType/question-type.entity';
 
 @Injectable()
 export class QuestionService {
@@ -71,7 +69,8 @@ export class QuestionService {
       newStatus === OpenQuestionStatus.Helping;
     const isDoneBeingHelped =
       oldStatus === OpenQuestionStatus.Helping &&
-      newStatus !== OpenQuestionStatus.Helping;
+      newStatus !== OpenQuestionStatus.Helping &&
+      question.helpedAt;
     const isBecomingPaused =
       oldStatus !== OpenQuestionStatus.Paused &&
       newStatus === OpenQuestionStatus.Paused;

--- a/packages/server/src/queue/__snapshots__/queue.service.spec.ts.snap
+++ b/packages/server/src/queue/__snapshots__/queue.service.spec.ts.snap
@@ -10,9 +10,11 @@ ListQuestionsResponse {
       "createdAt": 2020-11-02T12:00:00.000Z,
       "creator": UserModel {},
       "groupable": true,
+      "helpTime": 0,
       "helpedAt": null,
       "id": 1,
       "isTaskQuestion": false,
+      "lastReadyAt": null,
       "location": null,
       "questionTypes": [
         QuestionTypeModel {
@@ -27,15 +29,18 @@ ListQuestionsResponse {
       "status": "Queued",
       "taHelped": null,
       "text": "help us",
+      "waitTime": 0,
     },
     QuestionModel {
       "closedAt": null,
       "createdAt": 2020-11-02T12:00:00.000Z,
       "creator": UserModel {},
       "groupable": true,
+      "helpTime": 0,
       "helpedAt": null,
       "id": 2,
       "isTaskQuestion": false,
+      "lastReadyAt": null,
       "location": null,
       "questionTypes": [
         QuestionTypeModel {
@@ -50,6 +55,7 @@ ListQuestionsResponse {
       "status": "Queued",
       "taHelped": null,
       "text": "help someone else",
+      "waitTime": 0,
     },
   ],
   "questionsGettingHelp": [],
@@ -66,9 +72,11 @@ ListQuestionsResponse {
       "firstHelpedAt": null,
       "groupId": null,
       "groupable": true,
+      "helpTime": 0,
       "helpedAt": null,
       "id": 1,
       "isTaskQuestion": false,
+      "lastReadyAt": null,
       "location": null,
       "questionTypes": [
         QuestionTypeModel {
@@ -85,6 +93,7 @@ ListQuestionsResponse {
       "taHelped": null,
       "taHelpedId": null,
       "text": "help us",
+      "waitTime": 0,
     },
   ],
 }

--- a/packages/server/src/queue/queue.entity.ts
+++ b/packages/server/src/queue/queue.entity.ts
@@ -99,6 +99,7 @@ export class QueueModel extends BaseEntity {
     this.queueSize = await QuestionModel.inQueueWithStatus(this.id, [
       ...StatusInQueue,
       OpenQuestionStatus.Helping,
+      OpenQuestionStatus.Paused,
     ]).getCount();
   }
 

--- a/packages/server/src/queue/queue.service.ts
+++ b/packages/server/src/queue/queue.service.ts
@@ -136,6 +136,7 @@ export class QueueService {
         'createdAt',
         'firstHelpedAt',
         'helpedAt',
+        'lastReadyAt',
         'closedAt',
         'status',
         'location',
@@ -144,6 +145,8 @@ export class QueueService {
         'questionTypes',
         'taHelped',
         'isTaskQuestion',
+        'waitTime',
+        'helpTime',
       ]);
 
       Object.assign(temp, {
@@ -216,6 +219,7 @@ export class QueueService {
             'createdAt',
             'creatorId',
             'firstHelpedAt',
+            'lastReadyAt',
             'groupId',
             'groupable',
             'helpedAt',
@@ -228,6 +232,8 @@ export class QueueService {
             'taHelped',
             'text',
             'isTaskQuestion',
+            'waitTime',
+            'helpTime',
           ]);
 
           return Object.assign(temp, {

--- a/packages/server/test/__snapshots__/queue.integration.ts.snap
+++ b/packages/server/test/__snapshots__/queue.integration.ts.snap
@@ -18,9 +18,11 @@ exports[`Queue Integration GET /queues/:id/questions returns questions in the qu
       "createdAt": "2020-03-01T05:00:00.000Z",
       "creator": {},
       "groupable": true,
+      "helpTime": 0,
       "helpedAt": null,
       "id": 1,
       "isTaskQuestion": false,
+      "lastReadyAt": null,
       "location": null,
       "questionTypes": [
         {
@@ -35,6 +37,7 @@ exports[`Queue Integration GET /queues/:id/questions returns questions in the qu
       "status": "Queued",
       "taHelped": null,
       "text": "in queue",
+      "waitTime": 0,
     },
   ],
   "questionsGettingHelp": [],

--- a/packages/server/test/jest-integration.json
+++ b/packages/server/test/jest-integration.json
@@ -6,6 +6,5 @@
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   },
-  "moduleDirectories": ["node_modules", "src"],
-  "testTimeout": 30000
+  "moduleDirectories": ["node_modules", "src"]
 }

--- a/packages/server/test/jest-integration.json
+++ b/packages/server/test/jest-integration.json
@@ -6,5 +6,6 @@
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   },
-  "moduleDirectories": ["node_modules", "src"]
+  "moduleDirectories": ["node_modules", "src"],
+  "testTimeout": 30000
 }

--- a/packages/server/test/question.integration.ts
+++ b/packages/server/test/question.integration.ts
@@ -804,7 +804,6 @@ describe('Question Integration', () => {
     beforeAll(() => {
       jest.useFakeTimers();
     });
-
     afterAll(() => {
       jest.useRealTimers();
     });

--- a/packages/server/test/question.integration.ts
+++ b/packages/server/test/question.integration.ts
@@ -12,6 +12,7 @@ import supertest from 'supertest';
 import { QuestionModel } from '../src/question/question.entity';
 import { QuestionModule } from '../src/question/question.module';
 import {
+  AlertFactory,
   CourseFactory,
   QuestionFactory,
   QuestionTypeFactory,
@@ -802,6 +803,8 @@ describe('Question Integration', () => {
 
   describe('PATCH /questions/:id', () => {
     it('will accurately set waitTime and helpTime when going from Drafting -> Queued -> Helping -> Paused -> Helping -> Requeueing -> Queued -> Helping -> Resolved', async () => {
+      // Create an alert to hopefully avoid create alert table error?
+      await AlertFactory.create(); // I cannot BELIEVE this actually works LMAO
       jest.useFakeTimers({
         doNotFake: [
           'hrtime',
@@ -948,7 +951,7 @@ describe('Question Integration', () => {
       // simulate 1 minute passing
       jest.advanceTimersByTime(60 * 1000);
       // Requeueing -> Queued
-      const response6 = await supertest({ userId: ta.id })
+      const response6 = await supertest({ userId: student.id })
         .patch(`/questions/${q.id}`)
         .send({
           status: QuestionStatusKeys.Queued,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1852,16 +1852,6 @@
     slash "^3.0.0"
     write-file-atomic "^4.0.2"
 
-"@jest/types@^25.5.0":
-  version "25.5.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.5.0.tgz#4d6a4793f7b9599fc3680877b856a97dbccf2a9d"
-  integrity sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^1.1.1"
-    "@types/yargs" "^15.0.0"
-    chalk "^3.0.0"
-
 "@jest/types@^29.1.2", "@jest/types@^29.6.3":
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.6.3.tgz#1131f8cf634e7e84c5e77bab12f052af585fba59"
@@ -3828,14 +3818,6 @@
   dependencies:
     "@types/istanbul-lib-coverage" "*"
 
-"@types/istanbul-reports@^1.1.1":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz#e875cc689e47bce549ec81f3df5e6f6f11cfaeb2"
-  integrity sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==
-  dependencies:
-    "@types/istanbul-lib-coverage" "*"
-    "@types/istanbul-lib-report" "*"
-
 "@types/istanbul-reports@^3.0.0":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz#0f03e3d2f670fbdac586e34b433783070cc16f54"
@@ -3843,13 +3825,13 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@25.2.3":
-  version "25.2.3"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-25.2.3.tgz#33d27e4c4716caae4eced355097a47ad363fdcaf"
-  integrity sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==
+"@types/jest@^29.5.14":
+  version "29.5.14"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.14.tgz#2b910912fa1d6856cadcd0c1f95af7df1d6049e5"
+  integrity sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==
   dependencies:
-    jest-diff "^25.2.1"
-    pretty-format "^25.2.1"
+    expect "^29.0.0"
+    pretty-format "^29.0.0"
 
 "@types/json-schema@*", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.15"
@@ -4207,13 +4189,6 @@
   version "21.0.3"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.3.tgz#815e30b786d2e8f0dcd85fd5bcf5e1a04d008f15"
   integrity sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==
-
-"@types/yargs@^15.0.0":
-  version "15.0.19"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.19.tgz#328fb89e46109ecbdb70c295d96ff2f46dfd01b9"
-  integrity sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==
-  dependencies:
-    "@types/yargs-parser" "*"
 
 "@types/yargs@^17.0.8":
   version "17.0.33"
@@ -4827,7 +4802,7 @@ ansi-regex@^4.1.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
   integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
 
-ansi-regex@^5.0.0, ansi-regex@^5.0.1:
+ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
@@ -6900,11 +6875,6 @@ didyoumean@^1.2.2:
   resolved "https://registry.yarnpkg.com/didyoumean/-/didyoumean-1.2.2.tgz#989346ffe9e839b4555ecf5666edea0d3e8ad037"
   integrity sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==
 
-diff-sequences@^25.2.6:
-  version "25.2.6"
-  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.6.tgz#5f467c00edd35352b7bca46d7927d60e687a76dd"
-  integrity sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==
-
 diff-sequences@^29.6.3:
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
@@ -7882,7 +7852,7 @@ exit@^0.1.2:
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
   integrity sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==
 
-expect@^29.7.0:
+expect@^29.0.0, expect@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/expect/-/expect-29.7.0.tgz#578874590dcb3214514084c08115d8aee61e11bc"
   integrity sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==
@@ -9992,16 +9962,6 @@ jest-config@^29.7.0:
     slash "^3.0.0"
     strip-json-comments "^3.1.1"
 
-jest-diff@^25.2.1:
-  version "25.5.0"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.5.0.tgz#1dd26ed64f96667c068cef026b677dfa01afcfa9"
-  integrity sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==
-  dependencies:
-    chalk "^3.0.0"
-    diff-sequences "^25.2.6"
-    jest-get-type "^25.2.6"
-    pretty-format "^25.5.0"
-
 jest-diff@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.7.0.tgz#017934a66ebb7ecf6f205e84699be10afd70458a"
@@ -10041,11 +10001,6 @@ jest-environment-node@^29.7.0:
     "@types/node" "*"
     jest-mock "^29.7.0"
     jest-util "^29.7.0"
-
-jest-get-type@^25.2.6:
-  version "25.2.6"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-25.2.6.tgz#0b0a32fab8908b44d508be81681487dbabb8d877"
-  integrity sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==
 
 jest-get-type@^29.6.3:
   version "29.6.3"
@@ -13379,17 +13334,7 @@ prettier@^3.0.3:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.3.tgz#30c54fe0be0d8d12e6ae61dbb10109ea00d53105"
   integrity sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==
 
-pretty-format@^25.2.1, pretty-format@^25.5.0:
-  version "25.5.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.5.0.tgz#7873c1d774f682c34b8d48b6743a2bf2ac55791a"
-  integrity sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==
-  dependencies:
-    "@jest/types" "^25.5.0"
-    ansi-regex "^5.0.0"
-    ansi-styles "^4.0.0"
-    react-is "^16.12.0"
-
-pretty-format@^29.7.0:
+pretty-format@^29.0.0, pretty-format@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
   integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==
@@ -14240,7 +14185,7 @@ react-highlight-words@^0.20.0:
     memoize-one "^4.0.0"
     prop-types "^15.5.8"
 
-react-is@^16.10.2, react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0:
+react-is@^16.10.2, react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==


### PR DESCRIPTION
# Description

This is a really important PR that should be merged before we update prod with pause questions (#175 ) and the requeueing stuff in the queue locations one (#148). About 5% of questions have a helpedAt != firstHelpedAt, and these two PRs are going to increase that dramatically. And previously, any time that a question is helped more than once, it is impossible to properly calculate the waitTIme and helpTime.

Fixes
- You can now repeatedly pause/unpause a question and the waitTime and helpTime will be properly updated
- the wait time on question cards will no longer increase while the student is being helped or drafting or being requeued (because previously it wasn't the wait time, it was just the question's lifespan)
- Paused questions are now included in queueSize
- centralised the changeStatus service so that both students and TAs call it, making it more maintainable for the future (I didn't even know they had separate logic, when there really was no reason to)
- Removed paused time (and instead opted to just increase waitTime while paused, since they are fundamentally the same thing)
- Changed the pause timer on the questioncards to just be the helpTime but frozen (kinda like how you can pause a video, the timer stops until you click play again)
![image](https://github.com/user-attachments/assets/47770a0b-e5ae-4798-be55-2eac5e906e21)
![image](https://github.com/user-attachments/assets/3de3d9b7-3663-44a6-843f-4bbb393d1f63)


Closes #174 and #87 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [x] This change requires a database query to update old data on production. These queries are below:

```sql
UPDATE question_model
SET "lastReadyAt" = "createdAt"
```
```sql
UPDATE question_model
SET "waitTime" = CEIL(EXTRACT(EPOCH FROM question_model."firstHelpedAt"::TIMESTAMP) - EXTRACT(EPOCH FROM question_model."createdAt"::TIMESTAMP))
WHERE "firstHelpedAt" IS NOT NULL
```
```sql
UPDATE question_model
SET "helpTime" = CEIL(EXTRACT(EPOCH FROM question_model."closedAt"::TIMESTAMP) - EXTRACT(EPOCH FROM question_model."helpedAt"::TIMESTAMP))
WHERE "helpedAt" IS NOT NULL AND "closedAt" IS NOT NULL
```

@bhunt02 please double check to make sure these queries to update the old data looks correct (I tried to basically copy the same calculation as the insights, and it looks right to me, but I want to double check with you in case it looks like there should be something else). I tested these queries and they work, just looking for any logic issues

**I also made some queries that we could run if we wanted maybe more accurate wait/help times during this migration?**

This one will subtract 1min from the waitTime if they have been helped more than once (helpedAt != firstHelpedAt) with a minimum waitTime of 1min,
```
UPDATE question_model
SET "waitTime" = GREATEST(CEIL(
  EXTRACT(EPOCH FROM "firstHelpedAt"::TIMESTAMP) - EXTRACT(EPOCH FROM "createdAt"::TIMESTAMP) -
  CASE
    WHEN "firstHelpedAt" != "helpedAt" THEN 60
    ELSE 0
  END
), 60)
WHERE "firstHelpedAt" IS NOT NULL;
```

This one will add 1 min to helpTime if they have been helped more than once (helpedAt != firstHelpedAt) with a **maximum helpTime of 1h.** -> This will also fix all the multi-day long helpTime issues.
```sql
UPDATE question_model
SET "helpTime" = LEAST(
	  CEIL(
	  EXTRACT(EPOCH FROM question_model."closedAt"::TIMESTAMP) - EXTRACT(EPOCH FROM question_model."helpedAt"::TIMESTAMP) +
	  CASE
	    WHEN "firstHelpedAt" != "helpedAt" THEN 60
	    ELSE 0
	  END
	), 3600
 )
WHERE "helpedAt" IS NOT NULL AND "closedAt" IS NOT NULL
```


# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 

- Added tests to see if the waitTime and helpTime will correctly update as the status of a question changes (from  Drafting -> Queued -> Helping -> Paused -> Helping -> Requeueing -> Queued -> Helping -> Resolved)
- Edited tests for insights
- All queries have been tested on a copy of the production database and behave how you would expect.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [x] Any UI changes have been checked to work on desktop, tablet, and mobile
