### PR TITLE
Improve UX for Chatbot Document Upload

### DIFF
--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_settings/components/AddChatbotDocumentModal.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_settings/components/AddChatbotDocumentModal.tsx
@@ -150,7 +150,7 @@ const AddChatbotDocumentModal: React.FC<AddChatbotDocumentModalProps> = ({
                     that time.
                   </p>
                   <p>
-                    Any errors that occur during processing will be shown here.
+                    You will be notified when the document is processed
                   </p>
                   <p>Would you like to continue?</p>
                 </div>
@@ -264,7 +264,7 @@ const AddChatbotDocumentModal: React.FC<AddChatbotDocumentModalProps> = ({
               <Form.Item
                 name="isSlideDeck"
                 label="Parse document as slides"
-                tooltip="By default images/graphics embedded in your uploaded files will not be detected by the chatbot. Ticking this will transform pages of the document into images and automatically generate AI summaries of said images. This is useful for any document that isn't just text. Warning that it will take a lot longer to process."
+                tooltip="By default images/graphics embedded in your uploaded files will not be detected by the chatbot. Ticking this will transform pages of the document into images and automatically generate AI detailed descriptions of said images (using a UBC-hosted AI model). This is useful for any document that isn't just text. Warning that it will take a lot longer to process."
               >
                 <Switch
                   defaultChecked={isSlideDeck}

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_settings/components/AddChatbotDocumentModal.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_settings/components/AddChatbotDocumentModal.tsx
@@ -4,16 +4,14 @@ import {
   ExclamationCircleFilled,
   FileAddOutlined,
   GithubOutlined,
-  InboxOutlined,
+  UploadOutlined,
 } from '@ant-design/icons'
 import {
-  Alert,
   Form,
   Input,
   message,
   Modal,
   Popconfirm,
-  Progress,
   Segmented,
   Switch,
 } from 'antd'
@@ -22,6 +20,7 @@ import { useState } from 'react'
 import { RcFile } from 'antd/lib/upload'
 import { API } from '@/app/api'
 import { getErrorMessage } from '@/app/utils/generalUtils'
+import { useAsyncToaster } from '@/app/contexts/AsyncToasterContext'
 
 interface AddChatbotDocumentModalProps {
   courseId: number
@@ -40,13 +39,10 @@ const AddChatbotDocumentModal: React.FC<AddChatbotDocumentModalProps> = ({
   const [loading, setLoading] = useState(false)
   const [form] = Form.useForm()
   const [isSlideDeck, setIsSlideDeck] = useState(false)
-  const [countProcessed, setCountProcessed] = useState(0)
   const [fileList, setFileList] = useState<any[]>([])
-  const [uploadErrors, setUploadErrors] = useState<string[]>([])
-  const [confirmPopoverOpen, setConfirmPopoverOpen] = useState(false)
+  const { runAsyncToast } = useAsyncToaster()
 
   const addDocument = async () => {
-    setConfirmPopoverOpen(false)
     setLoading(true)
     try {
       const formData = await form.validateFields()
@@ -70,27 +66,59 @@ const AddChatbotDocumentModal: React.FC<AddChatbotDocumentModalProps> = ({
   }
 
   const uploadFiles = async (files: RcFile[]) => {
-    setCountProcessed(0)
-    let wasError = false
     for (const file of files) {
+      // if the file is already uploading or done, skip it and inform the user
+      if (fileList.find((f) => f.uid === file.uid)?.status === 'uploading') {
+        message.info(`${file.name} is still being processed.`)
+        continue
+      } else if (fileList.find((f) => f.uid === file.uid)?.status === 'done') {
+        message.info(`${file.name} is already done being processed.`)
+        continue
+      }
+
       const formData = new FormData()
       formData.append('file', file)
       formData.append('parseAsPng', isSlideDeck.toString())
 
-      await API.chatbot.staffOnly
-        .uploadDocument(courseId, formData)
-        .then(async () => {
-          message.success(`${file.name} uploaded and processed!`)
-          setCountProcessed((prev) => prev + 1)
-        })
-        .catch((e) => {
-          uploadErrors.push(
-            `Failed to upload/process ${file.name}: ${getErrorMessage(e)}`,
-          )
-          wasError = true
-        })
+      setFileList((prevFileList) =>
+        prevFileList.map((f) =>
+          f.uid === file.uid ? { ...f, status: 'uploading' } : f,
+        ),
+      )
+
+      runAsyncToast(
+        () => API.chatbot.staffOnly.uploadDocument(courseId, formData),
+        (result, error) => {
+          if (error) {
+            setFileList((prevFileList) =>
+              prevFileList.map((f) =>
+                f.uid === file.uid
+                  ? { ...f, status: 'error', response: getErrorMessage(error) }
+                  : f,
+              ),
+            )
+          } else {
+            // success
+            getDocuments()
+            // remove the file from the list
+            setFileList((prevFileList) =>
+              prevFileList.filter((f) => f.uid !== file.uid),
+            )
+          }
+        },
+        {
+          successMsg: `${file.name} uploaded and processed!`,
+          errorMsg: `Failed to upload/process ${file.name}`,
+          appendApiError: true,
+          successDuration: 3500,
+        },
+      )
     }
-    if (!wasError) handleSuccess()
+    message.info(
+      'All documents have been queued for processing. You will be notified of completion.',
+      3.5,
+    )
+    onClose()
   }
 
   const addUrl = async (url: string) => {
@@ -101,8 +129,8 @@ const AddChatbotDocumentModal: React.FC<AddChatbotDocumentModalProps> = ({
         handleSuccess()
       })
       .catch((e) => {
-        uploadErrors.push(
-          `Failed to upload file (${e}). Please check the file type of linked document`,
+        message.error(
+          `Failed to upload file (${getErrorMessage(e)}). Please check the file type of linked document`,
         )
       })
   }
@@ -119,16 +147,14 @@ const AddChatbotDocumentModal: React.FC<AddChatbotDocumentModalProps> = ({
         htmlType: 'submit',
         loading: loading,
         onClick: async () => {
-          await form.validateFields().then((formData) => {
-            if (documentType === 'FILE' && formData.isSlideDeck) {
-              setConfirmPopoverOpen(true)
-            } else {
-              addDocument()
-            }
+          await form.validateFields().then(() => {
+            addDocument()
           })
         },
       }}
-      okText="Confirm"
+      okText={
+        fileList.some((f) => f.status === 'error') ? 'Try Again' : 'Confirm'
+      }
       cancelButtonProps={{
         disabled: loading,
         onClick: onClose,
@@ -137,35 +163,7 @@ const AddChatbotDocumentModal: React.FC<AddChatbotDocumentModalProps> = ({
       footer={(_, { OkBtn, CancelBtn }) => (
         <div className={`flex flex-wrap justify-end gap-2 md:gap-3`}>
           <CancelBtn />
-          <div>
-            <OkBtn />
-            <Popconfirm
-              title={
-                <div className="flex max-w-80 flex-col gap-y-2">
-                  <p>
-                    <b className="font-semibold">
-                      This may take a few minutes to process
-                    </b>
-                    ; feel free to open a new tab and do something else during
-                    that time.
-                  </p>
-                  <p>
-                    You will be notified when the document is processed
-                  </p>
-                  <p>Would you like to continue?</p>
-                </div>
-              }
-              onConfirm={addDocument}
-              okText="Yes"
-              icon={<ExclamationCircleFilled className="text-blue-500" />}
-              cancelText="No"
-              open={confirmPopoverOpen}
-              onCancel={() => setConfirmPopoverOpen(false)}
-              okButtonProps={{ className: 'px-4' }}
-              cancelButtonProps={{ className: 'px-4' }}
-              placement={'bottomRight'}
-            ></Popconfirm>
-          </div>
+          <OkBtn />
         </div>
       )}
     >
@@ -246,7 +244,7 @@ const AddChatbotDocumentModal: React.FC<AddChatbotDocumentModalProps> = ({
                   beforeUpload={() => false} // Prevent automatic upload
                 >
                   <p className="ant-upload-drag-icon">
-                    <InboxOutlined />
+                    <UploadOutlined />
                   </p>
                   <p className="ant-upload-text">
                     Click or drag file to this area to upload
@@ -256,14 +254,9 @@ const AddChatbotDocumentModal: React.FC<AddChatbotDocumentModalProps> = ({
                   </p>
                 </Dragger>
               </Form.Item>
-              {loading && fileList.length > 1 && (
-                <Progress
-                  percent={Math.round((countProcessed / fileList.length) * 100)}
-                />
-              )}
               <Form.Item
                 name="isSlideDeck"
-                label="Parse document as slides"
+                label="Parse document(s) as slides"
                 tooltip="By default images/graphics embedded in your uploaded files will not be detected by the chatbot. Ticking this will transform pages of the document into images and automatically generate AI detailed descriptions of said images (using a UBC-hosted AI model). This is useful for any document that isn't just text. Warning that it will take a lot longer to process."
               >
                 <Switch
@@ -275,22 +268,6 @@ const AddChatbotDocumentModal: React.FC<AddChatbotDocumentModalProps> = ({
             </>
           )}
         </Form>
-        {uploadErrors.length > 0 &&
-          uploadErrors.map((uploadError, idx) => (
-            <Alert
-              key={idx}
-              description={
-                'There was an error uploading or processing your document: ' +
-                uploadError
-              }
-              type="error"
-              showIcon
-              closable
-              onClose={() =>
-                setUploadErrors(uploadErrors.filter((_, i) => i !== idx))
-              }
-            />
-          ))}
       </>
     </Modal>
   )

--- a/packages/frontend/app/contexts/AsyncToasterContext.tsx
+++ b/packages/frontend/app/contexts/AsyncToasterContext.tsx
@@ -13,6 +13,8 @@ type NotifyOptions = {
   successMsg: string
   errorMsg: string
   appendApiError: boolean
+  successDuration?: number
+  errorDuration?: number
 }
 
 interface AsyncToasterContextProps {
@@ -35,7 +37,6 @@ export const useAsyncToaster = () => useContext(AsyncToasterContext)
 
 const toastOptions: ExternalToast = {
   richColors: true,
-  duration: Infinity,
   dismissible: true,
   closeButton: true,
 }
@@ -51,7 +52,10 @@ export const AsyncToasterProvider: React.FC<PropsWithChildren> = ({
     apiCall()
       .then((result) => {
         if (notifyOptions) {
-          toast.success(notifyOptions.successMsg, toastOptions)
+          toast.success(notifyOptions.successMsg, {
+            ...toastOptions,
+            duration: notifyOptions.successDuration ?? Infinity,
+          })
         }
         callback(result)
       })
@@ -72,7 +76,10 @@ export const AsyncToasterProvider: React.FC<PropsWithChildren> = ({
             toastOptions,
           )
         } else {
-          toast.error(notifyOptions.errorMsg, toastOptions)
+          toast.error(notifyOptions.errorMsg, {
+            ...toastOptions,
+            duration: notifyOptions.errorDuration ?? Infinity,
+          })
         }
         callback(null, error)
       })
@@ -81,7 +88,7 @@ export const AsyncToasterProvider: React.FC<PropsWithChildren> = ({
   return (
     <AsyncToasterContext.Provider value={{ runAsyncToast }}>
       <Toaster
-        position="bottom-right"
+        position="bottom-left"
         toastOptions={{
           className: 'rounded p-4 text-md font-semibold min-h-18 w-96',
           duration: 5000,

--- a/packages/frontend/app/contexts/AsyncToasterContext.tsx
+++ b/packages/frontend/app/contexts/AsyncToasterContext.tsx
@@ -38,6 +38,7 @@ export const useAsyncToaster = () => useContext(AsyncToasterContext)
 const toastOptions: ExternalToast = {
   richColors: true,
   dismissible: true,
+  duration: Infinity,
   closeButton: true,
 }
 
@@ -91,7 +92,6 @@ export const AsyncToasterProvider: React.FC<PropsWithChildren> = ({
         position="bottom-left"
         toastOptions={{
           className: 'rounded p-4 text-md font-semibold min-h-18 w-96',
-          duration: 5000,
         }}
       />
       {children}


### PR DESCRIPTION
# Description

Refactors the AddChatbotDocumentModal to use AsyncToaster to asynchronously run toaster messages. It also does all uploads in parallel now rather than one-at-a-time

Now the user won't be stuck in the UI waiting for their chatbot documents to upload (notice how the notification here popped up even though i was on another page)
![image](https://github.com/user-attachments/assets/6ffbdf8b-1015-4901-8c12-598fd9974b7f)


also the errors show up indefinitely until dismissed so you can go afk and come back and not miss anything
![image](https://github.com/user-attachments/assets/35eb2faf-5d48-437b-8f59-547fd3605364)

and it will show in the modal as well (though that only works if they haven't left the page)
![image](https://github.com/user-attachments/assets/3e0688f2-1d0a-453e-ad22-6f08fb1b6cda)



## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

Manual testing


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing tests pass *locally* with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [x] Any UI changes have been checked to work on desktop, tablet, and mobile
