### PR TITLE
Fix Security on Chatbot Routes

### DIFF
--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -249,22 +249,18 @@ export enum AccountType {
 
 // chatbot questions and interactions
 
-export interface ChatbotQuestion {
-  id?: number
-  interactionId?: number
-  questionText?: string
-  responseText?: string
-  timestamp?: Date
-  userScore?: number
-  suggested?: boolean
-  isPreviousQuestion?: boolean
-  vectorStoreId?: string
+export interface UpdateDocumentChunkParams {
+  documentText: string
+  metadata: {
+    name: string
+    source: string
+  }
 }
 
-// comes from chatbot db
+// comes from helpme db
 export interface ChatbotQuestionResponseHelpMeDB {
   id: number
-  vectorStoreId?: string
+  vectorStoreId: string
   interactionId: number
   questionText: string
   responseText: string
@@ -321,14 +317,107 @@ export interface SourceDocument {
   pageNumber?: number
 }
 
-export interface ChatbotRequestParams {
-  interactionId: number
-  questionText: string
+export interface PreDeterminedQuestion {
+  id: string
+  pageContent: string
+  metadata: {
+    answer: string
+    courseId: string
+    inserted: boolean
+    sourceDocuments: SourceDocument[]
+    suggested: boolean
+    verified: boolean
+  }
+}
+
+export interface Message {
+  type: 'apiMessage' | 'userMessage'
+  message: string | void
+  verified?: boolean
+  sourceDocuments?: SourceDocument[]
+  questionId?: string
+  thinkText?: string | null // used on frontend only
+}
+
+export interface ChatbotAskParams {
+  question: string
+  history: Message[]
+  interactionId?: number
+  onlySaveInChatbotDB?: boolean
+}
+
+export interface ChatbotAskSuggestedParams {
+  question: string
   responseText: string
-  userScore?: number
-  suggested?: boolean
-  isPreviousQuestion?: boolean
   vectorStoreId: string
+}
+
+export interface AddDocumentChunkParams {
+  documentText: string
+  metadata: {
+    name: string
+    type: string
+    source?: string
+    loc?: Loc
+    id?: string
+    courseId?: number
+  }
+}
+
+export interface UpdateChatbotQuestionParams {
+  inserted?: boolean
+  id?: string
+  sourceDocuments?: SourceDocument[]
+  question?: string
+  answer?: string
+  verified?: boolean
+  suggested?: boolean
+  selectedDocuments?: {
+    docId: string
+    pageNumbersString: string
+  }[]
+}
+
+// this is the response from the backend when new questions are asked
+// if question is I don't know, only answer and questionId are returned
+export interface ChatbotAskResponse {
+  chatbotRepoVersion: ChatbotAskResponseChatbotDB
+  helpmeRepoVersion: ChatbotQuestionResponseHelpMeDB | null
+}
+
+// comes from /ask from chatbot db
+export interface ChatbotAskResponseChatbotDB {
+  question: string
+  answer: string
+  questionId: string
+  interactionId: number
+  sourceDocuments?: SourceDocument[]
+  verified: boolean
+  courseId: string
+  isPreviousQuestion: boolean
+}
+
+export interface AddChatbotQuestionParams {
+  question: string
+  answer: string
+  verified: boolean
+  suggested: boolean
+  sourceDocuments: SourceDocument[]
+}
+
+export interface ChatbotSettings {
+  id: string
+  AvailableModelTypes: Record<string, string>
+  pageContent: string
+  metadata: ChatbotSettingsMetadata
+}
+
+export interface ChatbotSettingsMetadata {
+  modelName: string
+  prompt: string
+  similarityThresholdDocuments: number
+  temperature: number
+  topK: number
 }
 
 export interface InteractionResponse {
@@ -344,8 +433,10 @@ export class ChatbotDocument {
   subDocumentIds!: string[]
 }
 
-export type GetInteractionsAndQuestionsResponse = InteractionResponse[]
-
+export type GetInteractionsAndQuestionsResponse = {
+  helpmeDB: InteractionResponse[]
+  chatbotDB: ChatbotQuestionResponseChatbotDB[]
+}
 /**
  * Represents one of two possible roles for the global account
  */
@@ -1283,14 +1374,6 @@ export type OrganizationProfessor = {
     lacksProfOrgRole?: boolean
   }
   userId: number
-}
-
-export class InteractionParams {
-  @IsInt()
-  courseId!: number
-
-  @IsInt()
-  userId!: number
 }
 
 export class UpdateOrganizationCourseDetailsParams {

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -315,6 +315,7 @@ export interface SourceDocument {
   pageNumbersString?: string // used only for the edit question modal
   sourceLink?: string
   pageNumber?: number
+  key?: string // used for front-end rendering
 }
 
 export interface PreDeterminedQuestion {
@@ -365,8 +366,8 @@ export interface AddDocumentChunkParams {
 }
 
 export interface UpdateChatbotQuestionParams {
+  id: string
   inserted?: boolean
-  id?: string
   sourceDocuments?: SourceDocument[]
   question?: string
   answer?: string

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_document_chunks/components/ChunkHelpTooltip.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_document_chunks/components/ChunkHelpTooltip.tsx
@@ -1,0 +1,17 @@
+import { QuestionCircleOutlined } from '@ant-design/icons'
+import { Tooltip } from 'antd'
+import React from 'react'
+
+const ChunkHelpTooltip: React.FC = () => {
+  return (
+    <div className="text-gray-500">
+      <Tooltip
+        title={`Chatbot document "chunks" are what are actually cited by the chatbot. Each chunk can have a page number, which is the page number of the original document that this chunk came from. Note that modifying a chunk does not actually modify the original document nor does it affect any previously asked chatbot questions.`}
+      >
+        Help <QuestionCircleOutlined />
+      </Tooltip>
+    </div>
+  )
+}
+
+export default ChunkHelpTooltip

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_document_chunks/components/EditChatbotDocumentChunkModal.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_document_chunks/components/EditChatbotDocumentChunkModal.tsx
@@ -6,6 +6,7 @@ import TextArea from 'antd/es/input/TextArea'
 import { getErrorMessage } from '@/app/utils/generalUtils'
 import { SourceDocument } from '@koh/common'
 import { API } from '@/app/api'
+import ChunkHelpTooltip from './ChunkHelpTooltip'
 
 interface FormValues {
   documentName: string
@@ -52,7 +53,12 @@ const EditDocumentChunkModal: React.FC<EditDocumentChunkModalProps> = ({
   return (
     <Modal
       open={open}
-      title="Edit Document Chunk"
+      title={
+        <div className="flex items-center justify-start gap-x-3">
+          <div>Edit Document Chunk</div>
+          <ChunkHelpTooltip />
+        </div>
+      }
       okText="Save Changes"
       cancelText="Cancel"
       okButtonProps={{
@@ -82,16 +88,22 @@ const EditDocumentChunkModal: React.FC<EditDocumentChunkModalProps> = ({
       <Form.Item
         label="Document Name"
         name="documentName"
+        tooltip={`This is the "name" of the document that this chunk came from `}
         rules={[{ required: true, message: 'Please input the document name' }]}
       >
         <Input />
       </Form.Item>
-      <Form.Item label="Content" name="content">
+      <Form.Item
+        label="Content"
+        name="content"
+        tooltip={`This is the text that was parsed during the document upload process. The Retrieval Augmented Generation (RAG) system searches through this content to find relevant information for the chatbot to use in its response.`}
+      >
         <TextArea autoSize={{ minRows: 3, maxRows: 10 }} />
       </Form.Item>
       <Form.Item
-        label="Source URL"
+        label="Source Link"
         name="source"
+        tooltip="When a student clicks on the citation, they will be redirected to this link"
         rules={[
           {
             type: 'url',

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_questions/components/EditChatbotQuestionModal.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_questions/components/EditChatbotQuestionModal.tsx
@@ -82,10 +82,11 @@ const EditChatbotQuestionModal: React.FC<EditChatbotQuestionModalProps> = ({
       .addDocumentChunk(cid, newChunk)
       .then(async () => {
         const updatedQuestion: UpdateChatbotQuestionParams = {
+          id: editingRecord.vectorStoreId,
           inserted: true,
         }
         await API.chatbot.staffOnly
-          .updateQuestion(cid, editingRecord.vectorStoreId, updatedQuestion)
+          .updateQuestion(cid, updatedQuestion)
           .then(() => {
             message.success(
               'Document inserted successfully. You can now cancel or save the changes you made to the Q&A',
@@ -151,7 +152,7 @@ const EditChatbotQuestionModal: React.FC<EditChatbotQuestionModalProps> = ({
     }
 
     await API.chatbot.staffOnly
-      .updateQuestion(cid, editingRecord.vectorStoreId, valuesWithId)
+      .updateQuestion(cid, valuesWithId)
       .then(() => {
         message.success('Question updated successfully')
         onSuccessfulUpdate()

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_questions/components/EditChatbotQuestionModal.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_questions/components/EditChatbotQuestionModal.tsx
@@ -9,8 +9,11 @@ import {
   Tooltip,
   Collapse,
 } from 'antd'
-import axios from 'axios'
-import { SourceDocument, User } from '@koh/common'
+import {
+  AddDocumentChunkParams,
+  SourceDocument,
+  UpdateChatbotQuestionParams,
+} from '@koh/common'
 import { ChatbotQuestionFrontend } from '../page'
 import { getErrorMessage } from '@/app/utils/generalUtils'
 import {
@@ -21,6 +24,7 @@ import {
   QuestionCircleOutlined,
 } from '@ant-design/icons'
 import MarkdownGuideTooltipBody from './MarkdownGuideTooltipBody'
+import { API } from '@/app/api'
 
 interface FormValues {
   question: string
@@ -40,7 +44,6 @@ interface EditChatbotQuestionModalProps {
   onCancel: () => void
   onSuccessfulUpdate: () => void
   cid: number
-  profile: User
   deleteQuestion: (id: string) => void
 }
 
@@ -50,11 +53,9 @@ const EditChatbotQuestionModal: React.FC<EditChatbotQuestionModalProps> = ({
   onCancel,
   onSuccessfulUpdate,
   cid,
-  profile,
   deleteQuestion,
 }) => {
   const [form] = Form.useForm()
-  const chatbotToken = profile.chat_token.token
   const [saveLoading, setSaveLoading] = useState(false)
 
   const [successfulQAInsert, setSuccessfulQAInsert] = useState(false)
@@ -68,69 +69,40 @@ const EditChatbotQuestionModal: React.FC<EditChatbotQuestionModalProps> = ({
   const handleOkInsert = async () => {
     const values = await form.validateFields()
     setSaveLoading(true)
-    await axios
-      .post(
-        `/chat/${cid}/documentChunk`,
-        {
-          documentText: values.question + '\nAnswer:' + values.answer,
-          metadata: {
-            name: 'inserted Q&A',
-            type: 'inserted_question',
-            id: editingRecord.vectorStoreId,
-            courseId: cid,
-          },
-        },
-        {
-          headers: {
-            'Content-Type': 'application/json',
-            HMS_API_TOKEN: chatbotToken,
-          },
-        },
-      )
-      .then(async (res) => {
-        if (res.status !== 200 && res.status !== 201) {
-          const errorMessage = getErrorMessage(res)
-          message.error('Insert unsuccessful:' + errorMessage)
-        } else {
-          await axios
-            .patch(
-              `/chat/${cid}/question`,
-              {
-                id: editingRecord.vectorStoreId,
-                inserted: true,
-              },
-              {
-                headers: {
-                  'Content-Type': 'application/json',
-                  HMS_API_TOKEN: chatbotToken,
-                },
-              },
-            )
-            .then((res) => {
-              if (res.status !== 200 && res.status !== 201) {
-                const errorMessage = getErrorMessage(res)
-                message.error('Insert unsuccessful:' + errorMessage)
-              } else {
-                message.success(
-                  'Document inserted successfully. You can now cancel or save the changes you made to the Q&A',
-                  6,
-                )
-                setSuccessfulQAInsert(true)
-              }
-            })
-            .catch((e) => {
-              throw e
-            })
+    const newChunk: AddDocumentChunkParams = {
+      documentText: values.question + '\nAnswer:' + values.answer,
+      metadata: {
+        name: 'inserted Q&A',
+        type: 'inserted_question',
+        id: editingRecord.vectorStoreId,
+        courseId: cid,
+      },
+    }
+    await API.chatbot.staffOnly
+      .addDocumentChunk(cid, newChunk)
+      .then(async () => {
+        const updatedQuestion: UpdateChatbotQuestionParams = {
+          inserted: true,
         }
+        await API.chatbot.staffOnly
+          .updateQuestion(cid, editingRecord.vectorStoreId, updatedQuestion)
+          .then(() => {
+            message.success(
+              'Document inserted successfully. You can now cancel or save the changes you made to the Q&A',
+              6,
+            )
+            setSuccessfulQAInsert(true)
+          })
       })
       .catch((e) => {
         const errorMessage = getErrorMessage(e)
-        message.error('Failed to insert document:' + errorMessage)
+        message.error('Failed to add document: ' + errorMessage)
       })
       .finally(() => {
         setSaveLoading(false)
       })
   }
+
   const confirmInsert = () => {
     Modal.confirm({
       title:
@@ -177,26 +149,17 @@ const EditChatbotQuestionModal: React.FC<EditChatbotQuestionModalProps> = ({
       id: editingRecord.vectorStoreId,
       sourceDocuments: values.sourceDocuments || [],
     }
-    try {
-      const response = await fetch(`/chat/${cid}/question`, {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          HMS_API_TOKEN: chatbotToken,
-        },
-        body: JSON.stringify(valuesWithId),
-      })
-      if (!response.ok) {
-        const errorMessage = getErrorMessage(response)
-        message.error('Save unsuccessful:' + errorMessage)
-      } else {
+
+    await API.chatbot.staffOnly
+      .updateQuestion(cid, editingRecord.vectorStoreId, valuesWithId)
+      .then(() => {
         message.success('Question updated successfully')
         onSuccessfulUpdate()
-      }
-    } catch (error) {
-      const errorMessage = getErrorMessage(error)
-      message.error('Error saving question:' + errorMessage)
-    }
+      })
+      .catch((e) => {
+        const errorMessage = getErrorMessage(e)
+        message.error('Error updating question:' + errorMessage)
+      })
   }
 
   return (
@@ -233,6 +196,7 @@ const EditChatbotQuestionModal: React.FC<EditChatbotQuestionModalProps> = ({
                 cancelText: 'No',
                 onOk() {
                   deleteQuestion(editingRecord.vectorStoreId)
+                  onCancel()
                 },
               })
             }}
@@ -260,7 +224,7 @@ const EditChatbotQuestionModal: React.FC<EditChatbotQuestionModalProps> = ({
             sourceDocuments: editingRecord.sourceDocuments,
           }}
           clearOnDestroy
-          onFinish={(values) => onFinish(values)}
+          onFinish={onFinish}
         >
           {dom}
         </Form>

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_questions/page.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_questions/page.tsx
@@ -14,7 +14,7 @@ import { API } from '@/app/api'
 import {
   ChatbotQuestionResponseChatbotDB,
   ChatbotQuestionResponseHelpMeDB,
-  GetInteractionsAndQuestionsResponse,
+  InteractionResponse,
   SourceDocument,
 } from '@koh/common'
 import { ThumbsDown, ThumbsUp } from 'lucide-react'
@@ -90,21 +90,23 @@ export default function ChatbotQuestions({
   }, [search, questions])
 
   useEffect(() => {
-    fetch(`/chat/${courseId}/aggregateDocuments`, {
-      headers: { HMS_API_TOKEN: userInfo.chat_token.token },
-    })
-      .then((res) => res.json())
-      .then((json) => {
-        // Convert the json to the expected format
-        const formattedDocuments = json.map((doc: SourceDocument) => ({
+    API.chatbot.staffOnly
+      .getAllAggregateDocuments(courseId)
+      .then((res) => {
+        const formattedDocuments = res.map((doc) => ({
+          key: doc.id,
           docId: doc.id,
           docName: doc.pageContent,
-          sourceLink: doc.metadata?.source || '', // Handle the optional source field
-          pageNumbers: doc.metadata?.loc ? [doc.metadata.loc.pageNumber] : [], // Handle the optional loc field
+          pageContent: doc.pageContent,
+          sourceLink: doc.metadata?.source || '',
+          pageNumbers: doc.metadata?.loc ? [doc.metadata.loc.pageNumber] : [],
         }))
         setExistingDocuments(formattedDocuments)
       })
-  }, [userInfo.chat_token.token, courseId])
+      .catch((e) => {
+        message.error('Failed to fetch documents: ' + getErrorMessage(e))
+      })
+  }, [courseId])
 
   const columns: any[] = [
     {
@@ -386,37 +388,15 @@ export default function ChatbotQuestions({
     setDataLoading(true)
     // NOTE
     // We store the chatbot questions in two separate backends for some reason
-    // the helpme database stores interactions and has duplicate questions
+    // the helpme database stores interactions and has duplicate questions and userScores
     // the chatbot database stores .sourceDocuments and .verified and .inserted (AND is the only one updated when a question is edited AND is where added questions from AddChatbotQuestionModal go)
     // we need to fetch both and merge them
     // this becomes a really hard problem especially if you consider how the first question in an interaction can be a duplicate but subsequent questions can be different
     try {
-      // Fire off both requests simultaneously.
-      const [interactions, allQuestionsResponse] = await Promise.all([
-        API.chatbot.getInteractionsAndQuestions(courseId), // helpme questions
-        fetch(`/chat/${courseId}/allQuestions`, {
-          // chatbot questions
-          method: 'GET',
-          headers: {
-            'Content-Type': 'application/json',
-            HMS_API_TOKEN: userInfo.chat_token.token,
-          },
-        }),
-      ])
+      const { helpmeDB, chatbotDB } =
+        await API.chatbot.staffOnly.getInteractionsAndQuestions(courseId)
 
-      // Check that the second response is ok.
-      if (!allQuestionsResponse.ok) {
-        const errorMessage = getErrorMessage(allQuestionsResponse)
-        throw new Error(errorMessage)
-      }
-
-      const allQuestionsData: ChatbotQuestionResponseChatbotDB[] =
-        await allQuestionsResponse.json()
-
-      const processedQuestions = processQuestions(
-        interactions,
-        allQuestionsData,
-      )
+      const processedQuestions = processQuestions(helpmeDB, chatbotDB)
 
       setQuestions(processedQuestions)
     } catch (e) {
@@ -424,27 +404,22 @@ export default function ChatbotQuestions({
       message.error('Failed to fetch questions: ' + errorMessage)
     }
     setDataLoading(false)
-  }, [courseId, userInfo.chat_token.token])
+  }, [courseId])
 
   useEffect(() => {
     getQuestions()
   }, [editingRecord, getQuestions])
 
   const deleteQuestion = async (questionId: string) => {
-    try {
-      await fetch(`/chat/${courseId}/question/${questionId}`, {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-          HMS_API_TOKEN: userInfo.chat_token.token,
-        },
+    await API.chatbot.staffOnly
+      .deleteQuestion(courseId, questionId)
+      .then(() => {
+        getQuestions()
+        message.success('Question successfully deleted')
       })
-
-      getQuestions()
-      message.success('Question successfully deleted')
-    } catch (e) {
-      message.error('Failed to delete question.')
-    }
+      .catch((e) => {
+        message.error('Failed to delete question: ' + getErrorMessage(e))
+      })
   }
 
   return (
@@ -468,7 +443,6 @@ export default function ChatbotQuestions({
         <EditChatbotQuestionModal
           open={editRecordModalOpen}
           cid={courseId}
-          profile={userInfo}
           editingRecord={editingRecord}
           onCancel={() => setEditRecordModalOpen(false)}
           onSuccessfulUpdate={() => {
@@ -559,7 +533,6 @@ export default function ChatbotQuestions({
     </div>
   )
 }
-
 function mergeChatbotQuestions(
   helpMeQuestion?: ChatbotQuestionResponseHelpMeDB | null,
   chatbotQuestion?: ChatbotQuestionResponseChatbotDB | null,
@@ -603,7 +576,7 @@ function mergeChatbotQuestions(
 }
 
 function processQuestions(
-  interactions: GetInteractionsAndQuestionsResponse,
+  interactions: InteractionResponse[],
   allQuestionsData: ChatbotQuestionResponseChatbotDB[],
 ): ChatbotQuestionFrontend[] {
   //

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_settings/components/AddChatbotDocumentModal.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_settings/components/AddChatbotDocumentModal.tsx
@@ -21,6 +21,7 @@ import Dragger from 'antd/es/upload/Dragger'
 import { useState } from 'react'
 import { RcFile } from 'antd/lib/upload'
 import { API } from '@/app/api'
+import { getErrorMessage } from '@/app/utils/generalUtils'
 
 interface AddChatbotDocumentModalProps {
   courseId: number
@@ -78,10 +79,7 @@ const AddChatbotDocumentModal: React.FC<AddChatbotDocumentModalProps> = ({
         source: source,
         parseAsPng: isSlideDeck,
       }
-      formData.append(
-        'source',
-        new Blob([JSON.stringify(jsonData)], { type: 'application/json' }),
-      )
+      formData.append('source', JSON.stringify(jsonData))
 
       await API.chatbot.staffOnly
         .uploadDocument(courseId, formData)
@@ -90,7 +88,9 @@ const AddChatbotDocumentModal: React.FC<AddChatbotDocumentModalProps> = ({
           setCountProcessed((prev) => prev + 1)
         })
         .catch((e) => {
-          uploadErrors.push(`Failed to upload/process ${file.name}: ${e}`)
+          uploadErrors.push(
+            `Failed to upload/process ${file.name}: ${getErrorMessage(e)}`,
+          )
           wasError = true
         })
     }

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_settings/page.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_settings/page.tsx
@@ -10,6 +10,7 @@ import AddChatbotDocumentModal from './components/AddChatbotDocumentModal'
 import { SourceDocument } from '@koh/common'
 import { FileAddOutlined, SettingOutlined } from '@ant-design/icons'
 import { API } from '@/app/api'
+import { useUserInfo } from '@/app/contexts/userContext'
 
 interface ChatbotPanelProps {
   params: { cid: string }
@@ -17,6 +18,7 @@ interface ChatbotPanelProps {
 export default function ChatbotSettings({
   params,
 }: ChatbotPanelProps): ReactElement {
+  const { userInfo } = useUserInfo()
   const courseId = Number(params.cid)
   const [chatbotParameterModalOpen, setChatbotParameterModalOpen] =
     useState(false)
@@ -173,6 +175,7 @@ export default function ChatbotSettings({
 
   return (
     <div className="m-auto my-5">
+      <title>{`HelpMe | Editing ${userInfo.courses.find((e) => e.course.id === courseId)?.course.name ?? ''} Chatbot`}</title>
       <AddChatbotDocumentModal
         open={addDocumentModalOpen}
         courseId={courseId}

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_settings/page.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_settings/page.tsx
@@ -1,9 +1,7 @@
 'use client'
 
 import { Button, Input, Pagination, Progress, Table, message } from 'antd'
-import { ReactElement, useCallback, useEffect, useState } from 'react'
-import axios from 'axios'
-import { useUserInfo } from '@/app/contexts/userContext'
+import { ReactElement, useCallback, useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
 import { TableRowSelection } from 'antd/es/table/interface'
 import ChatbotSettingsModal from './components/ChatbotSettingsModal'
@@ -11,18 +9,7 @@ import Highlighter from 'react-highlight-words'
 import AddChatbotDocumentModal from './components/AddChatbotDocumentModal'
 import { SourceDocument } from '@koh/common'
 import { FileAddOutlined, SettingOutlined } from '@ant-design/icons'
-
-export interface ChatbotDocument {
-  id: number
-  name: string
-  type: string
-  subDocumentIds: string[]
-}
-
-export interface ChatbotDocumentResponse {
-  chatQuestions: SourceDocument[]
-  total: number
-}
+import { API } from '@/app/api'
 
 interface ChatbotPanelProps {
   params: { cid: string }
@@ -34,15 +21,11 @@ export default function ChatbotSettings({
   const [chatbotParameterModalOpen, setChatbotParameterModalOpen] =
     useState(false)
   const [addDocumentModalOpen, setAddDocumentModalOpen] = useState(false)
-  const { userInfo } = useUserInfo()
   const [search, setSearch] = useState('')
   const [selectViewEnabled, setSelectViewEnabled] = useState(false)
   const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([])
   const [totalDocuments, setTotalDocuments] = useState(0)
   const [chatbotDocuments, setChatbotDocuments] = useState<SourceDocument[]>([])
-  const [filteredDocuments, setFilteredDocuments] = useState<SourceDocument[]>(
-    [],
-  )
   const [loading, setLoading] = useState(false)
   const [countProcessed, setCountProcessed] = useState(0)
 
@@ -57,13 +40,7 @@ export default function ChatbotSettings({
   const handleDeleteSelectedDocuments = async () => {
     try {
       for (const docId of selectedRowKeys) {
-        await fetch(`/chat/${courseId}/${docId}/document`, {
-          method: 'DELETE',
-          headers: {
-            'Content-Type': 'application/json',
-            HMS_API_TOKEN: userInfo.chat_token.token,
-          },
-        })
+        await API.chatbot.staffOnly.deleteDocument(courseId, docId.toString())
         setCountProcessed(countProcessed + 1)
       }
       message.success('Documents deleted.')
@@ -80,29 +57,18 @@ export default function ChatbotSettings({
 
   const handleDeleteDocument = async (record: any) => {
     setLoading(true)
-    try {
-      const response = await fetch(
-        `/chat/${courseId}/${record.docId}/document`,
-        {
-          method: 'DELETE',
-          headers: {
-            'Content-Type': 'application/json',
-            HMS_API_TOKEN: userInfo.chat_token.token,
-          },
-        },
-      )
-
-      if (!response.ok) {
-        throw new Error(`Failed to upload ${File.name}`)
-      }
-
-      message.success('Document deleted.')
-      getDocuments()
-    } catch (e) {
-      message.error('Failed to delete document.')
-    } finally {
-      setLoading(false)
-    }
+    await API.chatbot.staffOnly
+      .deleteDocument(courseId, record.docId.toString())
+      .then(() => {
+        message.success('Document deleted.')
+        getDocuments()
+      })
+      .catch(() => {
+        message.error('Failed to delete document.')
+      })
+      .finally(() => {
+        setLoading(false)
+      })
   }
 
   const columns = [
@@ -174,42 +140,35 @@ export default function ChatbotSettings({
   ]
 
   const getDocuments = useCallback(async () => {
-    try {
-      const response = await axios.get(`/chat/${courseId}/aggregateDocuments`, {
-        headers: {
-          HMS_API_TOKEN: userInfo.chat_token.token,
-        },
+    await API.chatbot.staffOnly
+      .getAllAggregateDocuments(courseId)
+      .then((response) => {
+        const formattedDocuments = response.map((doc) => ({
+          key: doc.id,
+          docId: doc.id,
+          docName: doc.pageContent,
+          pageContent: doc.pageContent, // idk what's going on here why is there both a docName and pageContent
+          sourceLink: doc.metadata?.source ?? '',
+          pageNumbers: [],
+        }))
+        setChatbotDocuments(formattedDocuments)
+        setTotalDocuments(formattedDocuments.length)
       })
-      const formattedDocuments = response.data.map((doc: SourceDocument) => ({
-        key: doc.id,
-        docId: doc.id,
-        docName: doc.pageContent,
-        sourceLink: doc.metadata?.source ?? '',
-        pageNumbers: [],
-      }))
-      setChatbotDocuments(formattedDocuments)
-      setTotalDocuments(formattedDocuments.length)
-    } catch (e) {
-      console.error(e)
-      setChatbotDocuments([])
-      setTotalDocuments(0)
-    }
-  }, [
-    courseId,
-    userInfo.chat_token.token,
-    setChatbotDocuments,
-    setTotalDocuments,
-  ])
+      .catch((e) => {
+        console.error(e)
+        setChatbotDocuments([])
+        setTotalDocuments(0)
+      })
+  }, [courseId, setChatbotDocuments, setTotalDocuments])
 
   useEffect(() => {
     getDocuments()
   }, [getDocuments])
 
-  useEffect(() => {
-    const filtered = chatbotDocuments.filter((doc) =>
+  const filteredDocuments = useMemo(() => {
+    return chatbotDocuments.filter((doc) =>
       doc.docName.toLowerCase().includes(search.toLowerCase()),
     )
-    setFilteredDocuments(filtered)
   }, [search, chatbotDocuments])
 
   return (

--- a/packages/frontend/app/(dashboard)/course/[cid]/async_centre/components/modals/ConvertChatbotQToAnytimeQModal.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/async_centre/components/modals/ConvertChatbotQToAnytimeQModal.tsx
@@ -56,17 +56,13 @@ const ConvertChatbotQToAnytimeQModal: React.FC<
         const data = {
           question: question,
           history: [],
+          onlySaveInChatbotDB: true,
         }
-        const response = await fetch(`/chat/${courseId}/ask`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            HMS_API_TOKEN: userInfo.chat_token.token,
-          },
-          body: JSON.stringify(data),
-        })
-        const json = await response.json()
-        return json.answer
+        const response = await API.chatbot.studentsOrStaff.askQuestion(
+          courseId,
+          data,
+        )
+        return response.chatbotRepoVersion.answer
       } else {
         return 'All AI uses have been used up for today. Please try again tomorrow.'
       }

--- a/packages/frontend/app/(dashboard)/course/[cid]/async_centre/components/modals/CreateAsyncQuestionModal.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/async_centre/components/modals/CreateAsyncQuestionModal.tsx
@@ -57,17 +57,13 @@ const CreateAsyncQuestionModal: React.FC<CreateAsyncQuestionModalProps> = ({
         const data = {
           question: question,
           history: [],
+          onlySaveInChatbotDB: true,
         }
-        const response = await fetch(`/chat/${courseId}/ask`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            HMS_API_TOKEN: userInfo.chat_token.token,
-          },
-          body: JSON.stringify(data),
-        })
-        const json = await response.json()
-        return json.answer
+        const response = await API.chatbot.studentsOrStaff.askQuestion(
+          courseId,
+          data,
+        )
+        return response.chatbotRepoVersion.answer
       } else {
         return 'All AI uses have been used up for today. Please try again tomorrow.'
       }

--- a/packages/frontend/app/(dashboard)/course/[cid]/components/chatbot/Chatbot.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/components/chatbot/Chatbot.tsx
@@ -17,7 +17,6 @@ import {
   RobotOutlined,
   CloseOutlined,
 } from '@ant-design/icons'
-import axios from 'axios'
 import { useCourseFeatures } from '@/app/hooks/useCourseFeatures'
 import { useUserInfo } from '@/app/contexts/userContext'
 import {
@@ -28,9 +27,6 @@ import {
 } from '@/app/utils/generalUtils'
 import { Feedback } from './Feedback'
 import {
-  PreDeterminedQuestion,
-  Message,
-  ChatbotAskResponse,
   chatbotStartingMessageSystem,
   chatbotStartingMessageCourse,
   ChatbotQuestionType,
@@ -39,7 +35,7 @@ import { API } from '@/app/api'
 import MarkdownCustom from '@/app/components/Markdown'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { Role } from '@koh/common'
+import { PreDeterminedQuestion, Role, Message } from '@koh/common'
 import { Bot } from 'lucide-react'
 
 const { TextArea } = Input
@@ -107,18 +103,10 @@ const Chatbot: React.FC<ChatbotProps> = ({
   useEffect(() => {
     if (messages.length === 1) {
       setPreDeterminedQuestions([])
-      axios
-        .get(`/chat/${courseIdToUse}/allSuggestedQuestions`, {
-          headers: { HMS_API_TOKEN: userInfo.chat_token?.token },
-        })
-        .then((res) => {
-          setPreDeterminedQuestions(
-            res.data.map((question: PreDeterminedQuestion) => ({
-              id: question.id,
-              pageContent: question.pageContent,
-              metadata: question.metadata,
-            })),
-          )
+      API.chatbot.studentsOrStaff
+        .getSuggestedQuestions(courseIdToUse)
+        .then((questions) => {
+          setPreDeterminedQuestions(questions)
         })
         .catch((err) => {
           console.error(err)
@@ -135,60 +123,6 @@ const Chatbot: React.FC<ChatbotProps> = ({
     setQuestionsLeft,
   ])
 
-  const query = async () => {
-    try {
-      const data = {
-        question:
-          chatbotQuestionType === 'System'
-            ? `${input}
-            \nThis user is currently on the ${currentPageTitle}.
-            \nThe user's role for this course is ${role === Role.PROFESSOR ? 'Professor (Staff)' : role === Role.TA ? 'TA (Staff)' : 'Student'}.`
-            : input,
-        history: messages,
-      }
-      const response = await fetch(`/chat/${courseIdToUse}/ask`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          HMS_API_TOKEN: userInfo.chat_token.token,
-        },
-        body: JSON.stringify(data),
-      })
-      const json = await response.json()
-      if (questionsLeft > 0) {
-        setQuestionsLeft(questionsLeft - 1)
-        setUserInfo({
-          ...userInfo,
-          chat_token: {
-            ...userInfo.chat_token,
-            used: userInfo.chat_token.used + 1,
-          },
-        })
-      }
-      return json
-    } catch (error) {
-      if (questionsLeft > 0) {
-        setQuestionsLeft(questionsLeft - 1)
-        setUserInfo({
-          ...userInfo,
-          chat_token: {
-            ...userInfo.chat_token,
-            used: userInfo.chat_token.used + 1,
-          },
-        })
-      }
-      return null
-    }
-  }
-  const createNewInteraction = async () => {
-    const interaction = await API.chatbot.createInteraction({
-      courseId: courseIdToUse,
-      userId: userInfo.id,
-    })
-    setInteractionId(interaction.id)
-    return interaction.id
-  }
-
   const handleAsk = async () => {
     if (!hasAskedQuestion.current) {
       hasAskedQuestion.current = true
@@ -196,40 +130,70 @@ const Chatbot: React.FC<ChatbotProps> = ({
     }
 
     setIsLoading(true)
-    let currentInteractionId = interactionId
-    if (!currentInteractionId) {
-      currentInteractionId = await createNewInteraction()
+
+    const data = {
+      question:
+        chatbotQuestionType === 'System'
+          ? `${input}
+            \nThis user is currently on the ${currentPageTitle}.
+            \nThe user's role for this course is ${role === Role.PROFESSOR ? 'Professor (Staff)' : role === Role.TA ? 'TA (Staff)' : 'Student'}.`
+          : input,
+      history: messages,
+      interactionId: interactionId,
     }
 
-    const result: ChatbotAskResponse = await query()
-
-    const answer = result ? result.answer : "Sorry, I couldn't find the answer"
-    const { thinkText, cleanAnswer } = parseThinkBlock(answer)
-    const sourceDocuments = result ? result.sourceDocuments : []
-    setMessages((prevMessages: Message[]) => [
-      ...prevMessages,
-      { type: 'userMessage', message: input },
-      {
-        type: 'apiMessage',
-        message: thinkText ? cleanAnswer : answer,
-        verified: result ? result.verified : true,
-        sourceDocuments: sourceDocuments ? sourceDocuments : [],
-        questionId: result ? result.questionId : undefined,
-        thinkText: thinkText,
-      },
-    ])
-
-    const helpmeQuestion = await API.chatbot.createQuestion({
-      vectorStoreId: result.questionId,
-      interactionId: currentInteractionId,
-      questionText: input,
-      responseText: answer,
-      userScore: 0,
-      isPreviousQuestion: result.isPreviousQuestion,
-    })
-    setHelpmeQuestionId(helpmeQuestion.id)
-    setIsLoading(false)
-    setInput('')
+    await API.chatbot.studentsOrStaff
+      .askQuestion(courseIdToUse, data)
+      .then((chatbotResponse) => {
+        const answer = chatbotResponse.chatbotRepoVersion.answer
+        const { thinkText, cleanAnswer } = parseThinkBlock(answer)
+        const sourceDocuments =
+          chatbotResponse.chatbotRepoVersion.sourceDocuments ?? []
+        setMessages((prevMessages: Message[]) => [
+          ...prevMessages,
+          { type: 'userMessage', message: input },
+          {
+            type: 'apiMessage',
+            message: thinkText ? cleanAnswer : answer,
+            verified: chatbotResponse.chatbotRepoVersion.verified,
+            sourceDocuments: sourceDocuments ? sourceDocuments : [],
+            questionId: chatbotResponse.chatbotRepoVersion.questionId,
+            thinkText: thinkText,
+          },
+        ])
+        setHelpmeQuestionId(chatbotResponse?.helpmeRepoVersion?.id)
+        setInteractionId(chatbotResponse?.helpmeRepoVersion?.interactionId)
+      })
+      .catch((err) => {
+        console.error(err)
+        const answer = "Sorry, I couldn't find the answer"
+        setMessages((prevMessages: Message[]) => [
+          ...prevMessages,
+          { type: 'userMessage', message: input },
+          {
+            type: 'apiMessage',
+            message: answer,
+            verified: false,
+            sourceDocuments: [],
+            questionId: undefined,
+            thinkText: null,
+          },
+        ])
+      })
+      .finally(() => {
+        if (questionsLeft > 0) {
+          setQuestionsLeft(questionsLeft - 1)
+          setUserInfo({
+            ...userInfo,
+            chat_token: {
+              ...userInfo.chat_token,
+              used: userInfo.chat_token.used + 1,
+            },
+          })
+        }
+        setIsLoading(false)
+        setInput('')
+      })
   }
 
   const answerPreDeterminedQuestion = async (
@@ -250,16 +214,14 @@ const Chatbot: React.FC<ChatbotProps> = ({
     ])
     setPreDeterminedQuestions([])
 
-    const currentInteractionId = await createNewInteraction()
-    const helpmeQuestion = await API.chatbot.createQuestion({
-      vectorStoreId: question.id,
-      interactionId: currentInteractionId,
-      questionText: question.pageContent,
-      responseText: question.metadata.answer, // store full question (including think text) in db
-      userScore: 0,
-      isPreviousQuestion: true,
-    })
+    const helpmeQuestion =
+      await API.chatbot.studentsOrStaff.askSuggestedQuestion(courseIdToUse, {
+        vectorStoreId: question.id,
+        question: question.pageContent,
+        responseText: question.metadata.answer, // store full question (including think text) in db
+      })
     setHelpmeQuestionId(helpmeQuestion.id)
+    setInteractionId(helpmeQuestion.interactionId)
   }
 
   /* newChatbotQuestionType was added to allow us to reset the chat using a new chatbotQuestionType.
@@ -279,32 +241,6 @@ const Chatbot: React.FC<ChatbotProps> = ({
     setInteractionId(undefined)
     setHelpmeQuestionId(undefined)
     setInput('')
-  }
-
-  const getSourceLinkButton = (
-    docName: string,
-    sourceLink: string,
-    part?: number,
-  ) => {
-    if (!sourceLink) {
-      return null
-    }
-
-    return (
-      <a
-        className={`flex items-center justify-center rounded-lg bg-blue-100 px-3 py-2 font-semibold transition ${
-          sourceLink && 'hover:bg-black-300 cursor-pointer hover:text-white'
-        }`}
-        key={`${docName}-${part}`}
-        href={sourceLink}
-        // open in new tab
-        target="_blank"
-      >
-        <p className="h-fit w-fit text-xs leading-4">
-          {part ? `p. ${part}` : 'Source'}
-        </p>
-      </a>
-    )
   }
 
   const extractLMSLink = (content?: string) => {
@@ -507,10 +443,10 @@ const Chatbot: React.FC<ChatbotProps> = ({
                             chatbotQuestionType === 'System' ? (
                               <div className="align-items-start flex h-fit w-fit max-w-[280px] flex-wrap justify-start gap-x-2 rounded-xl bg-slate-100 p-1 font-semibold">
                                 <p className="px-2 py-1">User Guide</p>
-                                {getSourceLinkButton(
-                                  'User Guide',
-                                  'https://github.com/ubco-db/helpme/blob/main/packages/frontend/public/userguide.md',
-                                )}
+                                <SourceLinkButton
+                                  docName="User Guide"
+                                  sourceLink="https://github.com/ubco-db/helpme/blob/main/packages/frontend/public/userguide.md"
+                                />
                               </div>
                             ) : (
                               item.sourceDocuments &&
@@ -534,20 +470,28 @@ const Chatbot: React.FC<ChatbotProps> = ({
                                         'inserted_lms_document' &&
                                         extractLMSLink(
                                           sourceDocument.content,
-                                        ) &&
-                                        getSourceLinkButton(
-                                          sourceDocument.docName,
-                                          extractLMSLink(
-                                            sourceDocument.content,
-                                          ) ?? '',
-                                          0,
+                                        ) && (
+                                          <SourceLinkButton
+                                            docName={sourceDocument.docName}
+                                            sourceLink={
+                                              extractLMSLink(
+                                                sourceDocument.content,
+                                              ) ?? ''
+                                            }
+                                            part={0}
+                                          />
                                         )}
                                       {sourceDocument.pageNumbers &&
-                                        sourceDocument.pageNumbers.map((part) =>
-                                          getSourceLinkButton(
-                                            sourceDocument.docName,
-                                            sourceDocument.sourceLink,
-                                            part,
+                                        sourceDocument.pageNumbers.map(
+                                          (part) => (
+                                            <SourceLinkButton
+                                              key={`${sourceDocument.docName}-${part}`}
+                                              docName={sourceDocument.docName}
+                                              sourceLink={
+                                                sourceDocument.sourceLink
+                                              }
+                                              part={part}
+                                            />
                                           ),
                                         )}
                                     </div>
@@ -559,7 +503,10 @@ const Chatbot: React.FC<ChatbotProps> = ({
                           {item.type === 'apiMessage' &&
                             index === messages.length - 1 &&
                             index !== 0 && (
-                              <Feedback questionId={helpmeQuestionId ?? 0} />
+                              <Feedback
+                                courseId={courseIdToUse}
+                                questionId={helpmeQuestionId ?? 0}
+                              />
                             )}
                         </div>
                       </div>
@@ -669,3 +616,29 @@ const Chatbot: React.FC<ChatbotProps> = ({
 }
 
 export default Chatbot
+
+const SourceLinkButton: React.FC<{
+  docName: string
+  sourceLink?: string
+  part?: number
+}> = ({ docName, sourceLink, part }) => {
+  if (!sourceLink) {
+    return null
+  }
+
+  return (
+    <a
+      className={`flex items-center justify-center rounded-lg bg-blue-100 px-3 py-2 font-semibold transition ${
+        sourceLink && 'hover:bg-black-300 cursor-pointer hover:text-white'
+      }`}
+      key={`${docName}-${part}`}
+      href={sourceLink}
+      // open in new tab
+      target="_blank"
+    >
+      <p className="h-fit w-fit text-xs leading-4">
+        {part ? `p. ${part}` : 'Source'}
+      </p>
+    </a>
+  )
+}

--- a/packages/frontend/app/(dashboard)/course/[cid]/components/chatbot/Feedback.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/components/chatbot/Feedback.tsx
@@ -1,23 +1,21 @@
 import { API } from '@/app/api'
 import { getErrorMessage } from '@/app/utils/generalUtils'
 import { ThumbsDown, ThumbsUp } from 'lucide-react'
-import React, { useState } from 'react'
+import { useState } from 'react'
 
 interface FeedbackProps {
-  questionId: number
+  courseId: number
+  questionId: number // this is a helpme question id
 }
 
-export const Feedback: React.FC<FeedbackProps> = ({ questionId }) => {
+export const Feedback: React.FC<FeedbackProps> = ({ courseId, questionId }) => {
   const [userScore, setUserScore] = useState(0)
 
   const handleClick = (newUserScore: number) => {
     const updatedUserScore = newUserScore == userScore ? 0 : newUserScore
-    setUserScore(updatedUserScore)
-    API.chatbot
-      .editQuestion({
-        userScore: updatedUserScore,
-        id: questionId,
-      })
+    setUserScore(updatedUserScore) // immediately show the user score as updated, asynchronously update the backend
+    API.chatbot.studentsOrStaff
+      .updateUserScore(courseId, questionId, updatedUserScore)
       .catch((error) => {
         const errorMessage = getErrorMessage(error)
         console.log('Error updating user score:', errorMessage)
@@ -30,14 +28,14 @@ export const Feedback: React.FC<FeedbackProps> = ({ questionId }) => {
         size={16}
         color="#1E38A8"
         fill={userScore === -1 ? '#1E38A8' : 'transparent'}
-        onClick={() => handleClick(-1)}
+        onClick={() => (userScore === -1 ? handleClick(0) : handleClick(-1))}
         className="cursor-pointer"
       />
       <ThumbsUp
         size={16}
         color="#1E38A8"
         fill={userScore === 1 ? '#1E38A8' : 'transparent'}
-        onClick={() => handleClick(1)}
+        onClick={() => (userScore === 1 ? handleClick(0) : handleClick(1))}
         className="cursor-pointer"
       />
     </div>

--- a/packages/frontend/app/api/index.ts
+++ b/packages/frontend/app/api/index.ts
@@ -33,12 +33,8 @@ import {
   Calendar,
   UpdateOrganizationDetailsParams,
   UpdateOrganizationUserRole,
-  ChatbotQuestion,
   UpdateOrganizationCourseDetailsParams,
-  InteractionResponse,
   OrganizationResponse,
-  DocumentParams,
-  ChatbotDocument,
   GetLimitedCourseResponse,
   GetOrganizationUserResponse,
   OrganizationCourseResponse,
@@ -79,6 +75,19 @@ import {
   AsyncQuestionCommentParams,
   UnreadAsyncQuestionResponse,
   GetInteractionsAndQuestionsResponse,
+  SourceDocument,
+  ChatbotSettings,
+  ChatbotSettingsMetadata,
+  PreDeterminedQuestion,
+  ChatbotAskResponse,
+  ChatbotQuestionResponseHelpMeDB,
+  UpdateDocumentChunkParams,
+  ChatbotAskParams,
+  ChatbotAskSuggestedParams,
+  AddChatbotQuestionParams,
+  ChatbotQuestionResponseChatbotDB,
+  AddDocumentChunkParams,
+  UpdateChatbotQuestionParams,
 } from '@koh/common'
 import Axios, { AxiosInstance, Method } from 'axios'
 import { plainToClass } from 'class-transformer'
@@ -152,21 +161,155 @@ class APIClient {
   }
 
   chatbot = {
-    createInteraction: async (body: {
-      courseId: number
-      userId: number
-    }): Promise<InteractionResponse> =>
-      this.req('POST', `/api/v1/chatbot/interaction`, undefined, body),
-    getInteractionsAndQuestions: async (
-      courseId: number,
-    ): Promise<GetInteractionsAndQuestionsResponse> =>
-      this.req('GET', `/api/v1/chatbot/questions/${courseId}`),
-    createQuestion: async (body: ChatbotQuestion): Promise<ChatbotQuestion> =>
-      this.req('POST', `/api/v1/chatbot/question`, undefined, body),
-    editQuestion: async (data: ChatbotQuestion): Promise<ChatbotQuestion> =>
-      this.req('PATCH', `/api/v1/chatbot/question`, undefined, data),
-    // deleteQuestion: async (body: ChatbotQuestion): Promise<ChatbotQuestion> => unused
-    //   this.req('DELETE', `/api/v1/chatbot/question`, undefined, body),
+    studentsOrStaff: {
+      // these endpoints are the main endpoints that students and staff use
+      askQuestion: async (
+        courseId: number,
+        body: ChatbotAskParams,
+      ): Promise<ChatbotAskResponse> =>
+        this.req('POST', `/api/v1/chatbot/ask/${courseId}`, undefined, body),
+      askSuggestedQuestion: async (
+        courseId: number,
+        body: ChatbotAskSuggestedParams,
+      ): Promise<ChatbotQuestionResponseHelpMeDB> =>
+        this.req(
+          'POST',
+          `/api/v1/chatbot/askSuggested/${courseId}`,
+          undefined,
+          body,
+        ),
+      getSuggestedQuestions: async (
+        courseId: number,
+      ): Promise<PreDeterminedQuestion[]> =>
+        this.req('GET', `/api/v1/chatbot/question/suggested/${courseId}`),
+      updateUserScore: async (
+        courseId: number,
+        questionId: number,
+        userScore: number,
+      ): Promise<ChatbotQuestionResponseHelpMeDB> =>
+        this.req(
+          'PATCH',
+          `/api/v1/chatbot/question/${courseId}/${questionId}`,
+          undefined,
+          { userScore },
+        ),
+    },
+    staffOnly: {
+      // these endpoints are more for management of chatbot questions
+      getInteractionsAndQuestions: async (
+        courseId: number,
+      ): Promise<GetInteractionsAndQuestionsResponse> =>
+        this.req('GET', `/api/v1/chatbot/question/all/${courseId}`),
+      addQuestion: async (
+        courseId: number,
+        questionData: AddChatbotQuestionParams,
+      ): Promise<ChatbotQuestionResponseHelpMeDB> =>
+        this.req(
+          'POST',
+          `/api/v1/chatbot/question/${courseId}`,
+          undefined,
+          questionData,
+        ),
+      updateQuestion: async (
+        courseId: number,
+        vectorStoreId: string,
+        body: UpdateChatbotQuestionParams,
+      ): Promise<ChatbotQuestionResponseChatbotDB> =>
+        this.req(
+          'PATCH',
+          `/api/v1/chatbot/question/${courseId}/${vectorStoreId}`,
+          undefined,
+          body,
+        ),
+      deleteQuestion: async (
+        courseId: number,
+        vectorStoreId: string,
+      ): Promise<{ success: boolean }> =>
+        this.req(
+          'DELETE',
+          `/api/v1/chatbot/question/${courseId}/${vectorStoreId}`,
+        ),
+      // deleteAllQuestions: async (courseId: number): Promise<{ success: boolean }> =>
+      //   this.req('DELETE', `/api/v1/chatbot/question/all/${courseId}`), Unused
+      // resetCourse: async (courseId: number): Promise<{ success: boolean }> =>
+      //   this.req('DELETE', `/api/v1/chatbot/resetCourse/${courseId}`), Unused, resets all chatbot data for the course
+      getAllAggregateDocuments: async (
+        courseId: number,
+      ): Promise<SourceDocument[]> =>
+        this.req('GET', `/api/v1/chatbot/aggregateDocuments/${courseId}`),
+      getAllDocumentChunks: async (
+        courseId: number,
+      ): Promise<SourceDocument[]> =>
+        this.req('GET', `/api/v1/chatbot/documentChunks/${courseId}`),
+      addDocumentChunk: async (
+        courseId: number,
+        body: AddDocumentChunkParams,
+      ): Promise<SourceDocument> =>
+        this.req(
+          'POST',
+          `/api/v1/chatbot/documentChunks/${courseId}`,
+          undefined,
+          body,
+        ),
+      updateDocumentChunk: async (
+        courseId: number,
+        docId: string,
+        body: UpdateDocumentChunkParams,
+      ): Promise<SourceDocument> =>
+        this.req(
+          'PATCH',
+          `/api/v1/chatbot/documentChunks/${courseId}/${docId}`,
+          undefined,
+          body,
+        ),
+      deleteDocumentChunk: async (
+        courseId: number,
+        docId: string,
+      ): Promise<{ success: boolean }> =>
+        this.req(
+          'DELETE',
+          `/api/v1/chatbot/documentChunks/${courseId}/${docId}`,
+        ),
+      deleteDocument: async (
+        courseId: number,
+        docId: string,
+      ): Promise<{ success: boolean }> =>
+        this.req('DELETE', `/api/v1/chatbot/documents/${courseId}/${docId}`),
+      uploadDocument: async (
+        courseId: number,
+        body: FormData,
+      ): Promise<{ success: boolean; documentId?: string }> =>
+        this.req(
+          'POST',
+          `/api/v1/chatbot/documents/${courseId}/upload`,
+          undefined,
+          body,
+        ),
+      addDocumentFromGithub: async (
+        courseId: number,
+        url: string,
+      ): Promise<{ success: boolean; documentId?: string }> =>
+        this.req(
+          'POST',
+          `/api/v1/chatbot/documents/${courseId}/github`,
+          undefined,
+          { url },
+        ),
+      getSettings: async (courseId: number): Promise<ChatbotSettings> =>
+        this.req('GET', `/api/v1/chatbot/settings/${courseId}`),
+      updateSettings: async (
+        courseId: number,
+        settings: ChatbotSettingsMetadata,
+      ): Promise<{ success: boolean }> =>
+        this.req(
+          'PATCH',
+          `/api/v1/chatbot/settings/${courseId}`,
+          undefined,
+          settings,
+        ),
+      resetSettings: async (courseId: number): Promise<{ success: boolean }> =>
+        this.req('PATCH', `/api/v1/chatbot/settings/${courseId}/reset`),
+    },
   }
 
   course = {

--- a/packages/frontend/app/api/index.ts
+++ b/packages/frontend/app/api/index.ts
@@ -189,7 +189,7 @@ class APIClient {
       ): Promise<ChatbotQuestionResponseHelpMeDB> =>
         this.req(
           'PATCH',
-          `/api/v1/chatbot/question/${courseId}/${questionId}`,
+          `/api/v1/chatbot/questionScore/${courseId}/${questionId}`,
           undefined,
           { userScore },
         ),
@@ -212,12 +212,11 @@ class APIClient {
         ),
       updateQuestion: async (
         courseId: number,
-        vectorStoreId: string,
         body: UpdateChatbotQuestionParams,
       ): Promise<ChatbotQuestionResponseChatbotDB> =>
         this.req(
           'PATCH',
-          `/api/v1/chatbot/question/${courseId}/${vectorStoreId}`,
+          `/api/v1/chatbot/question/${courseId}`,
           undefined,
           body,
         ),

--- a/packages/frontend/app/typings/chatbot.ts
+++ b/packages/frontend/app/typings/chatbot.ts
@@ -1,48 +1,7 @@
-export interface SourceDocument {
-  docName: string
-  sourceLink: string
-  pageNumbers: number[]
-  metadata?: { type?: string }
-  type?: string
-  content?: string
-}
-
-export interface PreDeterminedQuestion {
-  id: string
-  pageContent: string
-  metadata: {
-    answer: string
-    courseId: string
-    inserted: boolean
-    sourceDocuments: SourceDocument[]
-    suggested: boolean
-    verified: boolean
-  }
-}
-
-export interface Message {
-  type: 'apiMessage' | 'userMessage'
-  message: string | void
-  verified?: boolean
-  sourceDocuments?: SourceDocument[]
-  questionId?: string
-  thinkText?: string | null
-}
+import { Message } from '@koh/common'
 
 export interface ChatbotQToConvertToAnytimeQ {
   messages: Message[]
-}
-
-// this is the response from the backend when new questions are asked
-// if question is I don't know, only answer and questionId are returned
-export interface ChatbotAskResponse {
-  question?: string
-  answer: string
-  questionId: string
-  sourceDocuments?: SourceDocument[]
-  verified?: boolean
-  courseId?: any
-  isPreviousQuestion?: boolean
 }
 
 export const chatbotStartingMessageCourse =

--- a/packages/server/.env.development
+++ b/packages/server/.env.development
@@ -18,6 +18,8 @@ GMAIL_PASSWORD=fake_password
 SENTRY_AUTH_TOKEN=
 # Needed to make requests to the chatbot service in chatbot repo (needs to match the CHATBOT_API_KEY in the .env in the chatbot repo)
 CHATBOT_API_KEY=ForIBecomeBrokeFinancerOfOpenAICalls
+# Change this to the courseId of your "HelpMe" course (used by chatbot when asking system questions)
+HELPME_COURSE_ID = 
 
 BASE_BACKUP_COMMAND='docker exec -u postgres helpme-postgresql-1 pg_dumpall -U postgres | gzip >'
 

--- a/packages/server/.env.development
+++ b/packages/server/.env.development
@@ -16,5 +16,8 @@ GMAIL_USER=fake_email
 GMAIL_PASSWORD=fake_password
 # Used for gettings source maps (so that we know what code is causing the error instead of just the minified code)
 SENTRY_AUTH_TOKEN=
+# Needed to make requests to the chatbot service in chatbot repo (needs to match the CHATBOT_API_KEY in the .env in the chatbot repo)
+CHATBOT_API_KEY=ForIBecomeBrokeFinancerOfOpenAICalls
 
 BASE_BACKUP_COMMAND='docker exec -u postgres helpme-postgresql-1 pg_dumpall -U postgres | gzip >'
+

--- a/packages/server/.env.docker
+++ b/packages/server/.env.docker
@@ -20,3 +20,4 @@ SENTRY_AUTH_TOKEN=
 SENTRY_ORG=
 SENTRY_PROJECT=
 
+# this is outdate, use .env.development.local instead

--- a/packages/server/src/chatbot/chatbot-api.service.ts
+++ b/packages/server/src/chatbot/chatbot-api.service.ts
@@ -1,0 +1,254 @@
+import {
+  AddChatbotQuestionParams,
+  ChatbotSettingsMetadata,
+  UpdateDocumentChunkParams,
+  AddDocumentChunkParams,
+  ChatbotQuestionResponseChatbotDB,
+  UpdateChatbotQuestionParams,
+} from '@koh/common';
+import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+/* This is a list of all endpoints from the chatbot repo.
+    We now put this calls on the backend rather than the frontend so that 
+    we can properly guard our endpoints (e.g. to stop students from uploading documents to any course).
+    The chatbot repo requires both a user token (holds how many questions they've used)
+    and an API key (so that only this helpme repo can call those endpoints).
+    Whatever you set CHATBOT_API_KEY to (in your .env file), make sure it matches
+    the CHATBOT_API_KEY in the chatbot repo.
+*/
+export class ChatbotApiService {
+  private readonly chatbotApiUrl: string;
+  private readonly chatbotApiKey: string;
+
+  constructor(private configService: ConfigService) {
+    // this.chatbotApiUrl = this.configService.get<string>('CHATBOT_API_URL');
+    this.chatbotApiUrl = 'http://localhost:3003/chat';
+    this.chatbotApiKey = this.configService.get<string>('CHATBOT_API_KEY');
+  }
+
+  /**
+   * Makes an authenticated request to the chatbot service
+   * @param method HTTP method
+   * @param endpoint Endpoint path (without leading slash)
+   * @param data Request body data
+   * @param params Query parameters
+   * @param userToken user's API token for user-specific endpoints
+   * @returns Response from the chatbot service
+   */
+  private async request(
+    method: 'GET' | 'POST' | 'PATCH' | 'DELETE',
+    endpoint: string,
+    courseId: number,
+    userToken: string,
+    data?: any,
+    params?: any,
+  ) {
+    try {
+      const url = new URL(`${this.chatbotApiUrl}/${courseId}/${endpoint}`);
+      if (params) {
+        Object.entries(params).forEach(([key, value]) => {
+          url.searchParams.append(key, String(value));
+        });
+      }
+
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        'HMS-API-KEY': this.chatbotApiKey,
+        HMS_API_TOKEN: userToken,
+      };
+
+      const response = await fetch(url, {
+        method,
+        headers,
+        body: data ? JSON.stringify(data) : undefined,
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new HttpException(
+          error.error || 'Error from chatbot service',
+          response.status,
+        );
+      }
+
+      return await response.json();
+    } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      throw new HttpException(
+        'Failed to connect to chatbot service',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  // Question endpoints
+  async askQuestion(
+    question: string,
+    history: any,
+    userToken: string,
+    courseId: number,
+  ) {
+    return this.request('POST', 'ask', courseId, userToken, {
+      question,
+      history,
+    });
+  }
+
+  async getAllQuestions(courseId: number, userToken: string) {
+    return this.request('GET', 'allQuestions', courseId, userToken);
+  }
+
+  async getSuggestedQuestions(courseId: number, userToken: string) {
+    return this.request('GET', 'allSuggestedQuestions', courseId, userToken);
+  }
+
+  async addQuestion(
+    questionData: AddChatbotQuestionParams,
+    courseId: number,
+    userToken: string,
+  ) {
+    return this.request('POST', 'question', courseId, userToken, questionData);
+  }
+
+  async updateQuestion(
+    questionData: UpdateChatbotQuestionParams,
+    courseId: number,
+    userToken: string,
+  ): Promise<ChatbotQuestionResponseChatbotDB> {
+    return this.request('PATCH', 'question', courseId, userToken, questionData);
+  }
+
+  async deleteQuestion(id: string, courseId: number, userToken: string) {
+    return this.request('DELETE', `question/${id}`, courseId, userToken);
+  }
+
+  async deleteAllQuestions(courseId: number, userToken: string) {
+    // Unused
+    return this.request('DELETE', 'deleteAllQuestions', courseId, userToken);
+  }
+
+  // Chatbot settings endpoints
+  async getChatbotSettings(courseId: number, userToken: string) {
+    return this.request('GET', 'oneChatbotSetting', courseId, userToken);
+  }
+
+  async updateChatbotSettings(
+    settings: ChatbotSettingsMetadata,
+    courseId: number,
+    userToken: string,
+  ) {
+    return this.request(
+      'PATCH',
+      'updateChatbotSetting',
+      courseId,
+      userToken,
+      settings,
+    );
+  }
+
+  async resetChatbotSettings(courseId: number, userToken: string) {
+    return this.request('PATCH', 'resetChatbotSetting', courseId, userToken);
+  }
+
+  async resetCourse(courseId: number, userToken: string) {
+    // apparently resets all chatbot data for the course. Unused right now
+    return this.request('GET', 'resetCourse', courseId, userToken);
+  }
+
+  // Document endpoints
+  async getAllAggregateDocuments(courseId: number, userToken: string) {
+    return this.request('GET', 'aggregateDocuments', courseId, userToken);
+  }
+
+  async getAllDocumentChunks(courseId: number, userToken: string) {
+    return this.request('GET', 'allDocumentChunks', courseId, userToken);
+  }
+
+  async addDocumentChunk(
+    body: AddDocumentChunkParams,
+    courseId: number,
+    userToken: string,
+  ) {
+    return this.request('POST', 'documentChunk', courseId, userToken, body);
+  }
+
+  async updateDocumentChunk(
+    docId: string,
+    body: UpdateDocumentChunkParams,
+    courseId: number,
+    userToken: string,
+  ) {
+    return this.request(
+      'PATCH',
+      `${docId}/documentChunk`,
+      courseId,
+      userToken,
+      body,
+    );
+  }
+
+  async deleteDocumentChunk(
+    docId: string,
+    courseId: number,
+    userToken: string,
+  ) {
+    return this.request(
+      'DELETE',
+      `documentChunk/${docId}`,
+      courseId,
+      userToken,
+    );
+  }
+
+  async deleteDocument(docId: string, courseId: number, userToken: string) {
+    return this.request('DELETE', `${docId}/document`, courseId, userToken);
+  }
+
+  async uploadDocument(
+    file: Express.Multer.File,
+    source: string,
+    parseAsPng: boolean,
+    courseId: number,
+    userToken: string,
+  ) {
+    try {
+      // re-upload the file to the chatbot server while the file is still in memory here
+      const formData = new FormData();
+      formData.append('file', new Blob([file.buffer]), file.originalname);
+
+      // Create a blob with source and parseAsPng
+      const jsonData = {
+        source: source,
+        parseAsPng: parseAsPng,
+      };
+      formData.append(
+        'source',
+        new Blob([JSON.stringify(jsonData)], { type: 'application/json' }),
+      );
+
+      return this.request('POST', 'document', courseId, userToken, formData);
+    } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      throw new HttpException(
+        'Failed to upload document',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  async addDocumentFromGithub(
+    url: string,
+    courseId: number,
+    userToken: string,
+  ) {
+    return this.request('POST', 'document/url/github', courseId, userToken, {
+      url,
+    });
+  }
+}

--- a/packages/server/src/chatbot/chatbot.controller.ts
+++ b/packages/server/src/chatbot/chatbot.controller.ts
@@ -16,7 +16,6 @@ import {
 } from '@nestjs/common';
 import { ChatbotService } from './chatbot.service';
 import { JwtAuthGuard } from '../guards/jwt-auth.guard';
-import { ChatbotQuestionModel } from './question.entity';
 import { EmailVerifiedGuard } from 'guards/email-verified.guard';
 import {
   ChatbotAskResponse,
@@ -32,7 +31,6 @@ import {
   InteractionResponse,
   AddDocumentChunkParams,
   ChatbotQuestionResponseChatbotDB,
-  UpdateQuestionParams,
   UpdateChatbotQuestionParams,
 } from '@koh/common';
 import { CourseRolesGuard } from 'guards/course-roles.guard';
@@ -148,13 +146,13 @@ export class ChatbotController {
     );
   }
 
-  @Patch('question/:courseId/:questionId')
+  @Patch('questionScore/:courseId/:questionId')
   @UseGuards(CourseRolesGuard)
   @Roles(Role.PROFESSOR, Role.TA, Role.STUDENT)
   async updateChatbotUserScore(
     @Param('courseId', ParseIntPipe) courseId: number,
     @Param('questionId') questionId: number, // helpme question id
-    @Body() userScore: number,
+    @Body() { userScore }: { userScore: number },
   ) {
     return await this.chatbotService.updateQuestionUserScore(
       questionId,

--- a/packages/server/src/chatbot/chatbot.controller.ts
+++ b/packages/server/src/chatbot/chatbot.controller.ts
@@ -40,6 +40,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import { UserModel } from '../profile/user.entity';
 import { User, UserId } from '../decorators/user.decorator';
 import * as Sentry from '@sentry/nestjs';
+import { CourseRolesBypassHelpMeCourseGuard } from 'guards/course-roles-helpme-bypass.guard';
 
 @Controller('chatbot')
 @UseGuards(JwtAuthGuard, EmailVerifiedGuard)
@@ -53,7 +54,7 @@ export class ChatbotController {
   // Endpoints for both students and staff
   //
   @Post('ask/:courseId')
-  @UseGuards(CourseRolesGuard)
+  @UseGuards(CourseRolesBypassHelpMeCourseGuard)
   @Roles(Role.STUDENT, Role.TA, Role.PROFESSOR)
   async askQuestion(
     @Param('courseId', ParseIntPipe) courseId: number,
@@ -104,7 +105,7 @@ export class ChatbotController {
   }
 
   @Post('askSuggested/:courseId')
-  @UseGuards(CourseRolesGuard)
+  @UseGuards(CourseRolesBypassHelpMeCourseGuard)
   @Roles(Role.STUDENT, Role.TA, Role.PROFESSOR)
   async askSuggestedQuestion(
     @Param('courseId', ParseIntPipe) courseId: number,
@@ -133,8 +134,8 @@ export class ChatbotController {
   }
 
   @Get('question/suggested/:courseId')
-  @UseGuards(CourseRolesGuard)
-  @Roles(Role.PROFESSOR, Role.TA)
+  @UseGuards(CourseRolesBypassHelpMeCourseGuard)
+  @Roles(Role.PROFESSOR, Role.TA, Role.STUDENT)
   async getSuggestedQuestions(
     @Param('courseId', ParseIntPipe) courseId: number,
     @User(['chat_token']) user: UserModel,
@@ -147,7 +148,7 @@ export class ChatbotController {
   }
 
   @Patch('questionScore/:courseId/:questionId')
-  @UseGuards(CourseRolesGuard)
+  @UseGuards(CourseRolesBypassHelpMeCourseGuard)
   @Roles(Role.PROFESSOR, Role.TA, Role.STUDENT)
   async updateChatbotUserScore(
     @Param('courseId', ParseIntPipe) courseId: number,

--- a/packages/server/src/chatbot/chatbot.controller.ts
+++ b/packages/server/src/chatbot/chatbot.controller.ts
@@ -8,61 +8,448 @@ import {
   Get,
   Param,
   ParseIntPipe,
+  UploadedFile,
+  UseInterceptors,
+  BadRequestException,
+  HttpException,
+  HttpStatus,
 } from '@nestjs/common';
 import { ChatbotService } from './chatbot.service';
 import { JwtAuthGuard } from '../guards/jwt-auth.guard';
 import { ChatbotQuestionModel } from './question.entity';
 import { EmailVerifiedGuard } from 'guards/email-verified.guard';
 import {
-  ChatbotQuestion,
+  ChatbotAskResponse,
+  ChatbotQuestionResponseHelpMeDB,
+  ChatbotSettings,
+  ChatbotSettingsMetadata,
   GetInteractionsAndQuestionsResponse,
-  InteractionParams,
   Role,
+  AddChatbotQuestionParams,
+  ChatbotAskParams,
+  ChatbotAskSuggestedParams,
+  UpdateDocumentChunkParams,
+  InteractionResponse,
+  AddDocumentChunkParams,
+  ChatbotQuestionResponseChatbotDB,
+  UpdateQuestionParams,
+  UpdateChatbotQuestionParams,
 } from '@koh/common';
-import { InteractionModel } from './interaction.entity';
 import { CourseRolesGuard } from 'guards/course-roles.guard';
 import { Roles } from 'decorators/roles.decorator';
+import { ChatbotApiService } from './chatbot-api.service';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { UserModel } from '../profile/user.entity';
+import { User, UserId } from '../decorators/user.decorator';
+import * as Sentry from '@sentry/nestjs';
 
 @Controller('chatbot')
 @UseGuards(JwtAuthGuard, EmailVerifiedGuard)
 export class ChatbotController {
-  constructor(private readonly ChatbotService: ChatbotService) {}
-  @Post('interaction')
-  async addInteraction(
-    @Body() body: InteractionParams,
-  ): Promise<InteractionModel> {
-    return await this.ChatbotService.createInteraction(body);
-  }
+  constructor(
+    private readonly chatbotService: ChatbotService,
+    private readonly chatbotApiService: ChatbotApiService,
+  ) {}
 
-  @Post('question')
-  async addQuestion(
-    @Body() body: ChatbotQuestion,
-  ): Promise<ChatbotQuestionModel> {
-    return await this.ChatbotService.createQuestion(body);
-  }
-
-  @Patch('question')
-  async editQuestion(
-    @Body()
-    body: ChatbotQuestion,
-  ) {
-    return await this.ChatbotService.editQuestion(body);
-  }
-
-  // unused
-  // @Delete('question')
-  // async deleteQuestion(@Body() body: { questionId: number }) {
-  //   return await this.ChatbotService.deleteQuestion(body.questionId);
-  // }
-
-  @Get('questions/:courseId')
+  //
+  // Endpoints for both students and staff
+  //
+  @Post('ask/:courseId')
   @UseGuards(CourseRolesGuard)
-  @Roles(Role.TA, Role.PROFESSOR)
+  @Roles(Role.STUDENT, Role.TA, Role.PROFESSOR)
+  async askQuestion(
+    @Param('courseId', ParseIntPipe) courseId: number,
+    @Body()
+    { question, history, interactionId, onlySaveInChatbotDB }: ChatbotAskParams,
+    @User(['chat_token']) user: UserModel,
+  ): Promise<ChatbotAskResponse> {
+    handleChatbotTokenCheck(user);
+
+    const ChatbotDBResponse = await this.chatbotApiService.askQuestion(
+      question,
+      history,
+      user.chat_token.token,
+      courseId,
+    );
+
+    if (!onlySaveInChatbotDB) {
+      // if there's no interactionId (it's the first question), create a new interaction
+      if (!interactionId) {
+        const interaction = await this.chatbotService.createInteraction(
+          courseId,
+          user.id,
+        );
+        interactionId = interaction.id;
+      }
+      const HelpMeDBResponse = await this.chatbotService.createQuestion({
+        questionText: question,
+        responseText: ChatbotDBResponse.answer,
+        vectorStoreId: ChatbotDBResponse.questionId,
+        suggested: false,
+        isPreviousQuestion: ChatbotDBResponse.isPreviousQuestion ?? false,
+        interactionId: interactionId,
+      });
+
+      return {
+        chatbotRepoVersion: ChatbotDBResponse,
+        helpmeRepoVersion: {
+          ...HelpMeDBResponse,
+          interactionId: interactionId,
+        },
+      };
+    } else {
+      return {
+        chatbotRepoVersion: ChatbotDBResponse,
+        helpmeRepoVersion: null,
+      };
+    }
+  }
+
+  @Post('askSuggested/:courseId')
+  @UseGuards(CourseRolesGuard)
+  @Roles(Role.STUDENT, Role.TA, Role.PROFESSOR)
+  async askSuggestedQuestion(
+    @Param('courseId', ParseIntPipe) courseId: number,
+    @Body()
+    { question, responseText, vectorStoreId }: ChatbotAskSuggestedParams,
+    @UserId() userId: number, // this is the only chatbot endpoint that doesn't need the chat token since it doesn't require contacting the chatbot repo
+  ): Promise<ChatbotQuestionResponseHelpMeDB> {
+    const interaction = await this.chatbotService.createInteraction(
+      courseId,
+      userId,
+    );
+
+    const HelpMeDBResponse = await this.chatbotService.createQuestion({
+      questionText: question,
+      responseText: responseText,
+      vectorStoreId: vectorStoreId,
+      suggested: true,
+      isPreviousQuestion: true,
+      interactionId: interaction.id,
+    });
+
+    return {
+      ...HelpMeDBResponse,
+      interactionId: interaction.id,
+    };
+  }
+
+  @Get('question/suggested/:courseId')
+  @UseGuards(CourseRolesGuard)
+  @Roles(Role.PROFESSOR, Role.TA)
+  async getSuggestedQuestions(
+    @Param('courseId', ParseIntPipe) courseId: number,
+    @User(['chat_token']) user: UserModel,
+  ) {
+    handleChatbotTokenCheck(user);
+    return await this.chatbotApiService.getSuggestedQuestions(
+      courseId,
+      user.chat_token.token,
+    );
+  }
+
+  @Patch('question/:courseId/:questionId')
+  @UseGuards(CourseRolesGuard)
+  @Roles(Role.PROFESSOR, Role.TA, Role.STUDENT)
+  async updateChatbotUserScore(
+    @Param('courseId', ParseIntPipe) courseId: number,
+    @Param('questionId') questionId: number, // helpme question id
+    @Body() userScore: number,
+  ) {
+    return await this.chatbotService.updateQuestionUserScore(
+      questionId,
+      userScore,
+    );
+  }
+
+  //
+  // Endpoints for Staff-only
+  //
+
+  // Settings endpoints
+  @Get('settings/:courseId')
+  @UseGuards(CourseRolesGuard)
+  @Roles(Role.PROFESSOR, Role.TA)
+  async getChatbotSettings(
+    @Param('courseId', ParseIntPipe) courseId: number,
+    @User(['chat_token']) user: UserModel,
+  ): Promise<ChatbotSettings> {
+    handleChatbotTokenCheck(user);
+    return await this.chatbotApiService.getChatbotSettings(
+      courseId,
+      user.chat_token.token,
+    );
+  }
+
+  @Patch('settings/:courseId')
+  @UseGuards(CourseRolesGuard)
+  @Roles(Role.PROFESSOR, Role.TA)
+  async updateChatbotSettings(
+    @Param('courseId', ParseIntPipe) courseId: number,
+    @Body() settings: ChatbotSettingsMetadata,
+    @User(['chat_token']) user: UserModel,
+  ) {
+    handleChatbotTokenCheck(user);
+    return await this.chatbotApiService.updateChatbotSettings(
+      settings,
+      courseId,
+      user.chat_token.token,
+    );
+  }
+
+  @Patch('settings/:courseId/reset')
+  @UseGuards(CourseRolesGuard)
+  @Roles(Role.PROFESSOR, Role.TA)
+  async resetChatbotSettings(
+    @Param('courseId', ParseIntPipe) courseId: number,
+    @User(['chat_token']) user: UserModel,
+  ) {
+    handleChatbotTokenCheck(user);
+    return await this.chatbotApiService.resetChatbotSettings(
+      courseId,
+      user.chat_token.token,
+    );
+  }
+
+  // Question endpoints
+  @Get('question/all/:courseId')
+  @UseGuards(CourseRolesGuard)
+  @Roles(Role.PROFESSOR, Role.TA)
   async getInteractionsAndQuestions(
     @Param('courseId', ParseIntPipe) courseId: number,
+    @User(['chat_token']) user: UserModel,
   ): Promise<GetInteractionsAndQuestionsResponse> {
-    const interactions =
-      await this.ChatbotService.getInteractionsAndQuestions(courseId);
-    return interactions as unknown as GetInteractionsAndQuestionsResponse;
+    handleChatbotTokenCheck(user);
+    // Fire off both requests simultaneously.
+    const [interactions, allChatbotDBQuestions] = await Promise.all([
+      this.chatbotService.getInteractionsAndQuestions(courseId), // helpme db
+      this.chatbotApiService.getAllQuestions(courseId, user.chat_token.token), // chatbot db
+    ]);
+    return {
+      helpmeDB: interactions as unknown as InteractionResponse[], // interactions is of type InteractionModel[] which is basically the same
+      chatbotDB: allChatbotDBQuestions,
+    };
+  }
+
+  @Post('question/:courseId')
+  @UseGuards(CourseRolesGuard)
+  @Roles(Role.PROFESSOR, Role.TA)
+  async addChatbotQuestion(
+    @Param('courseId', ParseIntPipe) courseId: number,
+    @Body() questionData: AddChatbotQuestionParams,
+    @User(['chat_token']) user: UserModel,
+  ) {
+    handleChatbotTokenCheck(user);
+    // NOTE that this endpoint does NOT add the question to the helpme database
+    // (since the helpme database only hold questions that were actually asked)
+    return await this.chatbotApiService.addQuestion(
+      questionData,
+      courseId,
+      user.chat_token.token,
+    );
+  }
+
+  @Patch('question/:courseId')
+  @UseGuards(CourseRolesGuard)
+  @Roles(Role.PROFESSOR, Role.TA)
+  async updateChatbotQuestion(
+    @Param('courseId', ParseIntPipe) courseId: number,
+    @Body() questionData: UpdateChatbotQuestionParams,
+    @User(['chat_token']) user: UserModel,
+  ): Promise<ChatbotQuestionResponseChatbotDB> {
+    handleChatbotTokenCheck(user);
+    return await this.chatbotApiService.updateQuestion(
+      questionData,
+      courseId,
+      user.chat_token.token,
+    );
+  }
+
+  @Delete('question/:courseId/:questionId')
+  @UseGuards(CourseRolesGuard)
+  @Roles(Role.PROFESSOR, Role.TA)
+  async deleteChatbotQuestion(
+    @Param('courseId', ParseIntPipe) courseId: number,
+    @Param('questionId') questionId: string,
+    @User(['chat_token']) user: UserModel,
+  ) {
+    handleChatbotTokenCheck(user);
+    return await this.chatbotApiService.deleteQuestion(
+      questionId,
+      courseId,
+      user.chat_token.token,
+    );
+  }
+
+  // Unused
+  // @Delete('question/all/:courseId')
+  // @UseGuards(CourseRolesGuard)
+  // @Roles(Role.PROFESSOR, Role.TA)
+  // async deleteAllQuestions(
+  //   @Param('courseId', ParseIntPipe) courseId: number,
+  //   @User(['chat_token']) user: UserModel,
+  // ) {
+  //   handleChatbotTokenCheck(user);
+  //   return await this.chatbotApiService.deleteAllQuestions(courseId, user.chat_token.token);
+  // }
+
+  // resets all chatbot data for the course. Unused
+  // @Get('resetCourse/:courseId')
+  // @UseGuards(CourseRolesGuard)
+  // @Roles(Role.PROFESSOR, Role.TA)
+  // async resetCourse(
+  //   @Param('courseId', ParseIntPipe) courseId: number,
+  //   @User(['chat_token']) user: UserModel,
+  // ) {
+  //   handleChatbotTokenCheck(user)
+  //   return await this.chatbotApiService.resetCourse(courseId, user.chat_token.token);
+  // }
+
+  // Document endpoints
+  @Get('aggregateDocuments/:courseId')
+  @UseGuards(CourseRolesGuard)
+  @Roles(Role.PROFESSOR, Role.TA)
+  async getAllAggregateDocuments(
+    @Param('courseId', ParseIntPipe) courseId: number,
+    @User(['chat_token']) user: UserModel,
+  ) {
+    handleChatbotTokenCheck(user);
+    // this gets the full chatbot documents (rather than just the chunks)
+    return await this.chatbotApiService.getAllAggregateDocuments(
+      courseId,
+      user.chat_token.token,
+    );
+  }
+
+  @Get('documentChunks/:courseId')
+  @UseGuards(CourseRolesGuard)
+  @Roles(Role.PROFESSOR, Role.TA)
+  async getAllDocumentChunks(
+    @Param('courseId', ParseIntPipe) courseId: number,
+    @User(['chat_token']) user: UserModel,
+  ) {
+    handleChatbotTokenCheck(user);
+    return await this.chatbotApiService.getAllDocumentChunks(
+      courseId,
+      user.chat_token.token,
+    );
+  }
+
+  @Post('documentChunks/:courseId')
+  @UseGuards(CourseRolesGuard)
+  @Roles(Role.PROFESSOR, Role.TA)
+  async addDocumentChunk(
+    @Param('courseId', ParseIntPipe) courseId: number,
+    @Body() body: AddDocumentChunkParams,
+    @User(['chat_token']) user: UserModel,
+  ) {
+    handleChatbotTokenCheck(user);
+    return await this.chatbotApiService.addDocumentChunk(
+      body,
+      courseId,
+      user.chat_token.token,
+    );
+  }
+
+  @Patch('documentChunks/:courseId/:docId')
+  @UseGuards(CourseRolesGuard)
+  @Roles(Role.PROFESSOR, Role.TA)
+  async updateDocumentChunk(
+    @Param('courseId', ParseIntPipe) courseId: number,
+    @Param('docId') docId: string,
+    @Body() body: UpdateDocumentChunkParams,
+    @User(['chat_token']) user: UserModel,
+  ) {
+    handleChatbotTokenCheck(user);
+    return await this.chatbotApiService.updateDocumentChunk(
+      docId,
+      body,
+      courseId,
+      user.chat_token.token,
+    );
+  }
+
+  @Delete('documentChunks/:courseId/:docId')
+  @UseGuards(CourseRolesGuard)
+  @Roles(Role.PROFESSOR, Role.TA)
+  async deleteDocumentChunk(
+    @Param('courseId', ParseIntPipe) courseId: number,
+    @Param('docId') docId: string,
+    @User(['chat_token']) user: UserModel,
+  ) {
+    handleChatbotTokenCheck(user);
+    return await this.chatbotApiService.deleteDocumentChunk(
+      docId,
+      courseId,
+      user.chat_token.token,
+    );
+  }
+
+  @Delete('documents/:courseId/:docId')
+  @UseGuards(CourseRolesGuard)
+  @Roles(Role.PROFESSOR, Role.TA)
+  async deleteDocument(
+    @Param('courseId', ParseIntPipe) courseId: number,
+    @Param('docId') docId: string,
+    @User(['chat_token']) user: UserModel,
+  ) {
+    handleChatbotTokenCheck(user);
+    return await this.chatbotApiService.deleteDocument(
+      docId,
+      courseId,
+      user.chat_token.token,
+    );
+  }
+
+  @Post('documents/:courseId/upload')
+  @UseGuards(CourseRolesGuard)
+  @Roles(Role.PROFESSOR, Role.TA)
+  @UseInterceptors(
+    FileInterceptor('file', {
+      limits: {
+        fileSize: 1024 * 1024 * 80, // 80MB
+      },
+    }),
+  )
+  async uploadDocument(
+    @Param('courseId', ParseIntPipe) courseId: number,
+    @UploadedFile() file: Express.Multer.File,
+    @Body() { source, parseAsPng }: { source: string; parseAsPng: boolean },
+    @User(['chat_token']) user: UserModel,
+  ) {
+    handleChatbotTokenCheck(user);
+    if (!file) {
+      throw new BadRequestException('No file uploaded');
+    }
+    return await this.chatbotApiService.uploadDocument(
+      file,
+      source,
+      parseAsPng,
+      courseId,
+      user.chat_token.token,
+    );
+  }
+
+  @Post('documents/:courseId/github')
+  @UseGuards(CourseRolesGuard)
+  @Roles(Role.PROFESSOR, Role.TA)
+  async addDocumentFromGithub(
+    @Param('courseId', ParseIntPipe) courseId: number,
+    @Body() { url }: { url: string },
+    @User(['chat_token']) user: UserModel,
+  ) {
+    handleChatbotTokenCheck(user);
+    return await this.chatbotApiService.addDocumentFromGithub(
+      url,
+      courseId,
+      user.chat_token.token,
+    );
+  }
+}
+
+function handleChatbotTokenCheck(user: UserModel) {
+  if (!user.chat_token) {
+    Sentry.captureMessage('User has no chat token: ' + user.id);
+    throw new HttpException('User has no chat token', HttpStatus.FORBIDDEN);
   }
 }

--- a/packages/server/src/chatbot/chatbot.module.ts
+++ b/packages/server/src/chatbot/chatbot.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ChatbotService } from './chatbot.service';
 import { ChatbotController } from './chatbot.controller';
+import { ChatbotApiService } from './chatbot-api.service';
 
 @Module({
   controllers: [ChatbotController],
-  providers: [ChatbotService],
+  providers: [ChatbotService, ChatbotApiService],
 })
 export class ChatbotModule {}

--- a/packages/server/src/chatbot/chatbot.service.spec.ts
+++ b/packages/server/src/chatbot/chatbot.service.spec.ts
@@ -7,7 +7,6 @@ import {
   CourseFactory,
   InteractionFactory,
 } from '../../test/util/factories';
-import { ChatbotQuestion } from '@koh/common';
 import { ChatbotQuestionModel } from './question.entity';
 
 describe('ChatbotService', () => {
@@ -25,9 +24,9 @@ describe('ChatbotService', () => {
   });
   describe('createInteraction', () => {
     it('should throw an error if course is not found', async () => {
-      await expect(
-        service.createInteraction({ courseId: 0, userId: 1 }),
-      ).rejects.toThrow('Course not found based on the provided ID.');
+      await expect(service.createInteraction(0, 1)).rejects.toThrow(
+        'Course not found based on the provided ID.',
+      );
     });
 
     it('should create an interaction', async () => {
@@ -46,12 +45,12 @@ describe('ChatbotService', () => {
   describe('createQuestion', () => {
     it('should create a question with valid properties', async () => {
       const interaction = await InteractionFactory.create();
-      const questionParams: ChatbotQuestion = {
+      const questionParams = {
         interactionId: interaction.id,
         questionText: "What's the meaning of life?",
         responseText: "It's a philosophical question.",
         suggested: true,
-        userScore: 5,
+        isPreviousQuestion: false,
         vectorStoreId: '1',
       };
       const createdQuestion = await service.createQuestion(questionParams);
@@ -73,16 +72,15 @@ describe('ChatbotService', () => {
         interactionId: interaction.id,
         questionText: 'Original question',
         responseText: 'Original response',
-        userScore: 3,
         suggested: true,
         vectorStoreId: '1',
+        isPreviousQuestion: false,
       });
 
-      const updatedQuestionData: ChatbotQuestion = {
+      const updatedQuestionData = {
         id: originalQuestion.id,
         questionText: 'Updated question',
         responseText: 'Updated response',
-        userScore: 5,
         suggested: false,
         isPreviousQuestion: true,
         vectorStoreId: '2',
@@ -98,7 +96,6 @@ describe('ChatbotService', () => {
       expect(updatedQuestion.responseText).toEqual(
         updatedQuestionData.responseText,
       );
-      expect(updatedQuestion.userScore).toEqual(updatedQuestionData.userScore);
       expect(updatedQuestion.suggested).toEqual(updatedQuestionData.suggested);
       expect(updatedQuestion.isPreviousQuestion).toEqual(
         updatedQuestionData.isPreviousQuestion,
@@ -114,15 +111,14 @@ describe('ChatbotService', () => {
         interactionId: interaction.id,
         questionText: 'Original question',
         responseText: 'Original response',
-        userScore: 3,
         suggested: true,
         vectorStoreId: '1',
+        isPreviousQuestion: false,
       });
 
-      const updatedQuestionData: ChatbotQuestion = {
+      const updatedQuestionData = {
         id: originalQuestion.id,
         questionText: 'Updated question',
-        userScore: 4,
       };
 
       const updatedQuestion = await service.editQuestion(updatedQuestionData);
@@ -135,7 +131,6 @@ describe('ChatbotService', () => {
       expect(updatedQuestion.responseText).toEqual(
         originalQuestion.responseText,
       );
-      expect(updatedQuestion.userScore).toEqual(updatedQuestionData.userScore);
       expect(updatedQuestion.suggested).toEqual(originalQuestion.suggested);
       expect(updatedQuestion.vectorStoreId).toEqual(
         originalQuestion.vectorStoreId,
@@ -150,13 +145,13 @@ describe('ChatbotService', () => {
         vectorStoreId: '1',
         questionText: 'Original question',
         responseText: 'Original response',
-        userScore: 3,
+        suggested: true,
+        isPreviousQuestion: false,
       });
 
-      const updatedQuestionData: ChatbotQuestion = {
+      const updatedQuestionData = {
         id: originalQuestion.id,
         interactionId: interaction2.id,
-        userScore: 3,
       };
 
       await service.editQuestion(updatedQuestionData);

--- a/packages/server/src/chatbot/interaction.entity.ts
+++ b/packages/server/src/chatbot/interaction.entity.ts
@@ -11,6 +11,7 @@ import { CourseModel } from '../course/course.entity';
 import { UserModel } from '../profile/user.entity';
 import { ChatbotQuestionModel } from './question.entity';
 
+// A chatbot interaction is basically a conversation between a user and the chatbot.
 @Entity('chatbot_interactions_model')
 export class InteractionModel extends BaseEntity {
   @PrimaryGeneratedColumn()

--- a/packages/server/src/chatbot/question.entity.ts
+++ b/packages/server/src/chatbot/question.entity.ts
@@ -13,7 +13,7 @@ export class ChatbotQuestionModel extends BaseEntity {
   @PrimaryGeneratedColumn()
   public id: number;
 
-  @Column({ nullable: true })
+  @Column()
   vectorStoreId: string;
 
   @ManyToOne(() => InteractionModel)

--- a/packages/server/src/guards/course-roles-helpme-bypass.guard.ts
+++ b/packages/server/src/guards/course-roles-helpme-bypass.guard.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { RolesGuard } from './role.guard';
+import { UserModel } from '../profile/user.entity';
+import { Role } from '@koh/common';
+
+/* Functionally the same as CourseRolesGuard but will allow users 
+to access the course with id HELPME_COURSE_ID as a student */
+@Injectable()
+export class CourseRolesBypassHelpMeCourseGuard extends RolesGuard {
+  async setupData(
+    request: any,
+  ): Promise<{ courseId: number; user: UserModel }> {
+    const user = await UserModel.findOne(request.user.userId, {
+      relations: ['courses'],
+    });
+    const courseId =
+      request.params.id ??
+      request.params.courseId ??
+      request.params.cid ??
+      null;
+    // if it's the helpme course, edit user's course to be a student inside the helpme course (only if they aren't already in the course)
+    if (
+      courseId === process.env.HELPME_COURSE_ID &&
+      !user?.courses?.find((c) => c.courseId === courseId)
+    ) {
+      user.courses.push({
+        courseId,
+        role: Role.STUDENT,
+      });
+    }
+    return { courseId, user };
+  }
+}

--- a/packages/server/test/chatbot.integration.ts
+++ b/packages/server/test/chatbot.integration.ts
@@ -1,5 +1,5 @@
 import { ChatbotModule } from 'chatbot/chatbot.module';
-import { AddChatbotQuestionParams, Role } from '@koh/common';
+import { Role } from '@koh/common';
 import {
   InteractionFactory,
   UserFactory,
@@ -23,8 +23,8 @@ describe('ChatbotController Integration', () => {
       const interaction = await InteractionFactory.create({ user, course });
       const questionData = {
         vectorStoreId: '123',
-        question: 'How does photosynthesis work?',
-        answer: 'Photosynthesis is the process by which plants...',
+        questionText: 'How does photosynthesis work?',
+        responseText: 'Photosynthesis is the process by which plants...',
         verified: true,
         suggested: true,
         sourceDocuments: [],
@@ -66,8 +66,8 @@ describe('ChatbotController Integration', () => {
       const interaction = await InteractionFactory.create({ user, course });
       const questionData = {
         vectorStoreId: '123',
-        question: 'How does photosynthesis work?',
-        answer: 'Photosynthesis is the process by which plants...',
+        questionText: 'How does photosynthesis work?',
+        responseText: 'Photosynthesis is the process by which plants...',
         verified: true,
         suggested: true,
         sourceDocuments: [],

--- a/packages/server/test/chatbot.integration.ts
+++ b/packages/server/test/chatbot.integration.ts
@@ -94,7 +94,7 @@ describe('ChatbotController Integration', () => {
       const response = await supertest({ userId: user.id })
         .post(`/chatbot/askSuggested/${course.id}`)
         .send(body)
-        .expect(200);
+        .expect(201);
       expect(response.body.id).toBeDefined();
       expect(response.body.questionText).toEqual(body.question);
       expect(response.body.responseText).toEqual(body.responseText);

--- a/packages/server/test/chatbot.integration.ts
+++ b/packages/server/test/chatbot.integration.ts
@@ -22,6 +22,7 @@ describe('ChatbotController Integration', () => {
       });
       const interaction = await InteractionFactory.create({ user, course });
       const questionData = {
+        vectorStoreId: '123',
         question: 'How does photosynthesis work?',
         answer: 'Photosynthesis is the process by which plants...',
         verified: true,
@@ -42,7 +43,7 @@ describe('ChatbotController Integration', () => {
   });
 
   describe('GET /chatbot/questions/:courseId', () => {
-    it('should return 403 if user is not a TA or Professor', async () => {
+    it('should return 404 if user is not a TA or Professor', async () => {
       const user = await UserFactory.create();
       const course = await CourseFactory.create();
       await UserCourseFactory.create({
@@ -52,7 +53,7 @@ describe('ChatbotController Integration', () => {
       });
       await supertest({ userId: user.id })
         .get(`/chatbot/questions/${course.id}`)
-        .expect(403);
+        .expect(404);
     });
     it('should return questions for a course', async () => {
       const user = await UserFactory.create();
@@ -64,6 +65,7 @@ describe('ChatbotController Integration', () => {
       });
       const interaction = await InteractionFactory.create({ user, course });
       const questionData = {
+        vectorStoreId: '123',
         question: 'How does photosynthesis work?',
         answer: 'Photosynthesis is the process by which plants...',
         verified: true,

--- a/packages/server/test/chatbot.integration.ts
+++ b/packages/server/test/chatbot.integration.ts
@@ -42,7 +42,7 @@ describe('ChatbotController Integration', () => {
     });
   });
 
-  describe('GET /chatbot/questions/:courseId', () => {
+  describe('GET /chatbot/question/all/:courseId', () => {
     it('should return 404 if user is not a TA or Professor', async () => {
       const user = await UserFactory.create();
       const course = await CourseFactory.create();
@@ -52,7 +52,7 @@ describe('ChatbotController Integration', () => {
         role: Role.STUDENT,
       });
       await supertest({ userId: user.id })
-        .get(`/chatbot/questions/${course.id}`)
+        .get(`/chatbot/question/all/${course.id}`)
         .expect(404);
     });
     it('should return questions for a course', async () => {
@@ -75,7 +75,7 @@ describe('ChatbotController Integration', () => {
       };
       await ChatbotQuestionModel.create(questionData).save();
       await supertest({ userId: user.id })
-        .get(`/chatbot/questions/${course.id}`)
+        .get(`/chatbot/question/all/${course.id}`)
         .expect(200);
     });
   });


### PR DESCRIPTION
# Description

So the problem with the current token system is you just need to be logged in to get a token (and thus call any chatbot endpoint).
So, for example, i could just create an account (and never join any course) and then call the endpoints that delete all chatbot data for all of the courses (because that's an endpoint on the chatbot apparently lol).
So there are no role guards basically, nor any course guards (so i can access documents in questions in courses that i am not in).
So by adding a new chatbot api key (that only the backend of helpme has), users can't just call the chatbot endpoints directly, they have to go through the helpme system first (in which i can use CourseRolesGuard to protect the endpoints)

This also:
- Adjusts/adds more tooltips for helping users around the chatbot
- Cleaned up and consolidated a lot of chatbot types that should be a lot more accurate

Closes #252 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [x] This change requires an addition/change to the production .env variables. These changes are below:

In `/server/.env`:
```
# Needed to make requests to the chatbot service in chatbot repo (needs to match the CHATBOT_API_KEY in the .env in the chatbot repo)
CHATBOT_API_KEY=changemepls
# Change this to the courseId of your "HelpMe" course (used by chatbot when asking system questions)
HELPME_COURSE_ID = 34
```

In Chatbot Repo `.env`
```
# All requests made to the chatbot repo will need this API key (make sure it matches the CHATBOT_API_KEY in the .env in the helpme repo)
CHATBOT_API_KEY=changemepls
```

- [x] This change requires developers to add new .env variables. The file and variables needed are below:

In `/server/.env`:
```
# Needed to make requests to the chatbot service in chatbot repo (needs to match the CHATBOT_API_KEY in the .env in the chatbot repo)
CHATBOT_API_KEY=ForIBecomeBrokeFinancerOfOpenAICalls
# Change this to the courseId of your "HelpMe" course (used by chatbot when asking system questions)
HELPME_COURSE_ID = 
```

In Chatbot Repo `.env`
```
# All requests made to the chatbot repo will need this API key (make sure it matches the CHATBOT_API_KEY in the .env in the helpme repo)
CHATBOT_API_KEY=ForIBecomeBrokeFinancerOfOpenAICalls
```


- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

So I didn't add many integration tests for this since I basically would have to mock the chatbot api, which means the only things I would really be testing for is whether the guards are working. And tbh I want to gamble that spending the time to make a bunch of tests just to check the roles guard isn't going to save much maintenance time (if any time) in the future. And I'm very confident that I implemented the guard correctly on each of the endpoints since I have made various courseRolesGuards. Or in short, I guess ~~I'm just lazy~~ there's just a lot of work to be done and this is not a priority right now.

I did manually test each route though, and also tested if the CourseRolesGuard worked.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [ ] Any UI changes have been checked to work on desktop, tablet, and mobile
