### PR TITLE
Improved Course Chatbot Settings Backfill + Minor Migration Fix

### DIFF
--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -882,7 +882,6 @@ export class UpdateLLMTypeBody {
 
 export interface ChatbotSettings {
   id: string
-  AvailableModelTypes: Record<string, string>
   pageContent: string
   metadata: ChatbotSettingsMetadata
 }
@@ -1785,7 +1784,7 @@ export type LMSAnnouncement = {
 export type LMSPage = {
   id: number
   title: string
-  body: string
+  body?: string
   url: string
   frontPage: boolean
   syncEnabled?: boolean

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/lms_integrations/components/LMSDocumentList.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/lms_integrations/components/LMSDocumentList.tsx
@@ -481,7 +481,7 @@ export default function LMSDocumentList<
               (d as LMSPage).title
                 .toLowerCase()
                 .includes(search.toLowerCase()) ||
-              (d as LMSPage).body.toLowerCase().includes(search.toLowerCase())
+              (d as LMSPage).body?.toLowerCase().includes(search.toLowerCase())
             )
           case 'File':
             return (

--- a/packages/server/migration/1755999708148-lms-page-body-drop-not-null.ts
+++ b/packages/server/migration/1755999708148-lms-page-body-drop-not-null.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Test1755999708148 implements MigrationInterface {
+  name = 'Test1755999708148';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "lms_page_model" ALTER COLUMN "body" DROP NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "lms_page_model" ALTER COLUMN "body" SET NOT NULL`,
+    );
+  }
+}

--- a/packages/server/src/chatbot/chatbot-datasource/chatbot-datasource.service.ts
+++ b/packages/server/src/chatbot/chatbot-datasource/chatbot-datasource.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, OnModuleDestroy } from '@nestjs/common';
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
 import { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions';
 import { DataSource } from 'typeorm';
 
@@ -116,6 +116,8 @@ export class ChatbotDataSourceService implements OnModuleDestroy {
         console.error(err);
       }
     }
-    await this.dataSource.destroy();
+    if (this.dataSource.isInitialized) {
+      await this.dataSource.destroy();
+    }
   }
 }

--- a/packages/server/src/chatbot/chatbot.service.ts
+++ b/packages/server/src/chatbot/chatbot.service.ts
@@ -467,11 +467,11 @@ export class ChatbotService {
           const dataSource = await this.chatbotDataSource.getDataSource();
           const qry = dataSource.createQueryRunner();
           await qry.connect();
-          existingSetting = await qry.query(
+          existingSetting = (
             await qry.query(
               'SELECT * FROM course_setting WHERE "pageContent" = $1',
               [String(course.id)],
-            ),
+            )
           )[0];
         } catch (_err) {}
       }

--- a/packages/server/src/lmsIntegration/lmsIntegration.service.spec.ts
+++ b/packages/server/src/lmsIntegration/lmsIntegration.service.spec.ts
@@ -7,8 +7,7 @@ import {
 import { Test, TestingModule } from '@nestjs/testing';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import {
-  TestChatbotModule,
-  TestChatbotDataSourceModule,
+  TestChatbotConnectionOptions,
   TestConfigModule,
   TestTypeOrmModule,
 } from '../../test/util/testUtils';
@@ -32,7 +31,7 @@ import {
   LMSIntegrationPlatform,
 } from '@koh/common';
 import { LMSCourseIntegrationModel } from './lmsCourseIntegration.entity';
-import { HttpStatus, InjectionToken, Provider } from '@nestjs/common';
+import { HttpStatus } from '@nestjs/common';
 import { LMSOrganizationIntegrationModel } from './lmsOrgIntegration.entity';
 import { CourseModel } from '../course/course.entity';
 import { OrganizationModel } from '../organization/organization.entity';
@@ -42,8 +41,6 @@ import { FactoryModule } from 'factory/factory.module';
 import { FactoryService } from 'factory/factory.service';
 import { ChatbotModule } from '../chatbot/chatbot.module';
 import { ChatbotApiService } from '../chatbot/chatbot-api.service';
-import { getDataSourceToken, InjectDataSource } from '@nestjs/typeorm';
-import { ChatbotSettingsSubscriber } from '../chatbot/chatbot-infrastructure-models/chatbot-settings.subscriber';
 
 const mockCacheManager = {
   get: jest.fn(),
@@ -65,10 +62,9 @@ describe('LMSIntegrationService', () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [
         TestTypeOrmModule,
-        TestChatbotDataSourceModule,
         TestConfigModule,
         FactoryModule,
-        TestChatbotModule,
+        ChatbotModule.forRoot(TestChatbotConnectionOptions),
       ],
       providers: [
         LMSIntegrationService,

--- a/packages/server/src/lmsIntegration/lmsPage.entity.ts
+++ b/packages/server/src/lmsIntegration/lmsPage.entity.ts
@@ -26,8 +26,8 @@ export class LMSPageModel extends BaseEntity {
   @Column({ type: 'text' })
   title: string;
 
-  @Column({ type: 'text' })
-  body: string;
+  @Column({ type: 'text', nullable: true })
+  body?: string;
 
   @Column({ type: 'text', nullable: true })
   url: string;

--- a/packages/server/test/chatbot.integration.ts
+++ b/packages/server/test/chatbot.integration.ts
@@ -40,7 +40,7 @@ import { UserModel } from '../src/profile/user.entity';
 import { ChatbotApiService } from '../src/chatbot/chatbot-api.service';
 
 describe('ChatbotController Integration', () => {
-  const { supertest, getTestModule } = setupIntegrationTest(ChatbotModule);
+  const { supertest } = setupIntegrationTest(ChatbotModule);
 
   describe('PATCH /chatbot/questionScore/:courseId/:questionId', () => {
     it('should allow a student to update the score of a question', async () => {


### PR DESCRIPTION
# Description

* Improved course chatbot settings backfill to retain old parameters + model (if possible)
* Minor migration addition for the pages 'body' column being nullable

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

Manually

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing tests pass *locally* with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [x] Any UI changes have been checked to work on desktop, tablet, and mobile
