### PR TITLE
OrgOrCourseRolesGuard + Allow Course Profs to Edit Their Courses

### DIFF
--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -2565,6 +2565,15 @@ export const ERROR_MESSAGES = {
       `You must have one of roles [${roles.join(
         ', ',
       )}] to access this information`,
+    mustBeRoleToAccessExtended: (
+      courseRoles: string[],
+      orgRoles: string[],
+    ): string =>
+      `You must have one of the Course roles [${courseRoles.join(
+        ', ',
+      )}] or Organization roles [${orgRoles.join(
+        ', ',
+      )}] to access this information`,
     mustBeRoleToJoinCourse: (roles: string[]): string =>
       `You must have one of roles [${roles.join(', ')}] to access this course`,
   },

--- a/packages/server/src/decorators/course-role.decorator.ts
+++ b/packages/server/src/decorators/course-role.decorator.ts
@@ -1,6 +1,7 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 import { UserModel } from 'profile/user.entity';
 
+/* Gives the role of the user in the course */
 export const CourseRole = createParamDecorator(
   async (data: unknown, ctx: ExecutionContext) => {
     const request = ctx.switchToHttp().getRequest();

--- a/packages/server/src/decorators/course-roles.decorator.ts
+++ b/packages/server/src/decorators/course-roles.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata, CustomDecorator } from '@nestjs/common';
+
+/* Specifies which course roles may be needed to access a route. Only to be used in tandem with OrgOrCourseRolesGuard (and OrgRoles decorator) */
+export const CourseRoles = (...roles: string[]): CustomDecorator<string> =>
+  SetMetadata('CourseRoles', roles);

--- a/packages/server/src/decorators/org-roles.decorator.ts
+++ b/packages/server/src/decorators/org-roles.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata, CustomDecorator } from '@nestjs/common';
+
+/* Specifies which org roles may be needed to access a route. Only to be used in tandem with OrgOrCourseRolesGuard (and CourseRoles decorator) */
+export const OrgRoles = (...roles: string[]): CustomDecorator<string> =>
+  SetMetadata('OrgRoles', roles);

--- a/packages/server/src/decorators/roles.decorator.ts
+++ b/packages/server/src/decorators/roles.decorator.ts
@@ -1,4 +1,5 @@
 import { SetMetadata, CustomDecorator } from '@nestjs/common';
 
+/* Specifies which roles (org or course roles) are needed in order to access a route. Needs to be used in tandem with either OrganizationRolesGuard or CourseRolesGuard. */
 export const Roles = (...roles: string[]): CustomDecorator<string> =>
   SetMetadata('roles', roles);

--- a/packages/server/src/guards/org-or-course-roles.guard.ts
+++ b/packages/server/src/guards/org-or-course-roles.guard.ts
@@ -75,12 +75,15 @@ export class OrgOrCourseRolesGuard implements CanActivate {
     return true;
   }
 
