### PR TITLE
Highlight admins in professor selector and course roster

### DIFF
--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -47,6 +47,23 @@ export function timeDiffInMins(a: Date, b: Date): number {
 // NOTE: These are not the DB data types. They are only used for the api
 
 /**
+ * Represents one of two possible roles for the global account
+ */
+export enum UserRole {
+  USER = 'user',
+  ADMIN = 'admin',
+}
+
+/**
+ * Represents a user's role in an organization.
+ */
+export enum OrganizationRole {
+  MEMBER = 'member',
+  ADMIN = 'admin',
+  PROFESSOR = 'professor',
+}
+
+/**
  * Represents a user.
  * @param id - The unique id of the user in our db.
  * @param email - The email string of the user if they provide it (nullable)
@@ -146,6 +163,10 @@ export class UserPartial {
   @IsOptional()
   @IsString()
   TANotes?: string
+
+  @IsEnum(OrganizationRole)
+  @IsOptional()
+  organizationRole?: OrganizationRole
 }
 
 /**
@@ -532,22 +553,6 @@ export type GetInteractionsAndQuestionsResponse = {
 
 export type GetChatbotHistoryResponse = {
   history: InteractionResponse[]
-}
-/**
- * Represents one of two possible roles for the global account
- */
-export enum UserRole {
-  USER = 'user',
-  ADMIN = 'admin',
-}
-
-/**
- * Represents a user's role in an organization.
- */
-export enum OrganizationRole {
-  MEMBER = 'member',
-  ADMIN = 'admin',
-  PROFESSOR = 'professor',
 }
 
 /**
@@ -1528,8 +1533,8 @@ export type OrganizationProfessor = {
   organizationUser: {
     id: number
     name: string
-    lacksProfOrgRole?: boolean
   }
+  trueRole?: OrganizationRole
   userId: number
 }
 

--- a/packages/frontend/app/(dashboard)/components/EditCourseForm.tsx
+++ b/packages/frontend/app/(dashboard)/components/EditCourseForm.tsx
@@ -13,6 +13,7 @@ import {
 } from '@koh/common'
 import { Alert, Button, Form, Input, message, Select, Tag, Tooltip } from 'antd'
 import { useEffect, useState } from 'react'
+import { CrownFilled } from '@ant-design/icons'
 
 type EditCourseFormProps = {
   courseData: OrganizationCourseResponse
@@ -265,14 +266,29 @@ const EditCourseForm: React.FC<EditCourseFormProps> = ({
               showSearch
               optionFilterProp="label"
               options={professors.map((prof: OrganizationProfessor) => ({
-                key: prof.organizationUser.id,
-                label: prof.organizationUser.name,
+                key: `${prof.organizationUser.name}-${prof.organizationUser.id}`,
+                label: (
+                  <span>
+                    {prof.organizationUser.name}
+                    {prof.trueRole == OrganizationRole.ADMIN && (
+                      <Tooltip
+                        title={'This user is an organization administrator.'}
+                      >
+                        <CrownFilled
+                          className={
+                            'ml-1 text-yellow-500 transition-all hover:text-yellow-300'
+                          }
+                        />
+                      </Tooltip>
+                    )}
+                  </span>
+                ),
                 value: prof.organizationUser.id,
               }))}
               filterSort={(optionA, optionB) =>
-                (optionA?.label ?? '')
+                (optionA?.key ?? '')
                   .toLowerCase()
-                  .localeCompare((optionB?.label ?? '').toLowerCase())
+                  .localeCompare((optionB?.key ?? '').toLowerCase())
               }
               tagRender={(props) => {
                 const { label, value, closable, onClose } = props
@@ -283,9 +299,14 @@ const EditCourseForm: React.FC<EditCourseFormProps> = ({
                   event.stopPropagation()
                 }
                 // find the professor with the given id and see if they have lacksProfOrgRole
-                const lacksProfOrgRole = professors.find(
+                const match = professors.find(
                   (prof) => prof.organizationUser.id === value,
-                )?.organizationUser.lacksProfOrgRole
+                )
+                const lacksProfOrgRole = ![
+                  OrganizationRole.ADMIN,
+                  OrganizationRole.PROFESSOR,
+                ].includes(match?.trueRole ?? OrganizationRole.MEMBER)
+
                 return (
                   <Tooltip
                     title={

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/components/CourseRosterTable.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/components/CourseRosterTable.tsx
@@ -1,20 +1,20 @@
 import { API } from '@/app/api'
 import UserAvatar from '@/app/components/UserAvatar'
 import { useUserInfo } from '@/app/contexts/userContext'
-import { getErrorMessage } from '@/app/utils/generalUtils'
+import { cn, getErrorMessage } from '@/app/utils/generalUtils'
 import {
+  CrownFilled,
   DownOutlined,
   QuestionCircleOutlined,
   SearchOutlined,
   UserDeleteOutlined,
 } from '@ant-design/icons'
-import { Role, User, UserPartial } from '@koh/common'
+import { OrganizationRole, Role, User, UserPartial } from '@koh/common'
 import {
   Button,
   Dropdown,
   Input,
   List,
-  Menu,
   message,
   Modal,
   Pagination,
@@ -26,7 +26,6 @@ import {
 import TextArea from 'antd/es/input/TextArea'
 import { Notebook, NotebookText } from 'lucide-react'
 import { useEffect, useState } from 'react'
-import { cn } from '@/app/utils/generalUtils'
 
 type CourseRosterTableProps = {
   courseId: number
@@ -214,7 +213,20 @@ const RosterItem: React.FC<{
           avatar={
             <UserAvatar photoURL={item.photoURL} username={item.name ?? ''} />
           }
-          title={<span className="mr-0 md:mr-2">{item.name}</span>}
+          title={
+            <span className="mr-0 md:mr-2">
+              {item.name}
+              {item.organizationRole == OrganizationRole.ADMIN && (
+                <Tooltip title={'This user is an organization administrator.'}>
+                  <CrownFilled
+                    className={
+                      'ml-1 text-yellow-500 transition-all hover:text-yellow-300'
+                    }
+                  />
+                </Tooltip>
+              )}
+            </span>
+          }
           className="flex flex-grow items-center"
         />
         {isSensitiveInfoHidden ? (

--- a/packages/server/src/course/course.service.ts
+++ b/packages/server/src/course/course.service.ts
@@ -251,9 +251,10 @@ export class CourseService {
     }
 
     const query = `
-      SELECT user_model.id, user_model.name, user_model."photoURL", user_model.email, user_model.sid, user_course_model."TANotes", COUNT(*) OVER () AS total
+      SELECT user_model.id, user_model.name, user_model."photoURL", user_model.email, user_model.sid, user_course_model."TANotes", organization_user_model."role" as "organizationRole", COUNT(*) OVER () AS total
       FROM user_course_model
       INNER JOIN user_model ON user_model.id = user_course_model."userId"
+      INNER JOIN organization_user_model ON user_course_model."userId" = organization_user_model."userId"
       WHERE user_course_model."courseId" = $1
         ${roleCondition}
         ${searchCondition}

--- a/packages/server/src/course/course.service.ts
+++ b/packages/server/src/course/course.service.ts
@@ -254,7 +254,7 @@ export class CourseService {
       SELECT user_model.id, user_model.name, user_model."photoURL", user_model.email, user_model.sid, user_course_model."TANotes", organization_user_model."role" as "organizationRole", COUNT(*) OVER () AS total
       FROM user_course_model
       INNER JOIN user_model ON user_model.id = user_course_model."userId"
-      INNER JOIN organization_user_model ON user_course_model."userId" = organization_user_model."userId"
+      LEFT JOIN organization_user_model ON user_course_model."userId" = organization_user_model."userId"
       WHERE user_course_model."courseId" = $1
         ${roleCondition}
         ${searchCondition}

--- a/packages/server/src/organization/organization.controller.ts
+++ b/packages/server/src/organization/organization.controller.ts
@@ -533,48 +533,65 @@ export class OrganizationController {
       courseInfo.course.timezone = courseDetails.timezone;
 
       await manager.save(courseInfo.course);
-      // Remove current professors
-      await manager.delete(UserCourseModel, {
-        courseId: cid,
-        role: Role.PROFESSOR,
-      });
 
-      for (const profId of courseDetails.profIds) {
-        const chosenProfessor = await manager.findOne(UserModel, {
-          where: { id: profId },
-        });
-
-        if (!chosenProfessor) {
-          throw new HttpException(
-            ERROR_MESSAGES.profileController.userResponseNotFound,
-            HttpStatus.NOT_FOUND,
-          );
-        }
-
-        const userCourse = await manager.findOne(UserCourseModel, {
+      // If user is an admin, update professors according to list
+      if (user.organizationUser.role == OrganizationRole.ADMIN) {
+        // Retrieve any current professors
+        const currentProfs = await manager.find(UserCourseModel, {
           where: {
-            userId: profId,
             courseId: cid,
+            role: Role.PROFESSOR,
           },
         });
 
-        // User is already in the course
-        if (userCourse) {
-          userCourse.role = Role.PROFESSOR;
-          try {
-            await manager.save(userCourse);
-          } catch (err) {
-            throw new HttpException(err, HttpStatus.INTERNAL_SERVER_ERROR);
+        const demoted = currentProfs
+          .filter((v) => !courseDetails.profIds.includes(v.userId))
+          .map((v) => v.id);
+        const promoted = courseDetails.profIds.filter(
+          (v0) => !currentProfs.some((v1) => v0 == v1.userId),
+        );
+
+        // Demote professors not specified in list back to student
+        await manager.update(
+          UserCourseModel,
+          { id: In(demoted) },
+          { role: Role.STUDENT },
+        );
+
+        // Upsert professors specified in list
+        for (const profId of promoted) {
+          const chosenProfessor = await manager.findOne(UserModel, {
+            where: { id: profId },
+          });
+
+          if (!chosenProfessor) {
+            throw new HttpException(
+              ERROR_MESSAGES.profileController.userResponseNotFound,
+              HttpStatus.NOT_FOUND,
+            );
           }
-        } else {
+
           try {
-            const newUserCourse = manager.create(UserCourseModel, {
-              userId: profId,
-              courseId: cid,
-              role: Role.PROFESSOR,
+            const exists = await manager.findOne(UserCourseModel, {
+              where: {
+                userId: profId,
+                courseId: cid,
+              },
             });
-            await manager.save(newUserCourse);
+            if (exists) {
+              exists.role = Role.PROFESSOR;
+              await manager.save(exists);
+            } else {
+              await manager
+                .create(UserCourseModel, {
+                  userId: profId,
+                  courseId: cid,
+                  role: Role.PROFESSOR,
+                })
+                .save();
+            }
           } catch (err) {
+            console.error(err);
             throw new HttpException(err, HttpStatus.INTERNAL_SERVER_ERROR);
           }
         }
@@ -1467,7 +1484,11 @@ export class OrganizationController {
           courseId: cid,
           role: Role.PROFESSOR,
         },
-        relations: ['user'],
+        relations: {
+          user: {
+            organizationUser: true,
+          },
+        },
       });
 
       // filter out professors that are already an organization professor
@@ -1482,14 +1503,15 @@ export class OrganizationController {
           id: prof.organizationUser.id,
           name: prof.organizationUser.name,
         },
+        trueRole: prof.role,
         userId: prof.userId,
       })),
       ...courseProfs.map((prof) => ({
         organizationUser: {
           id: prof.user.id,
           name: prof.user.name,
-          lacksProfOrgRole: true,
         },
+        trueRole: prof.user.organizationUser.role,
         userId: prof.userId,
       })),
     ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -5252,15 +5252,6 @@ axios@^1.10.0:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
-axios@^1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.10.0.tgz#af320aee8632eaf2a400b6a1979fa75856f38d54"
-  integrity sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==
-  dependencies:
-    follow-redirects "^1.15.6"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
-
 axobject-query@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-4.1.0.tgz#28768c76d0e3cff21bc62a9e2d0b6ac30042a1ee"
@@ -15672,6 +15663,11 @@ sonner@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/sonner/-/sonner-2.0.2.tgz#d31316f5b93ecfbfa6c32c0ef4b856a651f5b167"
   integrity sha512-xOeXErZ4blqQd11ZnlDmoRmg+ctUJBkTU8H+HVh9rnWi9Ke28xiL39r4iCTeDX31ODTe/s1MaiaY333dUzLCtA==
+
+sonner@^2.0.6:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/sonner/-/sonner-2.0.7.tgz#810c1487a67ec3370126e0f400dfb9edddc3e4f6"
+  integrity sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==
 
 source-list-map@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
# Description

Crown icon next to admin names in professor selector + course roster
Professor selector was already an admin-only interface but I modified the backend logic to support that (prevent accidental mistakes)
Also made the organization course update route handler only do promotion/demotion, noticed that when deleting from the selector it actually removes the user from the course, it now only demotes to student to prevent unintended removals

Closes #322

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

Updated associated integration test
Manually tested

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing tests pass *locally* with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [x] Any UI changes have been checked to work on desktop, tablet, and mobile
