### PR TITLE
Issue #279. Chat token limit change on updating org level role.

### DIFF
--- a/packages/server/src/organization/organization.controller.ts
+++ b/packages/server/src/organization/organization.controller.ts
@@ -1051,7 +1051,22 @@ export class OrganizationController {
 
             await organizationUser
               .save()
-              .then((_) => {
+              .then(async (_) => {
+                const maxUses = [
+                  OrganizationRole.ADMIN,
+                  OrganizationRole.PROFESSOR,
+                ].includes(organizationUser.role)
+                  ? 300
+                  : 30;
+
+                await this.dataSource.query(
+                  `
+                UPDATE chat_token_model
+                SET max_uses = $1
+                WHERE "user" = $2
+                `,
+                  [maxUses, organizationUser.userId],
+                );
                 res.status(HttpStatus.OK).send({
                   message: 'Organization user role updated',
                 });


### PR DESCRIPTION
# Description

Resolves issue #279

It now also updates the chat token limits accordingly after updating the org level role for a user, i.e. immediately grants the 300/day limit to the org level prof when promoted, also if the user role is changed to member, then changes the limit to 30.

Closes #279

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

Manually tested it on the dev db, logged in from the admin account, navigated to the development tools page in organization settings and then tested by changing the roles of test students multiple times and then looked at the database being updated.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any work that this PR is dependent on has been merged into the main branch
- [ ] Any UI changes have been checked to work on desktop, tablet, and mobile