+  /* Returns false if the course does not exist, if they are not in the course, or if they have the wrong role.
+  This is because ultimately I opted for having better performance with having less queries with the tradeoff of less-granular error messages.
+  Same mantra goes for matchOrgRoles
+  */
   async matchCourseRoles(
     roles: string[],
     userId: number,
     courseId: number,
   ): Promise<boolean> {
-    // first, use query builder to check if they have the right course roles
     try {
       await UserCourseModel.findOneOrFail({
         where: {

--- a/packages/server/src/guards/org-or-course-roles.guard.ts
+++ b/packages/server/src/guards/org-or-course-roles.guard.ts
@@ -123,8 +123,6 @@ export class OrgOrCourseRolesGuard implements CanActivate {
         ou_role: string;
       }>();
 
-    console.log(orgCourseUser);
-
     if (!orgCourseUser) {
       throw new NotFoundException(
         'This course does not exist in your organization',

--- a/packages/server/src/guards/org-or-course-roles.guard.ts
+++ b/packages/server/src/guards/org-or-course-roles.guard.ts
@@ -18,6 +18,8 @@ import { In } from 'typeorm';
     This could be used if there was an endpoint you want the course professor to be able to use or the org admin.
     Note that you DO need a courseId or cid parameter.
     You do NOT need an orgId or oid parameter, as the org is determined by the course.
+
+    ALSO NOTE: if you pass in OrgRole(PROFESSOR), you are allowing ANY user with the org role of professor to access the endpoint, regardless of whether or not they are in the course
 */
 @Injectable()
 export class OrgOrCourseRolesGuard implements CanActivate {

--- a/packages/server/src/guards/org-or-course-roles.guard.ts
+++ b/packages/server/src/guards/org-or-course-roles.guard.ts
@@ -1,0 +1,125 @@
+import { ERROR_MESSAGES } from '@koh/common';
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  UnauthorizedException,
+  NotImplementedException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { OrganizationCourseModel } from 'organization/organization-course.entity';
+import { UserModel } from 'profile/user.entity';
+
+/* The user must have one of the specified CourseRoles OR OrgRoles in order to access this endpoint.
+    This could be used if there was an endpoint you want the course professor to be able to use or the org admin.
+    Note that you DO need a courseId or cid parameter.
+    You do NOT need an orgId or oid parameter, as the org is determined by the course.
+*/
+@Injectable()
+export class OrgOrCourseRolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  /* see https://docs.nestjs.com/guards for more details about this */
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const orgRoles = this.reflector.get<string[]>(
+      'OrgRoles',
+      context.getHandler(),
+    );
+    const courseRoles = this.reflector.get<string[]>(
+      'CourseRoles',
+      context.getHandler(),
+    );
+    const roles = this.reflector.get<string[]>('roles', context.getHandler());
+
+    if (!orgRoles || !courseRoles || roles) {
+      throw new NotImplementedException(
+        'This endpoint is missing either @OrgRoles or @CourseRoles (needs both). It should not use @Roles',
+      );
+    }
+
+    const request = context.switchToHttp().getRequest();
+    const { user } = await this.setupData(request);
+
+    const courseId = request.params.courseId ?? request.params.cid ?? null;
+
+    if (!user) {
+      throw new UnauthorizedException(ERROR_MESSAGES.roleGuard.notLoggedIn);
+    }
+    if (!courseId) {
+      throw new NotFoundException(ERROR_MESSAGES.roleGuard.noCourseIdFound);
+    }
+
+    // first check if they have the right course role (since usually that will get resolved first)
+    if (this.matchCourseRoles(courseRoles, user, courseId)) {
+      return true;
+    }
+    // then check if they have the right org role
+    if (await this.matchOrgRoles(orgRoles, user, courseId)) {
+      return true;
+    }
+    // if they don't have either, throw an error
+    throw new ForbiddenException(
+      ERROR_MESSAGES.roleGuard.mustBeRoleToAccessExtended(
+        courseRoles,
+        orgRoles,
+      ),
+    );
+  }
+
+  async setupData(request: any): Promise<{ user: UserModel }> {
+    const user = await UserModel.findOne(request.user.userId, {
+      relations: ['organizationUser', 'courses'],
+    });
+
+    return { user };
+  }
+
+  matchCourseRoles(
+    roles: string[],
+    user: UserModel,
+    courseId: number,
+  ): boolean {
+    const userCourse = user.courses.find((course) => {
+      return Number(course.courseId) === Number(courseId);
+    });
+    if (!userCourse) {
+      return false;
+    }
+
+    const hasCorrectRole = roles.includes(userCourse.role);
+
+    return hasCorrectRole;
+  }
+
+  async matchOrgRoles(
+    roles: string[],
+    user: UserModel,
+    courseId: number,
+  ): Promise<boolean> {
+    const userOrg = user.organizationUser;
+    if (!userOrg) {
+      throw new ForbiddenException('This user is not in any organization');
+    }
+
+    const hasCorrectRole = roles.includes(userOrg.role);
+    if (!hasCorrectRole) {
+      return false;
+    }
+
+    // make sure this org user is in the same org as the course (that way org profs in one course can't access courses in another org)
+    try {
+      await OrganizationCourseModel.findOneOrFail({
+        where: {
+          organizationId: userOrg.organizationId,
+          courseId,
+        },
+      });
+    } catch (e) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/packages/server/src/guards/org-or-course-roles.guard.ts
+++ b/packages/server/src/guards/org-or-course-roles.guard.ts
@@ -117,7 +117,9 @@ export class OrgOrCourseRolesGuard implements CanActivate {
         },
       });
     } catch (e) {
-      return false;
+      throw new NotFoundException(
+        'This course does not exist in your organization',
+      );
     }
 
     return true;

--- a/packages/server/src/guards/organization-roles.guard.ts
+++ b/packages/server/src/guards/organization-roles.guard.ts
@@ -13,10 +13,15 @@ export class OrganizationRolesGuard implements CanActivate {
   constructor(private reflector: Reflector) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const roles = this.reflector.get<string[]>('roles', context.getHandler());
+    let roles = this.reflector.get<string[]>('roles', context.getHandler());
 
     if (!roles) {
-      return true;
+      // if it doesn't have the roles decorator, maybe it has the OrgRoles decorator?
+      roles = this.reflector.get<string[]>('OrgRoles', context.getHandler());
+      if (!roles) {
+        // if it lacks any role decorator, then this guard won't do anything (TODO: maybe throw a NotImplementedException instead? Though doing this may break some endpoints)
+        return true;
+      }
     }
 
     const request = context.switchToHttp().getRequest();

--- a/packages/server/src/guards/role.guard.ts
+++ b/packages/server/src/guards/role.guard.ts
@@ -29,9 +29,14 @@ export abstract class RolesGuard implements CanActivate {
   constructor(private reflector: Reflector) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const roles = this.reflector.get<string[]>('roles', context.getHandler());
+    let roles = this.reflector.get<string[]>('roles', context.getHandler());
     if (!roles) {
-      return true;
+      // if it doesn't have the roles decorator, maybe it has the CourseRoles decorator?
+      roles = this.reflector.get<string[]>('CourseRoles', context.getHandler());
+      if (!roles) {
+        // if it lacks any role decorator, then this guard won't do anything (TODO: maybe throw a NotImplementedException instead? Though doing this may break some endpoints)
+        return true;
+      }
     }
     const request = context.switchToHttp().getRequest();
     const { courseId, user } = await this.setupData(request);

--- a/packages/server/src/organization/organization.controller.ts
+++ b/packages/server/src/organization/organization.controller.ts
@@ -63,6 +63,9 @@ import * as sharp from 'sharp';
 import { UserId } from 'decorators/user.decorator';
 import { SchedulerRegistry } from '@nestjs/schedule';
 import { CronJob } from 'cron';
+import { OrgOrCourseRolesGuard } from 'guards/org-or-course-roles.guard';
+import { OrgRoles } from 'decorators/org-roles.decorator';
+import { CourseRoles } from 'decorators/course-roles.decorator';
 
 @Controller('organization')
 export class OrganizationController {
@@ -678,8 +681,9 @@ export class OrganizationController {
   }
 
   @Get(':oid/get_course/:cid')
-  @UseGuards(JwtAuthGuard, OrganizationRolesGuard, EmailVerifiedGuard)
-  @Roles(OrganizationRole.ADMIN, OrganizationRole.PROFESSOR)
+  @UseGuards(JwtAuthGuard, EmailVerifiedGuard, OrgOrCourseRolesGuard)
+  @CourseRoles(Role.PROFESSOR, Role.TA)
+  @OrgRoles(OrganizationRole.ADMIN, OrganizationRole.PROFESSOR)
   async getOrganizationCourse(
     @Res() res: Response,
     @Param('oid', ParseIntPipe) oid: number,

--- a/packages/server/src/organization/organization.controller.ts
+++ b/packages/server/src/organization/organization.controller.ts
@@ -445,7 +445,7 @@ export class OrganizationController {
   @Patch(':oid/update_course/:cid')
   @UseGuards(JwtAuthGuard, EmailVerifiedGuard, OrgOrCourseRolesGuard)
   @CourseRoles(Role.PROFESSOR)
-  @OrgRoles(OrganizationRole.ADMIN, OrganizationRole.PROFESSOR)
+  @OrgRoles(OrganizationRole.ADMIN)
   async updateCourse(
     @Res() res: Response,
     @Param('oid', ParseIntPipe) oid: number,
@@ -684,7 +684,7 @@ export class OrganizationController {
   @Get(':oid/get_course/:cid')
   @UseGuards(JwtAuthGuard, EmailVerifiedGuard, OrgOrCourseRolesGuard)
   @CourseRoles(Role.PROFESSOR, Role.TA)
-  @OrgRoles(OrganizationRole.ADMIN, OrganizationRole.PROFESSOR)
+  @OrgRoles(OrganizationRole.ADMIN)
   async getOrganizationCourse(
     @Res() res: Response,
     @Param('oid', ParseIntPipe) oid: number,
@@ -1199,7 +1199,7 @@ export class OrganizationController {
   @Delete(':oid/drop_user_courses/:uid')
   @UseGuards(JwtAuthGuard, EmailVerifiedGuard, OrgOrCourseRolesGuard)
   @CourseRoles(Role.PROFESSOR)
-  @OrgRoles(OrganizationRole.ADMIN, OrganizationRole.PROFESSOR)
+  @OrgRoles(OrganizationRole.ADMIN)
   async deleteUserCourses(
     @Res() res: Response,
     @Param('uid', ParseIntPipe) uid: number,

--- a/packages/server/test/organization.integration.ts
+++ b/packages/server/test/organization.integration.ts
@@ -1707,16 +1707,12 @@ describe('Organization Integration', () => {
 
       expect(res.status).toBe(403);
     });
-    it('OrgOrCourseRolesGuard: should return 403 when the user is an org prof in one org and member in the main org', async () => {
+    it('OrgOrCourseRolesGuard: should return 404 when the user is an org prof in one org and member in the main org', async () => {
       const user = await UserFactory.create();
       const organization = await OrganizationFactory.create();
       const course = await CourseFactory.create();
       const otherOrganization = await OrganizationFactory.create();
 
-      await OrganizationUserFactory.create({
-        organizationUser: user,
-        organization, // regular member in this org
-      });
       await OrganizationUserFactory.create({
         organizationUser: user,
         organization: otherOrganization,
@@ -1731,9 +1727,9 @@ describe('Organization Integration', () => {
         `/organization/${organization.id}/get_course/${course.id}`,
       );
 
-      expect(res.status).toBe(403);
+      expect(res.status).toBe(404);
     });
-    it('OrgOrCourseRolesGuard: should return 403 when the user is a course prof in one org and a member in the main org', async () => {
+    it('OrgOrCourseRolesGuard: should return 404 when the user is a course prof in one org and a member in the main org', async () => {
       const user = await UserFactory.create();
       const organization = await OrganizationFactory.create();
       const course = await CourseFactory.create();
@@ -1742,11 +1738,7 @@ describe('Organization Integration', () => {
 
       await OrganizationUserFactory.create({
         organizationUser: user,
-        organization, // regular member in this org
-      });
-      await OrganizationUserFactory.create({
-        organizationUser: user,
-        organization: otherOrganization, // also a member in other org
+        organization: otherOrganization, // a member in other org
       });
       await OrganizationCourseFactory.create({
         course,
@@ -1759,14 +1751,14 @@ describe('Organization Integration', () => {
       await UserCourseFactory.create({
         user,
         course,
-        role: Role.PROFESSOR, // they are a prof in other org
+        role: Role.PROFESSOR, // they are a course prof in other org
       });
 
       const res = await supertest({ userId: user.id }).get(
         `/organization/${organization.id}/get_course/${course.id}`, // try to access main org's course
       );
 
-      expect(res.status).toBe(403);
+      expect(res.status).toBe(404);
     });
   });
 

--- a/packages/server/test/organization.integration.ts
+++ b/packages/server/test/organization.integration.ts
@@ -1750,7 +1750,7 @@ describe('Organization Integration', () => {
       });
       await UserCourseFactory.create({
         user,
-        course,
+        course: otherCourse,
         role: Role.PROFESSOR, // they are a course prof in other org
       });
 


### PR DESCRIPTION
# Description

Creates a new guard that allows you to specify an endpoint where the user needs either the right course role or the right org role
- it does two queries simultaneously to check if they either have the right org role or the right course role (for the given course)

**This also fixes some access problems where some endpoints would error for course profs**:
- deleteUserCourses (used to remove students from your course)
- getOrganizationCourse (used when the staff goes on any page to edit a course)
- updateCourse (used when prof wants to update their course details)

Another piece of motivation for creating this guard is it will make it easier to extend admin permissions so that they can call more endpoints without being in a course (for the future)

Here is an example of a course professor updating the course page (which would previously be impossible)
![image](https://github.com/user-attachments/assets/40573554-8a9a-49df-9037-a9ff40905a37)


Closes #237 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

Added a bunch of new tests to whatever endpoint is utilizing the new guard.

I have also manually tested:
- viewing course page as org admin
- dropping a user from a course as an org admin
- viewing and updating a course as course prof
- dropping a user from a course as a course prof

I didn't manually test with an org prof (who would also end up needing to be a course prof due to how the system is set up) since the same logic is checked

# Checklist:

- [ ] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [ ] Any UI changes have been checked to work on desktop, tablet, and mobile
