### PR TITLE
Markdown Parser Fixes

### DIFF
--- a/packages/frontend/app/components/Markdown.tsx
+++ b/packages/frontend/app/components/Markdown.tsx
@@ -21,7 +21,7 @@ import 'katex/dist/katex.min.css'
  */
 const preprocessText = (text: string): string => {
   return text
-    .replace(/\\\((.*?)\\\)/g, (_, expr) => `$${expr}$`) // Inline LaTeX expressions
+    .replace(/\\\((.*?)\\\)/g, (_, expr) => `$$${expr}$$`) // Inline LaTeX expressions
     .replace(/\\\[(.*?)\\\]/gs, (_, expr) => `$$${expr}$$`) // Block LaTeX expressions
 }
 
@@ -44,7 +44,7 @@ const MarkdownCustom: React.FC<MarkdownCustomProps> = ({
     <Markdown
       remarkPlugins={[
         // parses LaTeX math expressions in markdown
-        remarkMath,
+        [remarkMath, { singleDollarTextMath: false }],
         remarkBreaks, // parses line breaks in markdown (used for turning \n into <br> instead of spaces)
         remarkGfm, // parses GitHub Flavored Markdown (used for autolinks, footnotes, strikethrough, tables, and tasklist)
       ]}

--- a/packages/frontend/app/globals.css
+++ b/packages/frontend/app/globals.css
@@ -319,6 +319,12 @@ It is used for displaying markdown nicely inside any <Markdown> components
   margin-bottom: inherit;
 }
 
+.childrenMarkdownFormatted .katex-display {
+  overflow-x: auto;
+  height: fit-content;
+  margin: 0;
+  padding: 1em 0;
+}
 .no-scrollbar::-webkit-scrollbar {
   display: none;
   width: 0px;


### PR DESCRIPTION
# Description

Adjusts the markdown parser (used in chatbot responses) to stop formatting `$` into latex and also adds a scroll to prevent formulas from being cut off

Before:
<img width="270" height="643" alt="image" src="https://github.com/user-attachments/assets/350aaa98-3c8b-4617-9315-715e47227754" />

After:
<img width="391" height="732" alt="image" src="https://github.com/user-attachments/assets/d52f565d-6ce8-42e1-a107-136e4de6554c" />


Before:
<img width="395" height="812" alt="image" src="https://github.com/user-attachments/assets/a4d38d6b-7b5f-4470-90a8-3aeae63e49c5" />


After:
<img width="454" height="807" alt="image" src="https://github.com/user-attachments/assets/b53c11dc-3e6e-4c77-a232-9a4ea08e7cfa" />


Also, inline latex still works:
<img width="554" height="454" alt="image" src="https://github.com/user-attachments/assets/8deff3c4-bd55-4c60-a288-059ff4ea621a" />


Closes #318 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

Manual testing

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing tests pass *locally* with my changes
- [ ] Any work that this PR is dependent on has been merged into the main branch
- [ ] Any UI changes have been checked to work on desktop, tablet, and mobile
