### PR TITLE
Bug Fix: 'Enable Notifications' Popup

### DIFF
--- a/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/page.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/page.tsx
@@ -2,28 +2,28 @@
 
 import {
   ReactElement,
+  use,
   useCallback,
-  useState,
   useEffect,
   useRef,
-  use,
+  useState,
 } from 'react'
 import {
-  QuestionTypeParams,
   ClosedQuestionStatus,
+  ConfigTasksWithAssignmentProgress,
   ERROR_MESSAGES,
+  LimboQuestionStatus,
   OpenQuestionStatus,
   Question,
-  Role,
-  QuestionStatus,
-  ConfigTasksWithAssignmentProgress,
-  transformIntoTaskTree,
-  TaskTree,
-  QuestionType,
-  LimboQuestionStatus,
   QuestionLocations,
+  QuestionStatus,
+  QuestionType,
+  QuestionTypeParams,
+  Role,
+  TaskTree,
+  transformIntoTaskTree,
 } from '@koh/common'
-import { Tooltip, message, notification, Button, Divider } from 'antd'
+import { Button, Divider, message, notification, Tooltip } from 'antd'
 import { mutate } from 'swr'
 import { EditOutlined, LoginOutlined, PlusOutlined } from '@ant-design/icons'
 import { CheckCheck, ListChecks, ListTodoIcon } from 'lucide-react'
@@ -503,6 +503,8 @@ export default function QueuePage(props: QueuePageProps): ReactElement {
   const handleFirstQuestionNotification = useCallback(
     (cid: number) => {
       if (isFirstQuestion) {
+        // If they've asked a question, don't show this notification again
+        setIsFirstQuestion(false)
         notification.warning({
           message: 'Enable Notifications',
           description: (
@@ -514,7 +516,6 @@ export default function QueuePage(props: QueuePageProps): ReactElement {
               <Button
                 onClick={() => {
                   notification.destroy()
-                  setIsFirstQuestion(false)
                   router.push(`/profile?page=notifications`)
                 }}
                 className="ml-2"


### PR DESCRIPTION
# Description

Hopefully fixes the issue with the Enable Notifications popup showing up more than once. Always sets the localStorage value to false after creating a question; note that since it's localStorage it's not going to replicate across devices, but at least we don't need another DB column.

Closes #183 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

Manually

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [x] Any UI changes have been checked to work on desktop, tablet, and mobile
