### PR TITLE
[bugfix] Remove think block before sending AQ email

### DIFF
--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -2948,6 +2948,22 @@ export enum LMSIntegrationPlatform {
   Canvas = 'Canvas',
 }
 
+export function parseThinkBlock(answer: string) {
+  // Look for <think>...</think> (the "s" flag lets it match across multiple lines)
+  const thinkRegex = /<think>([\s\S]*?)<\/think>/
+  const match = answer.match(thinkRegex)
+
+  if (!match) {
+    // No <think> block, return the text unchanged
+    return { thinkText: null, cleanAnswer: answer }
+  }
+
+  const thinkText = match[1].trim()
+  const cleanAnswer = answer.replace(thinkRegex, '').trim()
+
+  return { thinkText, cleanAnswer }
+}
+
 export const ERROR_MESSAGES = {
   common: {
     pageOutOfBounds: "Can't retrieve out of bounds page.",

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_questions/page.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_questions/page.tsx
@@ -3,14 +3,14 @@
 import { Button, Divider, Input, message, Table, Tooltip } from 'antd'
 import {
   ReactElement,
+  use,
   useCallback,
   useEffect,
   useMemo,
   useState,
-  use,
 } from 'react'
 import ExpandableText from '@/app/components/ExpandableText'
-import { getErrorMessage, parseThinkBlock } from '@/app/utils/generalUtils'
+import { getErrorMessage } from '@/app/utils/generalUtils'
 import { useUserInfo } from '@/app/contexts/userContext'
 import EditChatbotQuestionModal from './components/EditChatbotQuestionModal'
 import { EditOutlined } from '@ant-design/icons'
@@ -22,6 +22,7 @@ import {
   ChatbotQuestionResponseChatbotDB,
   ChatbotQuestionResponseHelpMeDB,
   InteractionResponse,
+  parseThinkBlock,
   SourceDocument,
 } from '@koh/common'
 import { ThumbsDown, ThumbsUp } from 'lucide-react'

--- a/packages/frontend/app/(dashboard)/course/[cid]/async_centre/components/AsyncQuestionCard.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/async_centre/components/AsyncQuestionCard.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useReducer, useState } from 'react'
 import { Button, Col, message, Row, Tag, Tooltip } from 'antd'
-import { AsyncQuestion, asyncQuestionStatus, Role } from '@koh/common'
+import {
+  AsyncQuestion,
+  asyncQuestionStatus,
+  parseThinkBlock,
+  Role,
+} from '@koh/common'
 import {
   CheckCircleOutlined,
   DownOutlined,
@@ -9,7 +14,7 @@ import {
 } from '@ant-design/icons'
 import { API } from '@/app/api'
 import UserAvatar from '@/app/components/UserAvatar'
-import { cn, getErrorMessage, parseThinkBlock } from '@/app/utils/generalUtils'
+import { cn, getErrorMessage } from '@/app/utils/generalUtils'
 import { QuestionTagElement } from '../../components/QuestionTagElement'
 import { getAsyncWaitTime } from '@/app/utils/timeFormatUtils'
 import TAAsyncQuestionCardButtons from './TAAsyncQuestionCardButtons'

--- a/packages/frontend/app/(dashboard)/course/[cid]/components/chatbot/Chatbot.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/components/chatbot/Chatbot.tsx
@@ -23,7 +23,6 @@ import {
   cn,
   convertPathnameToPageName,
   getRoleInCourse,
-  parseThinkBlock,
 } from '@/app/utils/generalUtils'
 import { Feedback } from './Feedback'
 import {
@@ -35,7 +34,12 @@ import { API } from '@/app/api'
 import MarkdownCustom from '@/app/components/Markdown'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { Message, PreDeterminedQuestion, Role } from '@koh/common'
+import {
+  Message,
+  parseThinkBlock,
+  PreDeterminedQuestion,
+  Role,
+} from '@koh/common'
 import { Bot } from 'lucide-react'
 
 const { TextArea } = Input

--- a/packages/server/src/asyncQuestion/asyncQuestion.service.ts
+++ b/packages/server/src/asyncQuestion/asyncQuestion.service.ts
@@ -1,4 +1,4 @@
-import { MailServiceType, Role } from '@koh/common';
+import { MailServiceType, parseThinkBlock, Role } from '@koh/common';
 import { Injectable } from '@nestjs/common';
 import { MailService } from 'mail/mail.service';
 import { UserSubscriptionModel } from 'mail/user-subscriptions.entity';
@@ -178,13 +178,14 @@ export class AsyncQuestionService {
 
     if (subscription) {
       const service = subscription.service;
+      const { cleanAnswer } = parseThinkBlock(question.answerText);
       await this.mailService
         .sendEmail({
           receiver: question.creator.email,
           type: service.serviceType,
           subject: 'HelpMe - Your Anytime Question Has Been Answered',
           content: `<br> <b>Your question on the Anytime Question Hub has been answered or verified by staff.</b> 
-              <br> <b>Answer Text:</b> ${question.answerText}
+              <br> <b>Answer Text:</b> ${cleanAnswer}
               <br> <a href="${process.env.DOMAIN}/course/${question.courseId}/async_centre">View Here</a> <br>`,
         })
         .catch((err) => {


### PR DESCRIPTION
# Description

Deepseek think block was being sent in anytime question response email

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

Manually

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing tests pass *locally* with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [x] Any UI changes have been checked to work on desktop, tablet, and mobile
