### PR TITLE
fix(invite): add option to decline course invitation (#273)

### DIFF
--- a/packages/frontend/app/invite/components/InviteCard.tsx
+++ b/packages/frontend/app/invite/components/InviteCard.tsx
@@ -8,6 +8,8 @@ type InviteCardProps = {
   buttonAction: () => void
   description?: { title?: string; text?: string }
   cover?: ReactElement
+  secondaryButtonLabel?: string
+  secondaryButtonAction?: () => void
 }
 
 const InviteCard: React.FC<InviteCardProps> = ({
@@ -16,6 +18,8 @@ const InviteCard: React.FC<InviteCardProps> = ({
   buttonLabel,
   buttonAction,
   cover = undefined,
+  secondaryButtonLabel,
+  secondaryButtonAction,
 }) => {
   return (
     <Card style={{ maxWidth: '38rem', textAlign: 'center' }} cover={cover}>
@@ -32,6 +36,14 @@ const InviteCard: React.FC<InviteCardProps> = ({
         >
           {buttonLabel}
         </Button>
+        {secondaryButtonLabel && secondaryButtonAction && (
+          <Button
+            style={{ width: '100%', height: 50, borderRadius: '5px' }}
+            onClick={secondaryButtonAction}
+          >
+            {secondaryButtonLabel}
+          </Button>
+        )}
       </Space>
     </Card>
   )

--- a/packages/frontend/app/invite/page.tsx
+++ b/packages/frontend/app/invite/page.tsx
@@ -150,6 +150,10 @@ export default function CourseInvitePage(): ReactElement {
                 }
                 await addStudent(userData)
               }}
+              secondaryButtonLabel="Decline Invitation"
+              secondaryButtonAction={() => {
+                router.push('/courses')
+              }}
               cover={
                 <Image
                   alt="generic course image"


### PR DESCRIPTION
# Description

Fixes Issue #273
 
Adds a "Decline Invitation Button" to the invite page taking the user back to the `/courses` route.

Achieved by adding 2 optional (`secondaryButtonLabel` and `secondaryButtonAction`) props to the  `InviteCard` component which only renders if both the label and the action is provided.

No new dependencies required

Closes #273 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 

I logged in with an account with no courses and with the UBCO Organization, then went to `/invite?cid=37&code=invite-code` route on localhost, which is the invite link for CS 304 in the UBCO Org, then manually tested it.


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any work that this PR is dependent on has been merged into the main branch
- [x] Any UI changes have been checked to work on desktop, tablet, and mobile
