### PR TITLE
Populate Default Insights Page

### DIFF
--- a/packages/frontend/app/(dashboard)/course/[cid]/(insights)/insights/page.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(insights)/insights/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import DashboardPresetComponent from '../components/DashboardPresetComponent'
-import { useParams, useRouter } from 'next/navigation'
+import { useParams } from 'next/navigation'
 import InsightComponent from '@/app/(dashboard)/course/[cid]/(insights)/components/outputComponents/InsightComponent'
 import InsightsPageMenu from '@/app/(dashboard)/course/[cid]/(insights)/components/InsightsPageMenu'
 import { InsightContextProvider } from '@/app/(dashboard)/course/[cid]/(insights)/context/InsightsContext'
@@ -15,7 +15,6 @@ import {
   ListInsightsResponse,
 } from '@koh/common'
 import { API } from '@/app/api'
-import { NavigateOptions } from 'next/dist/shared/lib/app-router-context.shared-runtime'
 
 export default function InsightsPage() {
   const { cid } = useParams<{ cid: string }>()
@@ -64,9 +63,11 @@ export default function InsightsPage() {
         ? Object.keys(insightDirectory).filter(
             (v) => dashboardInsights?.insights[v]?.active == true,
           )
-        : Object.keys(insightDirectory).filter(
-            (v) => insightDirectory[v].insightCategory == category,
-          )
+        : category == 'Dashboard'
+          ? Object.keys(insightDirectory)
+          : Object.keys(insightDirectory).filter(
+              (v) => insightDirectory[v].insightCategory == category,
+            )
 
       const mappedInsights: { name: string; insight: InsightDisplayInfo }[] =
         validInsights.map((v) => {
@@ -155,15 +156,8 @@ export default function InsightsPage() {
                 <>
                   {(dashboardInsights != undefined &&
                     Object.keys(dashboardInsights.insights).length > 0 &&
-                    renderInsights(dashboardInsights.insights)) || (
-                    <div className={'h-full w-full text-center'}>
-                      <h2>No insights to show!</h2>
-                      <p>
-                        Create an insight dashboard preset to view available
-                        analytics.
-                      </p>
-                    </div>
-                  )}
+                    renderInsights(dashboardInsights.insights)) ||
+                    renderInsights()}
                 </>
               ) : (
                 renderInsights()

--- a/packages/server/src/insights/insight-objects.ts
+++ b/packages/server/src/insights/insight-objects.ts
@@ -205,11 +205,10 @@ export const MostActiveStudents: InsightObject = {
     );
 
     return {
-      headerRow: ['Student Name (Student ID)', 'Email', 'Questions Asked'],
+      headerRow: ['Student Name', 'Questions Asked'],
       data: dataSource.map((item) => {
         return {
-          studentName: `${item.name} (${item.studentId})`,
-          email: item.email,
+          studentName: `${item.name}`,
           questionsAsked: item.questionsAsked,
         };
       }),

--- a/packages/server/src/insights/insights.service.spec.ts
+++ b/packages/server/src/insights/insights.service.spec.ts
@@ -293,23 +293,19 @@ describe('InsightsService', () => {
 
     expect(output.data).toEqual([
       {
-        studentName: 'Jean Valjean (4)',
-        email: 'valjean.j@protonmail.com',
+        studentName: 'Jean Valjean',
         questionsAsked: '110',
       },
       {
-        studentName: 'David Wright (2)',
-        email: 'wright.da@northeastern.edu',
+        studentName: 'David Wright',
         questionsAsked: '20',
       },
       {
-        studentName: 'Adam Smith (3)',
-        email: 'smith.a@northeastern.edu',
+        studentName: 'Adam Smith',
         questionsAsked: '10',
       },
       {
-        studentName: 'Derek Jeter (1)',
-        email: 'jeter.d@northeastern.edu',
+        studentName: 'Derek Jeter',
         questionsAsked: '8',
       },
     ]);


### PR DESCRIPTION
# Description

I just made the insights page show all insights by default (kind of removes the purpose of the categories, but done by request)
Also removed the most active students table showing the emails & IDs as these are kind of unnecessary points to show that data

No related issue(s)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

Altered existing unit/integration tests where necessary

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [x] Any UI changes have been checked to work on desktop, tablet, and mobile
