### PR TITLE
deleteOldBackups ignore .md files

### DIFF
--- a/packages/frontend/public/changelog.md
+++ b/packages/frontend/public/changelog.md
@@ -1,8 +1,10 @@
-## Version 1.2.2 - Jan 16, 2024
+## Version 1.2.2 - Jan 17, 2024
 
 #### Improvements
 - Fixed a bug where end date would appear as "Invalid Date" when creating repeat events
 - Fixed this modal being very thin on some browsers
+- Fixed bug where verifying your email would not work when manually typing in the code
+- Misc bug fixes and improvements
 
 
 ***

--- a/packages/server/src/backup/backup.service.ts
+++ b/packages/server/src/backup/backup.service.ts
@@ -146,6 +146,10 @@ export class BackupService {
     fs.readdir(directory, (err, files) => {
       if (err) throw err;
       files.forEach((file) => {
+        // Skip .md files
+        if (file.endsWith('.md')) {
+          return;
+        }
         const filePath = path.join(directory, file);
         fs.stat(filePath, (err, stats) => {
           if (err) throw err;


### PR DESCRIPTION
# Description

A simple bug fix that makes it so deleteOldBackups ignores .md files

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

Added some tests for it but haven't yet done manual testing (it would be kinda hard to manually test)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [ ] Any UI changes have been checked to work on desktop, tablet, and mobile
