### PR TITLE
Improve RedisProfile Cache Busting

### DIFF
--- a/docs/NEWDEVS_STARTHERE.md
+++ b/docs/NEWDEVS_STARTHERE.md
@@ -32,6 +32,7 @@
       - [Testing](#testing)
         - [What is mocking?](#what-is-mocking)
         - [To mock or not to mock?](#to-mock-or-not-to-mock)
+      - [Event Subscribers](#event-subscribers)
 - [History](#history)
 - [TODO](#todo)
   - [For the whole project](#for-the-whole-project)
@@ -412,6 +413,16 @@ In general, it is recommended to only mock if you absolutely have to. For exampl
 Another example where you might need to mock is if you are dealing with a technology/library that doesn't play nice with jest for whatever reason (e.g. maybe redis or cron).
 
 In general though, try not to mock (e.g. don't mock database calls/returns). This is because mocking eliminates one of the key benefits of testing: knowing what things break after a change (aka regression testing). If you mock someone else's function but then they change something about it (like its parameters), the tests may still pass even though they should have failed. Another example is when you update a package and they adjust their APIs or behaviour but since you mocked their functions the test still pass instead of failing.
+
+#### Event Subscribers
+
+Typeorm has `@EventSubscriber`, which allows you to define certain actions after/before an insert, update, or delete.
+
+Some examples of where this is used:
+- For busting (deleting) the redis profile cache whenever a relevant entity updates (e.g. when a new UserCourse entity is created from a student joining a course, we need to bust their profile cache so they can see the new course) 
+- For notifying and sending new queue question data to all users subscribed to queue Server Side Events (which happens automatically when you are viewing a queue page)
+
+See https://orkhan.gitbook.io/typeorm/docs/listeners-and-subscribers for more info
 
 # History
 

--- a/packages/server/src/course/course.controller.ts
+++ b/packages/server/src/course/course.controller.ts
@@ -68,7 +68,6 @@ import { QuestionTypeModel } from 'questionType/question-type.entity';
 import { QueueCleanService } from 'queue/queue-clean/queue-clean.service';
 import { CourseRole } from 'decorators/course-role.decorator';
 import { DataSource } from 'typeorm';
-import { RedisProfileService } from 'redisProfile/redis-profile.service';
 import { OrgOrCourseRolesGuard } from 'guards/org-or-course-roles.guard';
 import { CourseRoles } from 'decorators/course-roles.decorator';
 import { OrgRoles } from 'decorators/org-roles.decorator';
@@ -82,7 +81,6 @@ export class CourseController {
     private heatmapService: HeatmapService,
     private courseService: CourseService,
     private queueCleanService: QueueCleanService,
-    private redisProfileService: RedisProfileService,
     private readonly appConfig: ApplicationConfigService,
     private dataSource: DataSource,
   ) {}
@@ -262,29 +260,7 @@ export class CourseController {
     @Param('id', ParseIntPipe) courseId: number,
     @Body() coursePatch: EditCourseInfoParams,
   ): Promise<void> {
-    await this.courseService
-      .editCourse(courseId, coursePatch)
-      .then(async () => {
-        const course = await CourseModel.findOne({
-          where: {
-            id: courseId,
-          },
-          relations: {
-            userCourses: true,
-          },
-        });
-
-        // Won't be a costly operation since courses are not modified often
-        if (course) {
-          await Promise.all(
-            course.userCourses.map(async (userCourse) => {
-              await this.redisProfileService.deleteProfile(
-                `u:${userCourse.userId}`,
-              );
-            }),
-          );
-        }
-      });
+    await this.courseService.editCourse(courseId, coursePatch);
   }
 
   @Patch(':courseId/toggle_favourited')
@@ -306,8 +282,6 @@ export class CourseController {
 
       userCourse.favourited = !userCourse.favourited;
       userCourse.save();
-
-      await this.redisProfileService.deleteProfile(`u:${userId}`);
 
       return 'Course favourited status updated successfully';
     } catch (err) {
@@ -688,7 +662,6 @@ export class CourseController {
       where: { courseId, userId },
     });
     await this.courseService.removeUserFromCourse(userCourse);
-    await this.redisProfileService.deleteProfile(`u:${userId}`);
   }
 
   @Get(':id/ta_check_in_times')
@@ -795,8 +768,6 @@ export class CourseController {
         res.status(HttpStatus.BAD_REQUEST).send({ message: err.message });
       });
 
-    // Delete old cached record if changed
-    await this.redisProfileService.deleteProfile(`u:${user.id}`);
     return;
   }
 
@@ -891,11 +862,7 @@ export class CourseController {
     }
 
     try {
-      await UserCourseModel.update({ courseId, userId }, { role }).then(
-        async () => {
-          await this.redisProfileService.deleteProfile(`u:${userId}`);
-        },
-      );
+      await UserCourseModel.update({ courseId, userId }, { role });
     } catch (err) {
       res.status(HttpStatus.BAD_REQUEST).send({ message: err.message });
       return;

--- a/packages/server/src/course/course.module.ts
+++ b/packages/server/src/course/course.module.ts
@@ -14,6 +14,7 @@ import { ApplicationConfigModule } from '../config/application_config.module';
 import { RedisQueueModule } from '../redisQueue/redis-queue.module';
 import { MailModule } from 'mail/mail.module';
 import { ChatbotApiService } from 'chatbot/chatbot-api.service';
+import { CourseSubscriber } from './course.subscriber';
 @Module({
   controllers: [CourseController],
   imports: [
@@ -29,6 +30,7 @@ import { ChatbotApiService } from 'chatbot/chatbot-api.service';
     HeatmapService,
     CourseService,
     RedisQueueService,
+    CourseSubscriber,
     RedisProfileService,
     QueueCleanService,
     ApplicationConfigService,

--- a/packages/server/src/course/course.service.ts
+++ b/packages/server/src/course/course.service.ts
@@ -34,7 +34,6 @@ import { CourseModel } from './course.entity';
 import { UserModel } from 'profile/user.entity';
 import { QueueInviteModel } from 'queue/queue-invite.entity';
 import { UnreadAsyncQuestionModel } from 'asyncQuestion/unread-async-question.entity';
-import { RedisProfileService } from 'redisProfile/redis-profile.service';
 import { CourseSettingsModel } from './course_settings.entity';
 import { OrganizationUserModel } from 'organization/organization-user.entity';
 import { OrganizationCourseModel } from 'organization/organization-course.entity';
@@ -49,7 +48,6 @@ import { ChatbotDocPdfModel } from 'chatbot/chatbot-doc-pdf.entity';
 @Injectable()
 export class CourseService {
   constructor(
-    private readonly redisProfileService: RedisProfileService,
     private readonly mailService: MailService,
     private readonly chatbotApiService: ChatbotApiService,
     private readonly dataSource: DataSource,
@@ -140,7 +138,6 @@ export class CourseService {
         userId: userCourse.userId,
         courseId: userCourse.courseId,
       });
-      await this.redisProfileService.deleteProfile(`u:${userCourse.userId}`);
     } catch (err) {
       console.error(err);
       throw new HttpException(
@@ -353,8 +350,6 @@ export class CourseService {
       updatedUserCourse.push(userCourse);
       user.courses = updatedUserCourse;
       await user.save();
-
-      await this.redisProfileService.deleteProfile(`u:${user.id}`);
 
       return true;
     } catch {
@@ -579,8 +574,6 @@ export class CourseService {
           profUserCourse.course = clonedCourse;
           profUserCourse.role = Role.PROFESSOR;
           await manager.save(profUserCourse);
-          // delete that professor's cache from redis
-          await this.redisProfileService.deleteProfile(`u:${professor.id}`);
         }
       } else {
         console.error(
@@ -591,7 +584,6 @@ export class CourseService {
         profUserCourse.courseId = clonedCourse.id;
         profUserCourse.role = Role.PROFESSOR;
         await manager.save(profUserCourse);
-        await this.redisProfileService.deleteProfile(`u:${userId}`);
       }
 
       const organizationCourse = new OrganizationCourseModel();

--- a/packages/server/src/course/course.subscriber.ts
+++ b/packages/server/src/course/course.subscriber.ts
@@ -1,0 +1,63 @@
+import {
+  DataSource,
+  EntitySubscriberInterface,
+  EventSubscriber,
+  RemoveEvent,
+  UpdateEvent,
+} from 'typeorm';
+import { CourseModel } from './course.entity';
+import { UserCourseModel } from '../profile/user-course.entity';
+import { RedisProfileService } from 'redisProfile/redis-profile.service';
+
+@EventSubscriber()
+export class CourseSubscriber
+  implements EntitySubscriberInterface<CourseModel>
+{
+  constructor(
+    private readonly redisProfileService: RedisProfileService,
+    dataSource: DataSource,
+  ) {
+    dataSource.subscribers.push(this);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  listenTo() {
+    return CourseModel;
+  }
+
+  async afterUpdate(event: UpdateEvent<CourseModel>): Promise<void> {
+    // delete cached profiles for all users enrolled in this course
+    await this.invalidateUsersInCourse(event.entity.id);
+  }
+
+  async beforeRemove(event: RemoveEvent<CourseModel>): Promise<void> {
+    // due to cascades entity is not guaranteed to be loaded
+    if (!event.entity) {
+      return;
+    }
+
+    // delete cached profiles for all users enrolled in this course
+    await this.invalidateUsersInCourse(event.entity.id);
+  }
+
+  private async invalidateUsersInCourse(courseId: number): Promise<void> {
+    if (!courseId) {
+      return;
+    }
+
+    // Get all user IDs for users enrolled in this course
+    const userCourses = await UserCourseModel.find({
+      where: { courseId },
+      select: {
+        userId: true,
+      },
+    });
+
+    // Delete cached profiles for all users in this course
+    const deletePromises = userCourses.map((userCourse) =>
+      this.redisProfileService.deleteProfile(`u:${userCourse.userId}`),
+    );
+
+    await Promise.all(deletePromises);
+  }
+}

--- a/packages/server/src/notification/desktop-notif-subscriber.ts
+++ b/packages/server/src/notification/desktop-notif-subscriber.ts
@@ -35,10 +35,10 @@ export class DesktopNotifSubscriber
       event.entity,
       "You've successfully signed up for desktop notifications!",
     );
-    await this.redisProfileService.deleteProfile(`u:${event.entity.user.id}`);
+    await this.redisProfileService.deleteProfile(`u:${event.entity.userId}`);
   }
 
   async afterRemove(event: RemoveEvent<DesktopNotifModel>): Promise<void> {
-    await this.redisProfileService.deleteProfile(`u:${event.entity.user.id}`);
+    await this.redisProfileService.deleteProfile(`u:${event.entity.userId}`);
   }
 }

--- a/packages/server/src/notification/desktop-notif-subscriber.ts
+++ b/packages/server/src/notification/desktop-notif-subscriber.ts
@@ -3,10 +3,12 @@ import {
   EntitySubscriberInterface,
   EventSubscriber,
   InsertEvent,
+  RemoveEvent,
 } from 'typeorm';
 import { DesktopNotifModel } from './desktop-notif.entity';
 import { NotificationService } from './notification.service';
 import { InjectDataSource } from '@nestjs/typeorm';
+import { RedisProfileService } from 'redisProfile/redis-profile.service';
 
 @EventSubscriber()
 export class DesktopNotifSubscriber
@@ -17,6 +19,7 @@ export class DesktopNotifSubscriber
     @InjectDataSource()
     dataSource: DataSource,
     notifService: NotificationService,
+    private readonly redisProfileService: RedisProfileService,
   ) {
     this.notifService = notifService;
     dataSource.subscribers.push(this);
@@ -32,5 +35,10 @@ export class DesktopNotifSubscriber
       event.entity,
       "You've successfully signed up for desktop notifications!",
     );
+    await this.redisProfileService.deleteProfile(`u:${event.entity.user.id}`);
+  }
+
+  async afterRemove(event: RemoveEvent<DesktopNotifModel>): Promise<void> {
+    await this.redisProfileService.deleteProfile(`u:${event.entity.user.id}`);
   }
 }

--- a/packages/server/src/notification/notification.module.ts
+++ b/packages/server/src/notification/notification.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { DesktopNotifSubscriber } from './desktop-notif-subscriber';
 import { NotificationController } from './notification.controller';
 import { NotificationService } from './notification.service';
+import { RedisProfileService } from 'redisProfile/redis-profile.service';
 
 @Module({
   controllers: [NotificationController],
-  providers: [NotificationService, DesktopNotifSubscriber],
+  providers: [NotificationService, DesktopNotifSubscriber, RedisProfileService],
   exports: [NotificationService],
 })
 export class NotificationModule {}

--- a/packages/server/src/organization/organization-user.subscriber.ts
+++ b/packages/server/src/organization/organization-user.subscriber.ts
@@ -1,0 +1,86 @@
+import {
+  DataSource,
+  EntitySubscriberInterface,
+  EventSubscriber,
+  InsertEvent,
+  RemoveEvent,
+  UpdateEvent,
+} from 'typeorm';
+import { OrganizationUserModel } from './organization-user.entity';
+import { RedisProfileService } from 'redisProfile/redis-profile.service';
+
+@EventSubscriber()
+export class OrganizationUserSubscriber
+  implements EntitySubscriberInterface<OrganizationUserModel>
+{
+  constructor(
+    private readonly redisProfileService: RedisProfileService,
+    dataSource: DataSource,
+  ) {
+    dataSource.subscribers.push(this);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  listenTo() {
+    return OrganizationUserModel;
+  }
+
+  async afterInsert(event: InsertEvent<OrganizationUserModel>): Promise<void> {
+    // delete cached profile when user-organization relationship is created
+    await this.invalidateUserProfile(event.entity);
+  }
+
+  async afterUpdate(event: UpdateEvent<OrganizationUserModel>): Promise<void> {
+    // delete cached profile when user-organization relationship is updated
+
+    if (event.entity instanceof OrganizationUserModel) {
+      await this.invalidateUserProfile(event.entity);
+    } else {
+      const orgUser = await OrganizationUserModel.findOne({
+        where: { id: event.entity.id },
+      });
+      if (orgUser) {
+        await this.invalidateUserProfile(orgUser);
+      } else {
+        console.error(
+          'OrganizationUser failed to bust profile cache for event',
+          event,
+        );
+      }
+    }
+  }
+
+  async beforeRemove(event: RemoveEvent<OrganizationUserModel>): Promise<void> {
+    // due to cascades entity is not guaranteed to be loaded
+    if (!event.entity) {
+      return;
+    }
+
+    // delete cached profile when user-organization relationship is deleted
+    await this.invalidateUserProfile(event.entity);
+  }
+
+  private async invalidateUserProfile(
+    entity: OrganizationUserModel,
+  ): Promise<void> {
+    let userId: number;
+
+    if (entity.userId) {
+      userId = entity.userId;
+    } else if (entity.organizationUser?.id) {
+      userId = entity.organizationUser.id;
+    } else {
+      // If user relationship is not loaded, we need to query for it
+      const orgUser = await OrganizationUserModel.findOne({
+        where: { id: entity.id },
+      });
+      if (orgUser?.userId) {
+        userId = orgUser.userId;
+      }
+    }
+
+    if (userId) {
+      await this.redisProfileService.deleteProfile(`u:${userId}`);
+    }
+  }
+}

--- a/packages/server/src/organization/organization.module.ts
+++ b/packages/server/src/organization/organization.module.ts
@@ -6,10 +6,16 @@ import { ScheduleModule } from '@nestjs/schedule';
 import { CourseService } from 'course/course.service';
 import { MailModule } from 'mail/mail.module';
 import { ChatbotApiService } from 'chatbot/chatbot-api.service';
+import { OrganizationUserSubscriber } from './organization-user.subscriber';
 @Module({
   imports: [RedisProfileModule, ScheduleModule.forRoot(), MailModule],
   controllers: [OrganizationController],
-  providers: [OrganizationService, CourseService, ChatbotApiService],
+  providers: [
+    OrganizationService,
+    CourseService,
+    ChatbotApiService,
+    OrganizationUserSubscriber,
+  ],
   exports: [OrganizationService],
 })
 export class OrganizationModule {}

--- a/packages/server/src/profile/profile.controller.ts
+++ b/packages/server/src/profile/profile.controller.ts
@@ -55,6 +55,8 @@ export class ProfileController {
     const redisRecord = await this.redisProfileService.getKey(`u:${userId}`);
 
     if (!redisRecord) {
+      // NOTE: If you are adding a new relation here, make sure to create a new EventSubscriber for inserts/updates/deletes on said relation to clear the profile cache when that relation updates.
+      // Otherwise, if that relation updates, the profile cache will not be invalidated and the old data will be served.
       const user = await UserModel.findOne({
         where: { id: userId },
         relations: {
@@ -188,9 +190,6 @@ export class ProfileController {
     try {
       user.readChangeLog = true;
       await user.save();
-
-      // Delete old cached record if changed
-      await this.redisProfileService.deleteProfile(`u:${user.id}`);
 
       return res
         .status(HttpStatus.OK)

--- a/packages/server/src/profile/profile.module.ts
+++ b/packages/server/src/profile/profile.module.ts
@@ -10,6 +10,9 @@ import { OrganizationModule } from '../organization/organization.module';
 import { RedisProfileService } from '../redisProfile/redis-profile.service';
 import { RedisProfileModule } from '../redisProfile/redis-profile.module';
 import { ProfileService } from './profile.service';
+import { ProfileSubscriber } from './profile.subscriber';
+import { UserCourseSubscriber } from './user-course.subscriber';
+import { UserTokenSubscriber } from './user-token.subscriber';
 
 @Module({
   imports: [
@@ -27,7 +30,14 @@ import { ProfileService } from './profile.service';
     OrganizationModule,
   ],
   controllers: [ProfileController],
-  providers: [JwtStrategy, ProfileService, RedisProfileService],
+  providers: [
+    JwtStrategy,
+    ProfileService,
+    RedisProfileService,
+    ProfileSubscriber,
+    UserCourseSubscriber,
+    UserTokenSubscriber,
+  ],
   exports: [ProfileService, RedisProfileService],
 })
 export class ProfileModule {}

--- a/packages/server/src/profile/profile.service.spec.ts
+++ b/packages/server/src/profile/profile.service.spec.ts
@@ -99,6 +99,9 @@ describe('ProfileService', () => {
 
     it('should throw if disk space is insufficient', async () => {
       const user = await UserFactory.create();
+      // Mock console.error to suppress expected error log
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
       process.env.UPLOAD_LOCATION = '/uploads';
 
       mockCheckDiskSpace.mockResolvedValue({
@@ -109,6 +112,13 @@ describe('ProfileService', () => {
       await expect(
         service.uploadUserProfileImage(mockFile, user),
       ).rejects.toThrow(ServiceUnavailableException);
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Error processing image:',
+        expect.any(ServiceUnavailableException),
+      );
+
+      consoleErrorSpy.mockRestore();
     });
   });
 

--- a/packages/server/src/profile/profile.service.spec.ts
+++ b/packages/server/src/profile/profile.service.spec.ts
@@ -94,9 +94,6 @@ describe('ProfileService', () => {
 
       expect(fileName).toMatch(new RegExp(`^${user.id}-\\d+\\.webp$`));
       expect(mockedSharp).toHaveBeenCalledWith(mockFile.buffer);
-      expect(redisProfileService.deleteProfile).toHaveBeenCalledWith(
-        `u:${user.id}`,
-      );
     });
 
     it('should throw if disk space is insufficient', async () => {
@@ -125,9 +122,6 @@ describe('ProfileService', () => {
 
       expect(unlinkSpy).toHaveBeenCalledWith(
         path.join('/', 'uploads', 'test-image.webp'),
-      );
-      expect(redisProfileService.deleteProfile).toHaveBeenCalledWith(
-        `u:${user.id}`,
       );
     });
 
@@ -160,9 +154,6 @@ describe('ProfileService', () => {
 
       expect(user.firstName).toBe('Updated');
       expect(user.lastName).toBe('User');
-      expect(redisProfileService.deleteProfile).toHaveBeenCalledWith(
-        `u:${user.id}`,
-      );
     });
 
     it('should throw error when updating email for non-legacy account', async () => {

--- a/packages/server/src/profile/profile.service.ts
+++ b/packages/server/src/profile/profile.service.ts
@@ -18,10 +18,14 @@ import {
 import { UserModel } from './user.entity';
 import { pick } from 'lodash';
 import { OrganizationService } from '../organization/organization.service';
-import * as checkDiskSpace from 'check-disk-space';
+import * as checkDiskSpaceModule from 'check-disk-space';
 import * as path from 'path';
 import * as fs from 'fs';
-import * as sharp from 'sharp';
+import * as sharpModule from 'sharp';
+
+const checkDiskSpace =
+  (checkDiskSpaceModule as any).default || checkDiskSpaceModule;
+const sharp = (sharpModule as any).default || sharpModule;
 
 @Injectable()
 export class ProfileService {

--- a/packages/server/src/profile/profile.service.ts
+++ b/packages/server/src/profile/profile.service.ts
@@ -18,10 +18,10 @@ import {
 import { UserModel } from './user.entity';
 import { pick } from 'lodash';
 import { OrganizationService } from '../organization/organization.service';
-import checkDiskSpace from 'check-disk-space';
+import * as checkDiskSpace from 'check-disk-space';
 import * as path from 'path';
 import * as fs from 'fs';
-import sharp from 'sharp';
+import * as sharp from 'sharp';
 
 @Injectable()
 export class ProfileService {

--- a/packages/server/src/profile/profile.subscriber.ts
+++ b/packages/server/src/profile/profile.subscriber.ts
@@ -1,0 +1,36 @@
+import {
+  DataSource,
+  EntitySubscriberInterface,
+  EventSubscriber,
+  RemoveEvent,
+  UpdateEvent,
+} from 'typeorm';
+import { UserModel } from './user.entity';
+import { RedisProfileService } from 'redisProfile/redis-profile.service';
+
+@EventSubscriber()
+export class ProfileSubscriber implements EntitySubscriberInterface<UserModel> {
+  constructor(
+    private readonly redisProfileService: RedisProfileService,
+    dataSource: DataSource,
+  ) {
+    dataSource.subscribers.push(this);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  listenTo() {
+    return UserModel;
+  }
+
+  async afterUpdate(event: UpdateEvent<UserModel>): Promise<void> {
+    // delete cached profile whenever user is updated
+    await this.redisProfileService.deleteProfile(`u:${event.entity.id}`);
+  }
+
+  async beforeRemove(event: RemoveEvent<UserModel>): Promise<void> {
+    // due to cascades entity is not guaranteed to be loaded
+    if (event.entity) {
+      await this.redisProfileService.deleteProfile(`u:${event.entity.id}`);
+    }
+  }
+}

--- a/packages/server/src/profile/user-course.subscriber.ts
+++ b/packages/server/src/profile/user-course.subscriber.ts
@@ -1,0 +1,102 @@
+import {
+  DataSource,
+  EntitySubscriberInterface,
+  EventSubscriber,
+  InsertEvent,
+  RemoveEvent,
+  UpdateEvent,
+} from 'typeorm';
+import { UserCourseModel } from './user-course.entity';
+import { RedisProfileService } from 'redisProfile/redis-profile.service';
+
+@EventSubscriber()
+export class UserCourseSubscriber
+  implements EntitySubscriberInterface<UserCourseModel>
+{
+  constructor(
+    private readonly redisProfileService: RedisProfileService,
+    dataSource: DataSource,
+  ) {
+    dataSource.subscribers.push(this);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  listenTo() {
+    return UserCourseModel;
+  }
+
+  async afterUpdate(event: UpdateEvent<UserCourseModel>): Promise<void> {
+    // delete cached profile whenever user course is updated
+    let userId: number;
+
+    if (event.entity.user?.id) {
+      userId = event.entity.user.id;
+    } else if (event.entity.userId) {
+      userId = event.entity.userId;
+    } else {
+      // If user relationship is not loaded, we need to query for it
+      const userCourse = await UserCourseModel.findOne({
+        where: { id: event.entity.id },
+        relations: ['user'],
+      });
+      if (userCourse?.user?.id) {
+        userId = userCourse.user.id;
+      }
+    }
+
+    if (userId) {
+      await this.redisProfileService.deleteProfile(`u:${userId}`);
+    }
+  }
+
+  async beforeRemove(event: RemoveEvent<UserCourseModel>): Promise<void> {
+    // due to cascades entity is not guaranteed to be loaded
+    if (!event.entity) {
+      return;
+    }
+
+    let userId: number;
+
+    if (event.entity.user?.id) {
+      userId = event.entity.user.id;
+    } else if (event.entity.userId) {
+      userId = event.entity.userId;
+    } else {
+      // If user relationship is not loaded, we need to query for it
+      const userCourse = await UserCourseModel.findOne({
+        where: { id: event.entity.id },
+        relations: ['user'],
+      });
+      if (userCourse?.user?.id) {
+        userId = userCourse.user.id;
+      }
+    }
+
+    if (userId) {
+      await this.redisProfileService.deleteProfile(`u:${userId}`);
+    }
+  }
+
+  async afterInsert(event: InsertEvent<UserCourseModel>): Promise<void> {
+    let userId: number;
+
+    if (event.entity.user?.id) {
+      userId = event.entity.user.id;
+    } else if (event.entity.userId) {
+      userId = event.entity.userId;
+    } else {
+      // If user relationship is not loaded, we need to query for it
+      const userCourse = await UserCourseModel.findOne({
+        where: { id: event.entity.id },
+        relations: ['user'],
+      });
+      if (userCourse?.user?.id) {
+        userId = userCourse.user.id;
+      }
+    }
+
+    if (userId) {
+      await this.redisProfileService.deleteProfile(`u:${userId}`);
+    }
+  }
+}

--- a/packages/server/src/profile/user-token.subscriber.ts
+++ b/packages/server/src/profile/user-token.subscriber.ts
@@ -1,0 +1,74 @@
+import {
+  DataSource,
+  EntitySubscriberInterface,
+  EventSubscriber,
+  RemoveEvent,
+  UpdateEvent,
+} from 'typeorm';
+import { UserTokenModel } from './user-token.entity';
+import { RedisProfileService } from 'redisProfile/redis-profile.service';
+
+@EventSubscriber()
+export class UserTokenSubscriber
+  implements EntitySubscriberInterface<UserTokenModel>
+{
+  constructor(
+    private readonly redisProfileService: RedisProfileService,
+    dataSource: DataSource,
+  ) {
+    dataSource.subscribers.push(this);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  listenTo() {
+    return UserTokenModel;
+  }
+
+  async afterUpdate(event: UpdateEvent<UserTokenModel>): Promise<void> {
+    // delete cached profile whenever user token is updated
+    let userId: number;
+
+    if (event.entity.userId || event.entity.user?.id) {
+      userId = event.entity.userId || event.entity.user.id;
+    } else {
+      // If user relationship is not loaded, we need to query for it
+      const userToken = await UserTokenModel.findOne({
+        where: { id: event.entity.id },
+        relations: ['user'],
+      });
+      if (userToken?.user?.id) {
+        userId = userToken.user.id;
+      }
+    }
+
+    if (userId) {
+      await this.redisProfileService.deleteProfile(`u:${userId}`);
+    }
+  }
+
+  async beforeRemove(event: RemoveEvent<UserTokenModel>): Promise<void> {
+    // due to cascades entity is not guaranteed to be loaded
+    if (!event.entity) {
+      return;
+    }
+
+    let userId: number;
+
+    if (event.entity.user?.id || (event.entity as any).userId) {
+      userId = event.entity.user?.id || (event.entity as any).userId;
+    } else {
+      // If user relationship is not loaded, we need to query for it
+      const userToken = await UserTokenModel.findOne({
+        where: { id: event.entity.id },
+        relations: ['user'],
+      });
+      if (userToken?.user?.id) {
+        userId = userToken.user.id;
+      }
+    }
+
+    if (userId) {
+      await this.redisProfileService.deleteProfile(`u:${userId}`);
+    }
+  }
+}

--- a/packages/server/src/profile/user.entity.ts
+++ b/packages/server/src/profile/user.entity.ts
@@ -56,10 +56,10 @@ export class UserModel extends BaseEntity {
   emailVerified: boolean;
 
   @Column('text', { nullable: true })
-  defaultMessage: string | null;
+  defaultMessage: string | null; //unused
 
   @Column({ type: 'boolean', default: true })
-  includeDefaultMessage: boolean;
+  includeDefaultMessage: boolean; //unused
 
   @Column({ type: 'text', enum: AccountType, default: AccountType.LEGACY })
   accountType: AccountType;

--- a/packages/server/src/semester/semester.module.ts
+++ b/packages/server/src/semester/semester.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { SemesterController } from './semester.controller';
+import { SemesterSubscriber } from './semester.subscriber';
+import { RedisProfileService } from 'redisProfile/redis-profile.service';
 
 @Module({
   controllers: [SemesterController],
-  providers: [],
+  providers: [RedisProfileService, SemesterSubscriber],
   imports: [],
 })
 export class SemesterModule {}

--- a/packages/server/src/semester/semester.subscriber.ts
+++ b/packages/server/src/semester/semester.subscriber.ts
@@ -1,0 +1,64 @@
+import {
+  DataSource,
+  EntitySubscriberInterface,
+  EventSubscriber,
+  RemoveEvent,
+  UpdateEvent,
+} from 'typeorm';
+import { SemesterModel } from './semester.entity';
+import { CourseModel } from '../course/course.entity';
+import { UserCourseModel } from '../profile/user-course.entity';
+import { RedisProfileService } from 'redisProfile/redis-profile.service';
+
+@EventSubscriber()
+export class SemesterSubscriber
+  implements EntitySubscriberInterface<SemesterModel>
+{
+  constructor(
+    private readonly redisProfileService: RedisProfileService,
+    dataSource: DataSource,
+  ) {
+    dataSource.subscribers.push(this);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  listenTo() {
+    return SemesterModel;
+  }
+
+  async afterUpdate(event: UpdateEvent<SemesterModel>): Promise<void> {
+    // delete cached profiles for all users in courses within this semester
+    await this.invalidateUsersInSemester(event.entity.id);
+  }
+
+  async beforeRemove(event: RemoveEvent<SemesterModel>): Promise<void> {
+    // due to cascades entity is not guaranteed to be loaded
+    if (!event.entity) {
+      return;
+    }
+
+    // delete cached profiles for all users in courses within this semester
+    await this.invalidateUsersInSemester(event.entity.id);
+  }
+
+  private async invalidateUsersInSemester(semesterId: number): Promise<void> {
+    if (!semesterId) {
+      return;
+    }
+
+    // Get all user IDs for users enrolled in courses within this semester
+    // Using a join query to efficiently get all user IDs in one database call
+    const userIds = await UserCourseModel.createQueryBuilder('uc')
+      .innerJoin(CourseModel, 'c', 'c.id = uc.courseId')
+      .select('DISTINCT uc.userId', 'userId')
+      .where('c.semesterId = :semesterId', { semesterId })
+      .getRawMany();
+
+    // Delete cached profiles for all users in courses within this semester
+    const deletePromises = userIds.map((result) =>
+      this.redisProfileService.deleteProfile(`u:${result.userId}`),
+    );
+
+    await Promise.all(deletePromises);
+  }
+}


### PR DESCRIPTION
# Description

So I found a bug where after creating an account and verifying my email, it doesn't clear the redis profile cache so I am just stuck there waiting for the 30mins or whatever for the cache to bust itself (also for more context, the redis profile caching is NOT on prod yet, so no actual users were affected by this bug).

And so rather than just adding another cache bust to that endpoint, I remembered that we have these typeorm EventSubscribers that we can use to connect database events with external systems. 

So, I opted to remove all manual cache busting and instead added EventSubscribers for all relevant updates so that they bust the caches automatically whenever they update.

Not only does this fix any cases we might've missed with the original redis profile cache, but this will also make it more maintainable for the future so that you don't have to remember to bust the cache for like any course update (though if someone were to add a new relation to the profile get() request, then they will need to add a new subscriber for events of that relation)



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

I only manually tested updating the user profile (changing name and then refreshing page) and it seems to work. I also tried updating and deleting semesters and that seems to work.

There's technically more to test but eh this will be tested as I make the guides for the system.

# Checklist:

- [ ] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any work that this PR is dependent on has been merged into the main branch
- [ ] Any UI changes have been checked to work on desktop, tablet, and mobile
