### PR TITLE
Improve syncDocuments functionality to detect changed LMS items, add …

### DIFF
--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -1354,6 +1354,7 @@ export type LMSAssignment = {
   due?: Date
   modified?: Date
   uploaded?: Date
+  chatbotDocumentId?: string
 }
 
 export type LMSAnnouncement = {
@@ -1364,6 +1365,7 @@ export type LMSAnnouncement = {
   syncEnabled?: boolean
   modified?: Date
   uploaded?: Date
+  chatbotDocumentId?: string
 }
 
 export type LMSPage = {
@@ -1375,6 +1377,7 @@ export type LMSPage = {
   syncEnabled?: boolean
   modified?: Date
   uploaded?: Date
+  chatbotDocumentId?: string
 }
 
 export type LMSFile = {
@@ -1386,6 +1389,7 @@ export type LMSFile = {
   syncEnabled?: boolean
   modified?: Date
   uploaded?: Date
+  chatbotDocumentId?: string
 }
 
 export enum SupportedLMSFileTypes {
@@ -1414,6 +1418,12 @@ export type LMSFileUploadResponse = {
   success: boolean
   documentId?: string
   reason?: LMSErrorType
+}
+
+export type LMSSyncDocumentsResult = {
+  itemsSynced: number
+  itemsRemoved: number
+  errors: number
 }
 
 export enum LMSApiResponseStatus {

--- a/packages/frontend/app/api/index.ts
+++ b/packages/frontend/app/api/index.ts
@@ -99,6 +99,7 @@ import {
   UpsertLMSCourseParams,
   UpsertLMSOrganizationParams,
   UserMailSubscription,
+  LMSSyncDocumentsResult,
 } from '@koh/common'
 import Axios, { AxiosInstance, Method } from 'axios'
 import { plainToClass } from 'class-transformer'
@@ -1154,7 +1155,7 @@ class APIClient {
       this.req('GET', `/api/v1/lms/${courseId}/files`),
     toggleSync: async (courseId: number): Promise<string> =>
       this.req('POST', `/api/v1/lms/${courseId}/sync`),
-    forceSync: async (courseId: number): Promise<string> =>
+    forceSync: async (courseId: number): Promise<LMSSyncDocumentsResult> =>
       this.req('POST', `/api/v1/lms/${courseId}/sync/force`),
     clearDocuments: async (courseId: number): Promise<string> =>
       this.req('DELETE', `/api/v1/lms/${courseId}/sync/clear`),

--- a/packages/server/src/lmsIntegration/lmsIntegration.adapter.ts
+++ b/packages/server/src/lmsIntegration/lmsIntegration.adapter.ts
@@ -286,6 +286,11 @@ class CanvasLMSAdapter extends ImplementedLMSAdapter {
             announcement.posted_at.trim() != ''
               ? new Date(announcement.posted_at)
               : undefined,
+          modified:
+            announcement.last_reply_at != undefined &&
+            announcement.last_reply_at.trim() != ''
+              ? new Date(announcement.last_reply_at)
+              : undefined,
         } as LMSAnnouncement;
       });
     announcements.sort((a0, a1) => {
@@ -338,6 +343,10 @@ class CanvasLMSAdapter extends ImplementedLMSAdapter {
           due:
             assignment.due_at != undefined && assignment.due_at.trim() != ''
               ? new Date(assignment.due_at)
+              : undefined,
+          modified: 
+              assignment.updated_at != undefined && assignment.updated_at.trim() != ''
+              ? new Date(assignment.updated_at)
               : undefined,
         } as LMSAssignment;
       });

--- a/packages/server/src/lmsIntegration/lmsIntegration.controller.ts
+++ b/packages/server/src/lmsIntegration/lmsIntegration.controller.ts
@@ -28,6 +28,7 @@ import {
   TestLMSIntegrationParams,
   UpsertLMSCourseParams,
   UpsertLMSOrganizationParams,
+  LMSSyncDocumentsResult,
 } from '@koh/common';
 import {
   LMSGet,
@@ -411,7 +412,7 @@ export class LMSIntegrationController {
   async forceSynchronizeCourse(
     @User() _user: UserModel,
     @Param('courseId', ParseIntPipe) courseId: number,
-  ): Promise<string> {
+  ): Promise<LMSSyncDocumentsResult> {
     const integration = await LMSCourseIntegrationModel.findOne({
       where: {
         courseId: courseId,
@@ -436,7 +437,7 @@ export class LMSIntegrationController {
     }
 
     try {
-      await this.integrationService.syncDocuments(courseId);
+      return await this.integrationService.syncDocuments(courseId);
     } catch (err) {
       console.error(err);
       throw new HttpException(
@@ -445,7 +446,7 @@ export class LMSIntegrationController {
       );
     }
 
-    return `Successfully forced synchronization with ${integration.orgIntegration.apiPlatform ?? 'LMS'} course.`;
+    //return `Successfully forced synchronization with ${integration.orgIntegration.apiPlatform ?? 'LMS'} course.`;
   }
 
   @Delete(':courseId/sync/clear')

--- a/packages/server/src/lmsIntegration/lmsIntegration.service.ts
+++ b/packages/server/src/lmsIntegration/lmsIntegration.service.ts
@@ -17,6 +17,7 @@ import {
   LMSPage,
   LMSResourceType,
   SupportedLMSFileTypes,
+  LMSSyncDocumentsResult
 } from '@koh/common';
 import { HttpException, HttpStatus, Inject, Injectable } from '@nestjs/common';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
@@ -412,6 +413,12 @@ export class LMSIntegrationService {
       where: { courseId: courseId },
     });
 
+    const syncDocumentsResult: LMSSyncDocumentsResult = {
+      itemsSynced: 0,
+      itemsRemoved: 0,
+      errors: 0,
+    }
+
     // maybe add this later to fallback to all resources if db fetch does not work
 
     //   const selectedResources: LMSResourceType[] =
@@ -442,7 +449,10 @@ export class LMSIntegrationService {
           type,
         );
         if (items.length > 0) {
-          await this.clearSpecificDocuments(courseId, items, model);
+          const numClearedDocuments = await this.clearSpecificDocuments(courseId, items, model);
+          
+          syncDocumentsResult.itemsRemoved += numClearedDocuments;
+          syncDocumentsResult.errors += items.length - numClearedDocuments;
         }
         continue;
       }
@@ -528,19 +538,34 @@ export class LMSIntegrationService {
         | LMSPageModel
         | LMSFileModel
       )[] = persistedItems.filter((i0) => !items.find((i1) => i1.id == i0.id));
-      if (toRemove.length > 0) {
-        const toRemoveIds = toRemove.map((i) => i.id);
-        persistedItems = persistedItems.filter((i) =>
-          toRemoveIds.includes(i.id),
-        );
 
-        await this.clearSpecificDocuments(courseId, toRemove, model);
+      if (toRemove.length > 0) {
+        // the code below led to inconsistent behaviour of syncDocuments when items
+        // are removed from the LMS
+
+        // const toRemoveIds = toRemove.map((i) => i.id);
+
+        // persistedItems = persistedItems.filter((i) =>
+        //   toRemoveIds.includes(i.id),
+        // );
+
+        const numClearedDocuments = await this.clearSpecificDocuments(courseId, toRemove, model);
+
+        syncDocumentsResult.itemsRemoved += numClearedDocuments;
+        syncDocumentsResult.errors += toRemove.length - numClearedDocuments;
       }
 
       for (let i = 0; i < items.length; i++) {
         const found = persistedItems.find((p) => p.id == items[i].id);
         if (found) {
-          items[i] = found;
+          // expand LMS item with peristed item's meta properties to properly
+          // update persisted data when it differs from LMS data
+          items[i] = {
+            ...items[i],
+            chatbotDocumentId: found.chatbotDocumentId,
+            uploaded: found.uploaded,
+            modified: items[i].modified ?? found.modified
+          }
         }
       }
 
@@ -557,9 +582,13 @@ export class LMSIntegrationService {
 
       const statuses: LMSFileUploadResponse[] = [];
       for (const item of items) {
-        statuses.push(
-          await this.uploadDocument(courseId, item, token, type, adapter),
-        );
+        const uploadDocumentResponse = await this.uploadDocument(courseId, item, token, type, adapter);
+        statuses.push(uploadDocumentResponse);
+
+        if(uploadDocumentResponse.success) 
+          syncDocumentsResult.itemsSynced++;
+        else
+          syncDocumentsResult.errors++;
       }
 
       await ChatTokenModel.remove(token);
@@ -671,6 +700,8 @@ export class LMSIntegrationService {
           break;
       }
     }
+
+    return syncDocumentsResult;
   }
 
   async clearDocuments(courseId: number, exceptIn?: LMSIntegrationPlatform) {
@@ -708,6 +739,8 @@ export class LMSIntegrationService {
       | typeof LMSPageModel
       | typeof LMSFileModel,
   ) {
+    let numClearedDocuments = 0;
+
     const tempUser = await UserModel.create({
       email: 'tempemail@example.com',
     }).save();
@@ -719,7 +752,10 @@ export class LMSIntegrationService {
 
     const statuses: LMSFileUploadResponse[] = [];
     for (const item of items) {
-      statuses.push(await this.deleteDocument(courseId, item, token));
+      const deleteResponse: LMSFileUploadResponse = await this.deleteDocument(courseId, item, token);
+      statuses.push(deleteResponse);
+
+      if(deleteResponse.success) numClearedDocuments++;
     }
 
     await ChatTokenModel.remove(token);
@@ -727,6 +763,8 @@ export class LMSIntegrationService {
 
     const successfulIds = statuses.filter((s) => s.success).map((s) => s.id);
     await model.remove(items.filter((i) => successfulIds.includes(i.id)));
+
+    return numClearedDocuments;
   }
 
   async singleDocOperation(


### PR DESCRIPTION
# Description

- Removed code in the LMS integration service's `syncDocuments` that resulted in inconsistent syncing behaviour when there are persisted items to remove (e.g. because they were removed from the LMS course)
- Modified `syncDocuments` to augment objects returned by the LMS's API (e.g. LMSPage, LMSAssignment, etc.) rather than fully replace them with persisted items to properly update persisted data when LMS data changes
- Added counters for synced/removed documents and modified return types to send synced/removed document counts to frontend
- Modified frontend messaging on the course settings page's "LMS Integrations" tab to provide more detailed but still brief feedback to the user after forcing synchronization

Closes #312

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

Tested manually.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing tests pass *locally* with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [x] Any UI changes have been checked to work on desktop, tablet, and mobile
