### PR TITLE
Uploads Backup Deletion Bugfix

### DIFF
--- a/packages/server/src/backup/backup.service.ts
+++ b/packages/server/src/backup/backup.service.ts
@@ -105,7 +105,7 @@ export class BackupService {
     }
   }
 
-  // Daily Uploads Backup Task - Keeps rolling backups for 5 days
+  // 4-day Uploads Backup Task - Keeps rolling backups for 12 days (3 backups)
   @Cron('0 0 */4 * *')
   async handleDailyUploadsBackup() {
     try {
@@ -131,7 +131,7 @@ export class BackupService {
         } else {
           console.log(`Uploads backup saved: ${backupFile}`);
           // Retain only the last 3 backups (the last 12 days)
-          this.deleteOldBackups(backupDir, 2);
+          this.deleteOldBackups(backupDir, 12);
         }
       });
     } catch (error) {


### PR DESCRIPTION
# Description

This change fixed the backend service for upload directory backups so that it no longer deletes the last two days of backups (all other backups). Just to give context to those not aware, this backup function should be run every 4 days and save the last three (12 days).

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires a database query to update old data on production. This query is below:
