### PR TITLE
Canvas Quizzes Integration

### DIFF
--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -1804,6 +1804,29 @@ export type LMSFile = {
   uploaded?: Date
 }
 
+export enum LMSQuizAccessLevel {
+  LOGISTICS_ONLY = 'logistics_only',
+  LOGISTICS_AND_QUESTIONS = 'logistics_and_questions',
+  LOGISTICS_QUESTIONS_GENERAL_COMMENTS = 'logistics_questions_general_comments',
+  FULL_ACCESS = 'full_access',
+}
+
+export type LMSQuiz = {
+  id: number
+  title: string
+  description?: string
+  due?: Date
+  unlock?: Date
+  lock?: Date
+  timeLimit?: number
+  allowedAttempts?: number
+  questions?: any[]
+  accessLevel?: LMSQuizAccessLevel
+  syncEnabled?: boolean
+  modified?: Date
+  uploaded?: Date
+}
+
 export enum SupportedLMSFileTypes {
   pdf = 'application/pdf', // .pdf files
   pptx = 'application/vnd.openxmlformats-officedocument.presentationml.presentation', // .pptx files
@@ -1853,6 +1876,7 @@ export enum LMSResourceType {
   ANNOUNCEMENTS = 'announcements',
   PAGES = 'pages',
   FILES = 'files',
+  QUIZZES = 'quizzes',
 }
 
 export interface CourseResponse {

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/lms_integrations/components/LMSQuizDocumentList.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/lms_integrations/components/LMSQuizDocumentList.tsx
@@ -1,0 +1,441 @@
+import {
+  CloseOutlined,
+  DeleteOutlined,
+  EyeOutlined,
+  InfoCircleOutlined,
+  SearchOutlined,
+  StopOutlined,
+  SyncOutlined,
+} from '@ant-design/icons'
+import { LMSQuiz, LMSQuizAccessLevel, LMSResourceType } from '@koh/common'
+import {
+  Badge,
+  Button,
+  Collapse,
+  Input,
+  List,
+  message,
+  Pagination,
+  Select,
+  Spin,
+  Tooltip,
+} from 'antd'
+import { useEffect, useMemo, useState } from 'react'
+import { cn, getErrorMessage } from '@/app/utils/generalUtils'
+import { API } from '@/app/api'
+import QuizContentPreviewModal from './QuizContentPreviewModal'
+
+export interface LMSQuizDocumentListProps {
+  courseId: number
+  documents: LMSQuiz[]
+  loadingLMSData?: boolean
+  lmsSynchronize?: boolean
+  onUpdateCallback?: () => void
+  selectedResourceTypes?: LMSResourceType[]
+}
+
+const accessLevelLabels = {
+  [LMSQuizAccessLevel.LOGISTICS_ONLY]: 'Logistics Only',
+  [LMSQuizAccessLevel.LOGISTICS_AND_QUESTIONS]: 'Logistics + Questions',
+  [LMSQuizAccessLevel.LOGISTICS_QUESTIONS_GENERAL_COMMENTS]:
+    'Logistics + Questions + Comments',
+  [LMSQuizAccessLevel.FULL_ACCESS]: 'Full Access',
+}
+
+const accessLevelDescriptions = {
+  [LMSQuizAccessLevel.LOGISTICS_ONLY]:
+    'Only quiz title, due dates, time limits, and availability dates',
+  [LMSQuizAccessLevel.LOGISTICS_AND_QUESTIONS]:
+    'Logistics + all question text (no answers)',
+  [LMSQuizAccessLevel.LOGISTICS_QUESTIONS_GENERAL_COMMENTS]:
+    'Logistics + questions + general quiz comments',
+  [LMSQuizAccessLevel.FULL_ACCESS]:
+    'Complete quiz content including all answers and detailed feedback',
+}
+
+export default function LMSQuizDocumentList({
+  courseId,
+  documents,
+  loadingLMSData = false,
+  lmsSynchronize,
+  onUpdateCallback = () => undefined,
+  selectedResourceTypes = [LMSResourceType.QUIZZES],
+}: LMSQuizDocumentListProps) {
+  const [search, setSearch] = useState<string>('')
+  const [page, setPage] = useState<number>(1)
+  const [pageSize, setPageSize] = useState<number>(25)
+  const [loading, setLoading] = useState<string[]>([])
+  const [accessLevelLoading, setAccessLevelLoading] = useState<string[]>([])
+  const [previewModalOpen, setPreviewModalOpen] = useState(false)
+  const [previewQuiz, setPreviewQuiz] = useState<LMSQuiz | null>(null)
+  const [bulkSyncLoading, setBulkSyncLoading] = useState(false)
+
+  const filteredDocuments = useMemo(() => {
+    return documents
+      .filter(
+        (doc) =>
+          search === '' ||
+          doc.title.toLowerCase().includes(search.toLowerCase()),
+      )
+      .sort((a, b) => {
+        // Sort by due date if available, otherwise by title
+        if (a.due && b.due) {
+          return new Date(a.due).getTime() - new Date(b.due).getTime()
+        } else if (a.due) {
+          return -1
+        } else if (b.due) {
+          return 1
+        } else {
+          return a.title.localeCompare(b.title)
+        }
+      })
+  }, [documents, search])
+
+  const paginatedDocuments = useMemo(() => {
+    const startIndex = (page - 1) * pageSize
+    return filteredDocuments.slice(startIndex, startIndex + pageSize)
+  }, [filteredDocuments, page, pageSize])
+
+  const handleToggleSync = async (quiz: LMSQuiz) => {
+    if (loading.includes(quiz.id.toString())) return
+
+    setLoading([...loading, quiz.id.toString()])
+    try {
+      const updatedQuiz = { ...quiz, syncEnabled: !quiz.syncEnabled }
+      await API.lmsIntegration.toggleSyncQuiz(courseId, quiz.id, updatedQuiz)
+      onUpdateCallback()
+      message.success(
+        `Quiz sync ${updatedQuiz.syncEnabled ? 'enabled' : 'disabled'}`,
+      )
+    } catch (error) {
+      message.error(getErrorMessage(error))
+    } finally {
+      setLoading(loading.filter((id) => id !== quiz.id.toString()))
+    }
+  }
+
+  const handleAccessLevelChange = async (
+    quiz: LMSQuiz,
+    accessLevel: LMSQuizAccessLevel,
+  ) => {
+    if (accessLevelLoading.includes(quiz.id.toString())) return
+
+    setAccessLevelLoading([...accessLevelLoading, quiz.id.toString()])
+    try {
+      await API.lmsIntegration.updateQuizAccessLevel(
+        courseId,
+        quiz.id,
+        accessLevel,
+      )
+      onUpdateCallback()
+      message.success('Quiz access level updated')
+    } catch (error) {
+      message.error(getErrorMessage(error))
+    } finally {
+      setAccessLevelLoading(
+        accessLevelLoading.filter((id) => id !== quiz.id.toString()),
+      )
+    }
+  }
+
+  const handlePreviewQuiz = (quiz: LMSQuiz) => {
+    setPreviewQuiz(quiz)
+    setPreviewModalOpen(true)
+  }
+
+  const handleClosePreview = () => {
+    setPreviewModalOpen(false)
+    setPreviewQuiz(null)
+  }
+
+  const handleBulkDisableSync = async () => {
+    if (bulkSyncLoading) return
+
+    setBulkSyncLoading(true)
+    try {
+      await API.lmsIntegration.bulkUpdateQuizSync(courseId, 'disable')
+      onUpdateCallback()
+      message.success('Successfully disabled sync for all quizzes')
+    } catch (error) {
+      message.error(getErrorMessage(error))
+    } finally {
+      setBulkSyncLoading(false)
+    }
+  }
+
+  const handleBulkEnableSync = async () => {
+    if (bulkSyncLoading) return
+
+    const allQuizIds = documents.map((quiz) => quiz.id)
+    if (allQuizIds.length === 0) {
+      message.warning('No quizzes available to enable')
+      return
+    }
+
+    setBulkSyncLoading(true)
+    try {
+      await API.lmsIntegration.bulkUpdateQuizSync(
+        courseId,
+        'enable',
+        allQuizIds,
+      )
+      onUpdateCallback()
+      message.success('Successfully enabled sync for all quizzes')
+    } catch (error) {
+      message.error(getErrorMessage(error))
+    } finally {
+      setBulkSyncLoading(false)
+    }
+  }
+
+  const getQuizBadges = (quiz: LMSQuiz) => {
+    const badges = []
+
+    if (quiz.due) {
+      const dueDate = new Date(quiz.due)
+      const isOverdue = dueDate < new Date()
+      badges.push(
+        <Badge
+          key="due"
+          color={isOverdue ? 'red' : 'blue'}
+          text={`Due: ${dueDate.toLocaleDateString()}`}
+        />,
+      )
+    }
+
+    if (quiz.timeLimit) {
+      badges.push(
+        <Badge key="time" color="orange" text={`${quiz.timeLimit} min`} />,
+      )
+    }
+
+    if (quiz.allowedAttempts) {
+      badges.push(
+        <Badge
+          key="attempts"
+          color="purple"
+          text={`${quiz.allowedAttempts} attempt${quiz.allowedAttempts > 1 ? 's' : ''}`}
+        />,
+      )
+    }
+
+    return badges
+  }
+
+  const isQuizSyncEnabled = selectedResourceTypes.includes(
+    LMSResourceType.QUIZZES,
+  )
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Search and Controls */}
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <Input
+          placeholder="Search quizzes..."
+          prefix={<SearchOutlined />}
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          allowClear
+          className="sm:w-64"
+        />
+        <div className="flex items-center gap-2">
+          {isQuizSyncEnabled && lmsSynchronize && (
+            <>
+              <Button
+                icon={<SyncOutlined />}
+                onClick={handleBulkEnableSync}
+                loading={bulkSyncLoading}
+                size="small"
+                type="primary"
+                title="Enable sync for all quizzes"
+              >
+                Enable All Sync
+              </Button>
+              <Button
+                icon={<StopOutlined />}
+                onClick={handleBulkDisableSync}
+                loading={bulkSyncLoading}
+                size="small"
+                title="Disable sync for all quizzes - useful for selective re-enabling"
+              >
+                Disable All Sync
+              </Button>
+            </>
+          )}
+          <span className="text-sm text-gray-600">
+            {filteredDocuments.length} quiz
+            {filteredDocuments.length !== 1 ? 'es' : ''}
+          </span>
+        </div>
+      </div>
+
+      {/* Resource Type Warning */}
+      {!isQuizSyncEnabled && (
+        <div className="rounded-md border border-orange-200 bg-orange-50 p-4">
+          <div className="flex items-start">
+            <InfoCircleOutlined className="mt-1 text-orange-500" />
+            <div className="ml-3">
+              <p className="text-sm text-orange-800">
+                Quiz syncing is currently disabled. Enable "Quizzes" in the
+                resource selection to sync quiz content with the chatbot.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Loading State */}
+      {loadingLMSData ? (
+        <div className="flex items-center justify-center py-8">
+          <Spin size="large" />
+        </div>
+      ) : (
+        <>
+          {/* Quiz List */}
+          <List
+            dataSource={paginatedDocuments}
+            renderItem={(quiz) => {
+              const isItemLoading = loading.includes(quiz.id.toString())
+              const isAccessLevelLoading = accessLevelLoading.includes(
+                quiz.id.toString(),
+              )
+              const currentAccessLevel =
+                quiz.accessLevel || LMSQuizAccessLevel.LOGISTICS_ONLY
+
+              return (
+                <List.Item
+                  className={cn(
+                    'mb-4 rounded-lg border border-gray-200 p-4',
+                    quiz.syncEnabled && 'border-green-200 bg-green-50',
+                  )}
+                >
+                  <div className="w-full">
+                    <div className="flex items-start justify-between">
+                      <div className="min-w-0 flex-1">
+                        <h3 className="truncate text-lg font-semibold text-gray-900">
+                          {quiz.title}
+                        </h3>
+
+                        {quiz.description && (
+                          <p className="mt-1 line-clamp-2 text-sm text-gray-600">
+                            {quiz.description.replace(/<[^>]*>/g, '')}
+                          </p>
+                        )}
+
+                        <div className="mt-2 flex flex-wrap gap-2">
+                          {getQuizBadges(quiz)}
+                        </div>
+
+                        {quiz.syncEnabled && (
+                          <div className="mt-3">
+                            <div className="mb-2 flex items-center gap-2">
+                              <span className="text-sm font-medium text-gray-700">
+                                Access Level:
+                              </span>
+                              <Tooltip
+                                title={
+                                  accessLevelDescriptions[currentAccessLevel]
+                                }
+                              >
+                                <InfoCircleOutlined className="text-gray-400" />
+                              </Tooltip>
+                            </div>
+                            <Select
+                              value={currentAccessLevel}
+                              onChange={(value) =>
+                                handleAccessLevelChange(quiz, value)
+                              }
+                              loading={isAccessLevelLoading}
+                              disabled={!quiz.syncEnabled}
+                              className="w-64"
+                              options={Object.entries(accessLevelLabels).map(
+                                ([value, label]) => ({
+                                  value,
+                                  label,
+                                }),
+                              )}
+                            />
+                          </div>
+                        )}
+                      </div>
+
+                      <div className="ml-4 flex flex-col gap-2">
+                        <Button
+                          icon={<EyeOutlined />}
+                          onClick={() => handlePreviewQuiz(quiz)}
+                          size="small"
+                          title="Preview what content the chatbot will see"
+                        >
+                          Preview Content
+                        </Button>
+                        {isQuizSyncEnabled && lmsSynchronize && (
+                          <Button
+                            type={quiz.syncEnabled ? 'default' : 'primary'}
+                            icon={
+                              quiz.syncEnabled ? (
+                                <CloseOutlined />
+                              ) : (
+                                <SyncOutlined />
+                              )
+                            }
+                            loading={isItemLoading}
+                            onClick={() => handleToggleSync(quiz)}
+                            size="small"
+                          >
+                            {quiz.syncEnabled ? 'Disable Sync' : 'Enable Sync'}
+                          </Button>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </List.Item>
+              )
+            }}
+          />
+
+          {/* Pagination */}
+          {filteredDocuments.length > pageSize && (
+            <div className="mt-4 flex justify-center">
+              <Pagination
+                current={page}
+                pageSize={pageSize}
+                total={filteredDocuments.length}
+                onChange={(newPage, newPageSize) => {
+                  setPage(newPage)
+                  if (newPageSize) setPageSize(newPageSize)
+                }}
+                showSizeChanger
+                showQuickJumper
+                showTotal={(total, range) =>
+                  `${range[0]}-${range[1]} of ${total} quizzes`
+                }
+              />
+            </div>
+          )}
+
+          {/* Empty State */}
+          {filteredDocuments.length === 0 && !loadingLMSData && (
+            <div className="py-8 text-center">
+              <p className="text-gray-500">
+                {search ? 'No quizzes match your search.' : 'No quizzes found.'}
+              </p>
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Preview Modal */}
+      {previewQuiz && (
+        <QuizContentPreviewModal
+          quiz={previewQuiz}
+          courseId={courseId}
+          currentAccessLevel={
+            previewQuiz.accessLevel || LMSQuizAccessLevel.LOGISTICS_ONLY
+          }
+          open={previewModalOpen}
+          onClose={handleClosePreview}
+        />
+      )}
+    </div>
+  )
+}

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/lms_integrations/components/QuizContentPreviewModal.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/lms_integrations/components/QuizContentPreviewModal.tsx
@@ -1,0 +1,159 @@
+'use client'
+
+import React, { useState, useEffect } from 'react'
+import { Modal, Select, Typography, Spin, Alert, Button } from 'antd'
+import { EyeOutlined } from '@ant-design/icons'
+import { LMSQuiz, LMSQuizAccessLevel } from '@koh/common'
+import { API } from '@/app/api'
+
+const { Option } = Select
+const { Text } = Typography
+
+interface QuizContentPreviewModalProps {
+  quiz: LMSQuiz
+  courseId: number
+  currentAccessLevel: LMSQuizAccessLevel
+  open: boolean
+  onClose: () => void
+}
+
+const ACCESS_LEVEL_LABELS = {
+  [LMSQuizAccessLevel.LOGISTICS_ONLY]: 'Logistics Only',
+  [LMSQuizAccessLevel.LOGISTICS_AND_QUESTIONS]: 'Logistics & Questions',
+  [LMSQuizAccessLevel.LOGISTICS_QUESTIONS_GENERAL_COMMENTS]:
+    'Logistics, Questions & Comments',
+  [LMSQuizAccessLevel.FULL_ACCESS]: 'Full Access',
+}
+
+const ACCESS_LEVEL_DESCRIPTIONS = {
+  [LMSQuizAccessLevel.LOGISTICS_ONLY]:
+    'Only basic quiz information (title, due dates, time limits)',
+  [LMSQuizAccessLevel.LOGISTICS_AND_QUESTIONS]:
+    'Basic info + question text (no answers)',
+  [LMSQuizAccessLevel.LOGISTICS_QUESTIONS_GENERAL_COMMENTS]:
+    'Basic info + questions + general comments',
+  [LMSQuizAccessLevel.FULL_ACCESS]:
+    'Complete quiz content including answers and feedback',
+}
+
+export const QuizContentPreviewModal: React.FC<
+  QuizContentPreviewModalProps
+> = ({ quiz, courseId, currentAccessLevel, open, onClose }) => {
+  const [selectedAccessLevel, setSelectedAccessLevel] =
+    useState<LMSQuizAccessLevel>(currentAccessLevel)
+  const [previewContent, setPreviewContent] = useState<string>('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (open) {
+      setSelectedAccessLevel(currentAccessLevel)
+      fetchPreview(currentAccessLevel)
+    }
+  }, [open, currentAccessLevel])
+
+  const fetchPreview = async (accessLevel: LMSQuizAccessLevel) => {
+    setLoading(true)
+    setError(null)
+
+    try {
+      const response = await API.lmsIntegration.getQuizContentPreview(
+        courseId,
+        quiz.id,
+        accessLevel,
+      )
+      setPreviewContent(response.content)
+    } catch (err) {
+      setError('Failed to load preview content')
+      console.error('Preview error:', err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleAccessLevelChange = (accessLevel: LMSQuizAccessLevel) => {
+    setSelectedAccessLevel(accessLevel)
+    fetchPreview(accessLevel)
+  }
+
+  return (
+    <Modal
+      title={
+        <div>
+          <EyeOutlined style={{ marginRight: 8 }} />
+          Chatbot Content Preview: {quiz.title}
+        </div>
+      }
+      open={open}
+      onCancel={onClose}
+      width={800}
+      footer={[
+        <Button key="close" onClick={onClose}>
+          Close
+        </Button>,
+      ]}
+    >
+      <div style={{ marginBottom: 16 }}>
+        <div style={{ marginBottom: 8 }}>
+          <Text strong>Access Level:</Text>
+        </div>
+        <Select
+          value={selectedAccessLevel}
+          onChange={handleAccessLevelChange}
+          style={{ width: '100%', marginBottom: 8 }}
+        >
+          {Object.values(LMSQuizAccessLevel).map((level) => (
+            <Option key={level} value={level}>
+              {ACCESS_LEVEL_LABELS[level]}
+            </Option>
+          ))}
+        </Select>
+        <Text type="secondary" style={{ fontSize: '12px' }}>
+          {ACCESS_LEVEL_DESCRIPTIONS[selectedAccessLevel]}
+        </Text>
+      </div>
+
+      {selectedAccessLevel !== currentAccessLevel && (
+        <Alert
+          message="Preview Mode"
+          description={`This shows what the chatbot would see if access level was changed to "${ACCESS_LEVEL_LABELS[selectedAccessLevel]}". Current level is "${ACCESS_LEVEL_LABELS[currentAccessLevel]}".`}
+          type="info"
+          showIcon
+          style={{ marginBottom: 16 }}
+        />
+      )}
+
+      <div style={{ marginBottom: 8 }}>
+        <Text strong>Content that will be sent to the chatbot:</Text>
+      </div>
+
+      {loading ? (
+        <div style={{ textAlign: 'center', padding: '40px 0' }}>
+          <Spin size="large" />
+          <div style={{ marginTop: 16 }}>Loading preview...</div>
+        </div>
+      ) : error ? (
+        <Alert message="Error" description={error} type="error" showIcon />
+      ) : (
+        <div
+          style={{
+            backgroundColor: '#f5f5f5',
+            border: '1px solid #d9d9d9',
+            borderRadius: '6px',
+            padding: '16px',
+            maxHeight: '400px',
+            overflow: 'auto',
+            fontFamily: 'monospace',
+            fontSize: '12px',
+            lineHeight: '1.5',
+            whiteSpace: 'pre-wrap',
+          }}
+        >
+          {previewContent || 'No content available for this access level.'}
+        </div>
+      )}
+    </Modal>
+  )
+}
+
+export default QuizContentPreviewModal

--- a/packages/frontend/app/api/index.ts
+++ b/packages/frontend/app/api/index.ts
@@ -63,6 +63,8 @@ import {
   LMSFile,
   LMSOrganizationIntegrationPartial,
   LMSPage,
+  LMSQuiz,
+  LMSQuizAccessLevel,
   MailServiceWithSubscription,
   OllamaLLMType,
   OrganizationChatbotSettings,
@@ -1339,6 +1341,8 @@ class APIClient {
       this.req('GET', `/api/v1/lms/${courseId}/pages`),
     getFiles: async (courseId: number): Promise<LMSFile[]> =>
       this.req('GET', `/api/v1/lms/${courseId}/files`),
+    getQuizzes: async (courseId: number): Promise<LMSQuiz[]> =>
+      this.req('GET', `/api/v1/lms/${courseId}/quizzes`),
     toggleSync: async (courseId: number): Promise<string> =>
       this.req('POST', `/api/v1/lms/${courseId}/sync`),
     forceSync: async (courseId: number): Promise<LMSSyncDocumentsResult> =>
@@ -1389,6 +1393,46 @@ class APIClient {
         undefined,
         file,
       ),
+    toggleSyncQuiz: async (
+      courseId: number,
+      quizId: number,
+      quiz: LMSQuiz,
+    ): Promise<string> =>
+      this.req(
+        'POST',
+        `/api/v1/lms/${courseId}/sync/quiz/${quizId}/toggle`,
+        undefined,
+        quiz,
+      ),
+    updateQuizAccessLevel: async (
+      courseId: number,
+      quizId: number,
+      accessLevel: LMSQuizAccessLevel,
+    ): Promise<string> =>
+      this.req(
+        'POST',
+        `/api/v1/lms/${courseId}/quiz/${quizId}/access-level`,
+        undefined,
+        { accessLevel },
+      ),
+    getQuizContentPreview: async (
+      courseId: number,
+      quizId: number,
+      accessLevel: LMSQuizAccessLevel,
+    ): Promise<{ content: string }> =>
+      this.req(
+        'GET',
+        `/api/v1/lms/${courseId}/quiz/${quizId}/preview/${accessLevel}`,
+      ),
+    bulkUpdateQuizSync: async (
+      courseId: number,
+      action: 'enable' | 'disable',
+      quizIds?: number[],
+    ): Promise<string> =>
+      this.req('POST', `/api/v1/lms/${courseId}/quizzes/bulk-sync`, undefined, {
+        action,
+        quizIds,
+      }),
     updateSelectedResourceTypes: async (
       courseId: number,
       selectedResourceTypes: string[],

--- a/packages/frontend/app/hooks/useCourseLmsIntegration.ts
+++ b/packages/frontend/app/hooks/useCourseLmsIntegration.ts
@@ -6,6 +6,7 @@ import {
   LMSCourseIntegrationPartial,
   LMSFile,
   LMSPage,
+  LMSQuiz,
 } from '@koh/common'
 import { API } from '@/app/api'
 import { getErrorMessage } from '@/app/utils/generalUtils'
@@ -18,6 +19,7 @@ export type CourseLmsIntegration = {
   announcements: LMSAnnouncement[]
   pages: LMSPage[]
   files: LMSFile[]
+  quizzes: LMSQuiz[]
   students: string[]
   isLoading: boolean
   isLoadingIntegration: boolean
@@ -27,6 +29,7 @@ export type CourseLmsIntegration = {
   isLoadingAnnouncements: boolean
   isLoadingFiles: boolean
   isLoadingPages: boolean
+  isLoadingQuizzes: boolean
 }
 
 export function useCourseLmsIntegration(
@@ -41,6 +44,7 @@ export function useCourseLmsIntegration(
   const [announcements, setAnnouncements] = useState<LMSAnnouncement[]>([])
   const [pages, setPages] = useState<LMSPage[]>([])
   const [files, setFiles] = useState<LMSFile[]>([])
+  const [quizzes, setQuizzes] = useState<LMSQuiz[]>([])
   const [students, setStudents] = useState<string[]>([])
   const [isLoading, setIsLoading] = useState<boolean>(true)
   const [isLoadingIntegration, setIsLoadingIntegration] =
@@ -54,6 +58,7 @@ export function useCourseLmsIntegration(
   const [isLoadingAnnouncements, setIsLoadingAnnouncements] =
     useState<boolean>(false)
   const [isLoadingFiles, setIsLoadingFiles] = useState<boolean>(false)
+  const [isLoadingQuizzes, setIsLoadingQuizzes] = useState<boolean>(false)
 
   const errorFx = (error: any) => {
     message.error(getErrorMessage(error))
@@ -114,6 +119,11 @@ export function useCourseLmsIntegration(
             setPages,
             setIsLoadingPages,
           )
+          await getResource(
+            API.lmsIntegration.getQuizzes(courseId),
+            setQuizzes,
+            setIsLoadingQuizzes,
+          )
           setIsLoading(false)
         }
       } else {
@@ -123,6 +133,7 @@ export function useCourseLmsIntegration(
         setIsLoadingFiles(false)
         setIsLoadingAssignments(false)
         setIsLoadingAnnouncements(false)
+        setIsLoadingQuizzes(false)
       }
     }
     getResources()
@@ -135,6 +146,7 @@ export function useCourseLmsIntegration(
     setAnnouncements([])
     setPages([])
     setFiles([])
+    setQuizzes([])
     setStudents([])
     setIsLoading(true)
     setIsLoadingIntegration(true)
@@ -143,6 +155,7 @@ export function useCourseLmsIntegration(
     setIsLoadingFiles(false)
     setIsLoadingAssignments(false)
     setIsLoadingAnnouncements(false)
+    setIsLoadingQuizzes(false)
   }
 
   useEffect(() => {
@@ -173,6 +186,7 @@ export function useCourseLmsIntegration(
     announcements,
     pages,
     files,
+    quizzes,
     students,
     isLoading,
     isLoadingIntegration,
@@ -182,5 +196,6 @@ export function useCourseLmsIntegration(
     isLoadingAnnouncements,
     isLoadingFiles,
     isLoadingPages,
+    isLoadingQuizzes,
   }
 }

--- a/packages/server/migration/1756027628128-add-quizzes-to-lms-resource-types.ts
+++ b/packages/server/migration/1756027628128-add-quizzes-to-lms-resource-types.ts
@@ -1,0 +1,65 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddQuizzesToLmsResourceTypes1756027628128
+  implements MigrationInterface
+{
+  name = 'AddQuizzesToLmsResourceTypes1756027628128';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."lms_quiz_model_accesslevel_enum" AS ENUM('logistics_only', 'logistics_and_questions', 'logistics_questions_general_comments', 'full_access')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "lms_quiz_model" ("id" integer NOT NULL, "courseId" integer NOT NULL, "lmsSource" text NOT NULL, "title" text NOT NULL, "description" text, "due" TIMESTAMP, "unlock" TIMESTAMP, "lock" TIMESTAMP, "timeLimit" integer, "allowedAttempts" integer, "questions" jsonb, "modified" TIMESTAMP NOT NULL, "accessLevel" "public"."lms_quiz_model_accesslevel_enum" NOT NULL DEFAULT 'logistics_only', "chatbotDocumentId" text, "uploaded" TIMESTAMP, "syncEnabled" boolean NOT NULL DEFAULT true, CONSTRAINT "PK_704637485df0a069c217aaaf61a" PRIMARY KEY ("id", "courseId"))`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."lms_course_integration_model_selectedresourcetypes_enum" RENAME TO "lms_course_integration_model_selectedresourcetypes_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."lms_course_integration_model_selectedresourcetypes_enum" AS ENUM('assignments', 'announcements', 'pages', 'files', 'quizzes')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "lms_course_integration_model" ALTER COLUMN "selectedResourceTypes" DROP DEFAULT`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "lms_course_integration_model" ALTER COLUMN "selectedResourceTypes" TYPE "public"."lms_course_integration_model_selectedresourcetypes_enum"[] USING "selectedResourceTypes"::"text"::"public"."lms_course_integration_model_selectedresourcetypes_enum"[]`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "lms_course_integration_model" ALTER COLUMN "selectedResourceTypes" SET DEFAULT '{assignments,announcements,pages}'`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."lms_course_integration_model_selectedresourcetypes_enum_old"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "lms_quiz_model" ADD CONSTRAINT "FK_a1fc6aaad49b5fb4045f28d1d49" FOREIGN KEY ("courseId") REFERENCES "lms_course_integration_model"("courseId") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "lms_quiz_model" DROP CONSTRAINT "FK_a1fc6aaad49b5fb4045f28d1d49"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."lms_course_integration_model_selectedresourcetypes_enum_old" AS ENUM('assignments', 'announcements', 'pages', 'files')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "lms_course_integration_model" ALTER COLUMN "selectedResourceTypes" DROP DEFAULT`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "lms_course_integration_model" ALTER COLUMN "selectedResourceTypes" TYPE "public"."lms_course_integration_model_selectedresourcetypes_enum_old"[] USING "selectedResourceTypes"::"text"::"public"."lms_course_integration_model_selectedresourcetypes_enum_old"[]`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "lms_course_integration_model" ALTER COLUMN "selectedResourceTypes" SET DEFAULT '{assignments,announcements,pages}'`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."lms_course_integration_model_selectedresourcetypes_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."lms_course_integration_model_selectedresourcetypes_enum_old" RENAME TO "lms_course_integration_model_selectedresourcetypes_enum"`,
+    );
+    await queryRunner.query(`DROP TABLE "lms_quiz_model"`);
+    await queryRunner.query(
+      `DROP TYPE "public"."lms_quiz_model_accesslevel_enum"`,
+    );
+  }
+}

--- a/packages/server/ormconfig.ts
+++ b/packages/server/ormconfig.ts
@@ -40,6 +40,7 @@ import { LMSAssignmentModel } from './src/lmsIntegration/lmsAssignment.entity';
 import { LMSAnnouncementModel } from './src/lmsIntegration/lmsAnnouncement.entity';
 import { LMSPageModel } from './src/lmsIntegration/lmsPage.entity';
 import { LMSFileModel } from './src/lmsIntegration/lmsFile.entity';
+import { LMSQuizModel } from './src/lmsIntegration/lmsQuiz.entity';
 import { UnreadAsyncQuestionModel } from './src/asyncQuestion/unread-async-question.entity';
 import { AsyncQuestionCommentModel } from './src/asyncQuestion/asyncQuestionComment.entity';
 import { ChatbotDocPdfModel } from './src/chatbot/chatbot-doc-pdf.entity';
@@ -119,6 +120,7 @@ const typeorm: DataSourceOptions = {
     LMSAnnouncementModel,
     LMSPageModel,
     LMSFileModel,
+    LMSQuizModel,
     ChatbotDocPdfModel,
     SuperCourseModel,
     SentEmailModel,

--- a/packages/server/src/lmsIntegration/lmsCourseIntegration.entity.ts
+++ b/packages/server/src/lmsIntegration/lmsCourseIntegration.entity.ts
@@ -14,6 +14,7 @@ import { LMSAssignmentModel } from './lmsAssignment.entity';
 import { LMSAnnouncementModel } from './lmsAnnouncement.entity';
 import { LMSPageModel } from './lmsPage.entity';
 import { LMSFileModel } from './lmsFile.entity';
+import { LMSQuizModel } from './lmsQuiz.entity';
 import { LMSResourceType } from '@koh/common';
 
 @Entity('lms_course_integration_model')
@@ -70,4 +71,7 @@ export class LMSCourseIntegrationModel extends BaseEntity {
 
   @OneToMany((type) => LMSFileModel, (file) => file.course)
   files: LMSFileModel[];
+
+  @OneToMany((type) => LMSQuizModel, (quiz) => quiz.course)
+  quizzes: LMSQuizModel[];
 }

--- a/packages/server/src/lmsIntegration/lmsIntegration.service.ts
+++ b/packages/server/src/lmsIntegration/lmsIntegration.service.ts
@@ -15,6 +15,8 @@ import {
   LMSIntegrationPlatform,
   LMSOrganizationIntegrationPartial,
   LMSPage,
+  LMSQuiz,
+  LMSQuizAccessLevel,
   LMSResourceType,
   SupportedLMSFileTypes,
   LMSSyncDocumentsResult,
@@ -26,6 +28,7 @@ import { LMSAssignmentModel } from './lmsAssignment.entity';
 import { LMSAnnouncementModel } from './lmsAnnouncement.entity';
 import { LMSPageModel } from './lmsPage.entity';
 import { LMSFileModel } from './lmsFile.entity';
+import { LMSQuizModel } from './lmsQuiz.entity';
 import { ChatTokenModel } from '../chatbot/chat-token.entity';
 import { UserModel } from '../profile/user.entity';
 import { Cron, CronExpression } from '@nestjs/schedule';
@@ -43,6 +46,7 @@ export enum LMSGet {
   Announcements,
   Pages,
   Files,
+  Quizzes,
 }
 
 export enum LMSUpload {
@@ -50,9 +54,16 @@ export enum LMSUpload {
   Announcements,
   Pages,
   Files,
+  Quizzes,
 }
 
-type ExtendedLMSItem = (LMSAnnouncement | LMSAssignment | LMSPage | LMSFile) & {
+type ExtendedLMSItem = (
+  | LMSAnnouncement
+  | LMSAssignment
+  | LMSPage
+  | LMSFile
+  | LMSQuiz
+) & {
   chatbotDocumentId: string;
 };
 
@@ -106,6 +117,7 @@ export class LMSIntegrationService {
     [LMSUpload.Announcements]: LMSResourceType.ANNOUNCEMENTS,
     [LMSUpload.Pages]: LMSResourceType.PAGES,
     [LMSUpload.Files]: LMSResourceType.FILES,
+    [LMSUpload.Quizzes]: LMSResourceType.QUIZZES,
   };
 
   public async upsertOrganizationLMSIntegration(
@@ -352,6 +364,38 @@ export class LMSIntegrationService {
         retrievalStatus = status;
         break;
       }
+      case LMSGet.Quizzes: {
+        const { status, quizzes } = await adapter.getQuizzes();
+        const { items } = await this.getDocumentModelAndItems(
+          courseId,
+          LMSUpload.Quizzes,
+        );
+        for (let idx = 0; idx < quizzes.length; idx++) {
+          const found = items.find(
+            (i) => i.id == quizzes[idx].id,
+          ) as unknown as LMSQuizModel;
+          if (found) {
+            quizzes[idx] = {
+              id: found.id,
+              title: found.title,
+              description: found.description,
+              due: found.due,
+              unlock: found.unlock,
+              lock: found.lock,
+              timeLimit: found.timeLimit,
+              allowedAttempts: found.allowedAttempts,
+              questions: found.questions,
+              accessLevel: found.accessLevel,
+              modified: quizzes[idx].modified ?? found.modified,
+              uploaded: found.uploaded,
+              syncEnabled: found.syncEnabled,
+            };
+          }
+        }
+        retrieved = quizzes;
+        retrievalStatus = status;
+        break;
+      }
     }
 
     if (retrievalStatus != LMSApiResponseStatus.Success) {
@@ -375,6 +419,8 @@ export class LMSIntegrationService {
           return LMSPageModel;
         case LMSUpload.Files:
           return LMSFileModel;
+        case LMSUpload.Quizzes:
+          return LMSQuizModel;
       }
     })();
 
@@ -471,6 +517,7 @@ export class LMSIntegrationService {
         announcements?: LMSAnnouncement[];
         pages?: LMSPage[];
         files?: LMSFile[];
+        quizzes?: LMSQuiz[];
       };
 
       const modelAndPersisted = await this.getDocumentModelAndItems(
@@ -496,6 +543,9 @@ export class LMSIntegrationService {
         case LMSUpload.Files:
           result = await adapter.getFiles();
           break;
+        case LMSUpload.Quizzes:
+          result = await adapter.getQuizzes();
+          break;
         default:
           result = { status: LMSApiResponseStatus.Error };
           break;
@@ -517,6 +567,8 @@ export class LMSIntegrationService {
         | LMSPageModel
         | LMSFile
         | LMSFileModel
+        | LMSQuiz
+        | LMSQuizModel
       )[];
       switch (type) {
         case LMSUpload.Assignments:
@@ -531,6 +583,9 @@ export class LMSIntegrationService {
         case LMSUpload.Files:
           items = result.files;
           break;
+        case LMSUpload.Quizzes:
+          items = result.quizzes;
+          break;
       }
 
       const persistedItems: (
@@ -538,6 +593,7 @@ export class LMSIntegrationService {
         | LMSAssignmentModel
         | LMSPageModel
         | LMSFileModel
+        | LMSQuizModel
       )[] = modelAndPersisted.items;
 
       const toRemove: (
@@ -545,6 +601,7 @@ export class LMSIntegrationService {
         | LMSAssignmentModel
         | LMSPageModel
         | LMSFileModel
+        | LMSQuizModel
       )[] = persistedItems.filter((i0) => !items.find((i1) => i1.id == i0.id));
 
       if (toRemove.length > 0) {
@@ -687,6 +744,28 @@ export class LMSIntegrationService {
                     : new Date(),
                 lmsSource: adapter.getPlatform(),
               }) as LMSFileModel;
+            case LMSUpload.Quizzes:
+              const quiz = i as LMSQuiz;
+              return (model as typeof LMSQuizModel).create({
+                id: quiz.id,
+                title: quiz.title,
+                description: quiz.description,
+                due: quiz.due,
+                unlock: quiz.unlock,
+                lock: quiz.lock,
+                timeLimit: quiz.timeLimit,
+                allowedAttempts: quiz.allowedAttempts,
+                questions: quiz.questions,
+                accessLevel: LMSQuizAccessLevel.LOGISTICS_ONLY, // Default access level
+                chatbotDocumentId: chatbotDocumentId,
+                uploaded: new Date(),
+                courseId: courseId,
+                modified:
+                  quiz.modified != undefined
+                    ? new Date(quiz.modified)
+                    : new Date(),
+                lmsSource: adapter.getPlatform(),
+              }) as LMSQuizModel;
             default:
               return undefined;
           }
@@ -695,7 +774,8 @@ export class LMSIntegrationService {
         | LMSAssignmentModel[]
         | LMSAnnouncementModel[]
         | LMSPageModel[]
-        | LMSFileModel[];
+        | LMSFileModel[]
+        | LMSQuizModel[];
 
       switch (type) {
         case LMSUpload.Announcements:
@@ -713,6 +793,9 @@ export class LMSIntegrationService {
           break;
         case LMSUpload.Files:
           await (model as typeof LMSFileModel).save(entities as LMSFileModel[]);
+          break;
+        case LMSUpload.Quizzes:
+          await (model as typeof LMSQuizModel).save(entities as LMSQuizModel[]);
           break;
       }
     }
@@ -748,12 +831,14 @@ export class LMSIntegrationService {
       | LMSAnnouncementModel
       | LMSPageModel
       | LMSFileModel
+      | LMSQuizModel
     )[],
     model:
       | typeof LMSAssignmentModel
       | typeof LMSAnnouncementModel
       | typeof LMSPageModel
-      | typeof LMSFileModel,
+      | typeof LMSFileModel
+      | typeof LMSQuizModel,
   ) {
     let numClearedDocuments = 0;
 
@@ -793,7 +878,8 @@ export class LMSIntegrationService {
       | LMSAnnouncementModel
       | LMSAssignmentModel
       | LMSPageModel
-      | LMSFileModel,
+      | LMSFileModel
+      | LMSQuizModel,
     type: LMSUpload,
     action: 'Sync' | 'Clear',
   ) {
@@ -811,7 +897,8 @@ export class LMSIntegrationService {
       | LMSAnnouncementModel
       | LMSAssignmentModel
       | LMSPageModel
-      | LMSFileModel,
+      | LMSFileModel
+      | LMSQuizModel,
     type: LMSUpload,
   ) {
     const adapter = await this.getAdapter(courseId);
@@ -860,7 +947,8 @@ export class LMSIntegrationService {
       | LMSAnnouncementModel
       | LMSAssignmentModel
       | LMSPageModel
-      | LMSFileModel,
+      | LMSFileModel
+      | LMSQuizModel,
     type: LMSUpload,
   ) {
     const model = await this.getDocumentModel(type);
@@ -899,6 +987,8 @@ export class LMSIntegrationService {
         return 'Page';
       case LMSUpload.Files:
         return 'File';
+      case LMSUpload.Quizzes:
+        return 'Quiz';
       default:
         return 'Resource';
     }
@@ -914,7 +1004,9 @@ export class LMSIntegrationService {
       | LMSPage
       | LMSPageModel
       | LMSFile
-      | LMSFileModel,
+      | LMSFileModel
+      | LMSQuiz
+      | LMSQuizModel,
     token: ChatTokenModel,
     type: LMSUpload,
     adapter: AbstractLMSAdapter,
@@ -1053,6 +1145,13 @@ export class LMSIntegrationService {
           } as LMSFileUploadResponse;
         }
       }
+      case LMSUpload.Quizzes: {
+        const q = item as LMSQuiz | LMSQuizModel;
+        prefix = `(Course Quiz)\nTitle: ${q.title}${!isNaN(new Date(q.due).valueOf()) ? `\nDue Date: ${new Date(q.due).toLocaleDateString()}` : ''}${!isNaN(new Date(q.modified).valueOf()) ? `\nModified: ${new Date(q.modified).toLocaleDateString()}` : ''}`;
+        name = `${q.title}`;
+        documentText = this.formatQuizContent(q);
+        break;
+      }
       default:
         return {
           id: item.id,
@@ -1145,7 +1244,8 @@ export class LMSIntegrationService {
       | LMSAnnouncementModel
       | LMSAssignmentModel
       | LMSPageModel
-      | LMSFileModel,
+      | LMSFileModel
+      | LMSQuizModel,
     token: ChatTokenModel,
   ) {
     // Already deleted in this case
@@ -1266,5 +1366,129 @@ export class LMSIntegrationService {
       }
     }
     return Buffer.concat(chunks);
+  }
+
+  async updateQuizAccessLevel(
+    courseId: number,
+    quizId: number,
+    accessLevel: LMSQuizAccessLevel,
+  ): Promise<boolean> {
+    try {
+      const quiz = await LMSQuizModel.findOne({
+        where: { id: quizId, courseId },
+      });
+
+      if (!quiz) {
+        throw new Error('Quiz not found');
+      }
+
+      quiz.accessLevel = accessLevel;
+      await quiz.save();
+
+      if (quiz.syncEnabled && quiz.chatbotDocumentId) {
+        console.log(
+          `Updating chatbot document for quiz ${quizId} with new access level: ${accessLevel}`,
+        );
+
+        await this.singleDocOperation(
+          courseId,
+          quiz,
+          LMSUpload.Quizzes,
+          'Clear',
+        );
+
+        await this.singleDocOperation(
+          courseId,
+          quiz,
+          LMSUpload.Quizzes,
+          'Sync',
+        );
+
+        console.log(`Successfully updated chatbot document for quiz ${quizId}`);
+      }
+
+      return true;
+    } catch (error) {
+      console.error('Failed to update quiz access level:', error);
+      return false;
+    }
+  }
+
+  private formatQuizContent(quiz: LMSQuiz | LMSQuizModel): string {
+    let content = '';
+
+    if (quiz.description) {
+      content += `\nDescription: ${convert(quiz.description)}`;
+    }
+
+    if (quiz.unlock) {
+      content += `\nAvailable from: ${new Date(quiz.unlock).toLocaleDateString()}`;
+    }
+
+    if (quiz.lock) {
+      content += `\nAvailable until: ${new Date(quiz.lock).toLocaleDateString()}`;
+    }
+
+    if (quiz.timeLimit) {
+      content += `\nTime Limit: ${quiz.timeLimit} minutes`;
+    }
+
+    if (quiz.allowedAttempts) {
+      content += `\nAllowed Attempts: ${quiz.allowedAttempts}`;
+    }
+
+    // Get access level (default to LOGISTICS_ONLY if not specified)
+    const accessLevel =
+      'accessLevel' in quiz
+        ? quiz.accessLevel
+        : LMSQuizAccessLevel.LOGISTICS_ONLY;
+
+    if (accessLevel === LMSQuizAccessLevel.LOGISTICS_ONLY) {
+      return content;
+    }
+
+    // Add questions for LOGISTICS_AND_QUESTIONS level and higher
+    if (quiz.questions && quiz.questions.length > 0) {
+      content += '\n\nQuestions:';
+      quiz.questions.forEach((q: any, i: number) => {
+        content += `\n${i + 1}. ${q.question_text || q.question_name || 'Question'}`;
+
+        if (
+          accessLevel ===
+          LMSQuizAccessLevel.LOGISTICS_QUESTIONS_GENERAL_COMMENTS
+        ) {
+          if (q.neutral_comments) {
+            content += `\n   General comments: ${q.neutral_comments}`;
+          }
+        }
+
+        if (accessLevel === LMSQuizAccessLevel.FULL_ACCESS && q.answers) {
+          content += '\n   Answer options:';
+          q.answers.forEach((a: any) => {
+            const marker = a.weight > 0 ? ' [CORRECT]' : '';
+            content += `\n   - ${a.text}${marker}`;
+          });
+
+          if (q.correct_comments) {
+            content += `\n   Correct answer feedback: ${q.correct_comments}`;
+          }
+
+          if (q.incorrect_comments) {
+            content += `\n   Incorrect answer feedback: ${q.incorrect_comments}`;
+          }
+
+          if (q.neutral_comments) {
+            content += `\n   General comments: ${q.neutral_comments}`;
+          }
+        }
+      });
+    }
+
+    return content;
+  }
+
+  // Public method for generating preview content
+  formatQuizContentPreview(quiz: any): string {
+    return this.formatQuizContent(quiz);
   }
 }

--- a/packages/server/src/lmsIntegration/lmsQuiz.entity.ts
+++ b/packages/server/src/lmsIntegration/lmsQuiz.entity.ts
@@ -1,0 +1,76 @@
+import {
+  BaseEntity,
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+} from 'typeorm';
+import { LMSCourseIntegrationModel } from './lmsCourseIntegration.entity';
+import { LMSIntegrationPlatform, LMSQuizAccessLevel } from '@koh/common';
+
+@Entity('lms_quiz_model')
+export class LMSQuizModel extends BaseEntity {
+  @PrimaryColumn()
+  id: number;
+
+  @PrimaryColumn()
+  courseId: number;
+
+  // Would rather this be enum, but evolving enums are not well-supported...
+  @Column({
+    type: 'text',
+  })
+  lmsSource: LMSIntegrationPlatform;
+
+  @Column({ type: 'text' })
+  title: string;
+
+  @Column({ type: 'text', nullable: true })
+  description: string;
+
+  @Column({ type: 'timestamp', nullable: true })
+  due: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  unlock: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  lock: Date;
+
+  @Column({ type: 'integer', nullable: true })
+  timeLimit: number; // in minutes
+
+  @Column({ type: 'integer', nullable: true })
+  allowedAttempts: number;
+
+  @Column({ type: 'jsonb', nullable: true })
+  questions: any[]; // Store quiz questions as JSON
+
+  @Column({ type: 'timestamp' })
+  modified: Date;
+
+  @Column({
+    type: 'enum',
+    enum: LMSQuizAccessLevel,
+    default: LMSQuizAccessLevel.LOGISTICS_ONLY,
+  })
+  accessLevel: LMSQuizAccessLevel;
+
+  @Column({ type: 'text', nullable: true })
+  chatbotDocumentId: string;
+
+  @Column({ type: 'timestamp', nullable: true })
+  uploaded: Date;
+
+  @Column({ type: 'boolean', default: true })
+  syncEnabled: boolean;
+
+  @ManyToOne(
+    (type) => LMSCourseIntegrationModel,
+    (integration) => integration.quizzes,
+    { onDelete: 'CASCADE' },
+  )
+  @JoinColumn({ name: 'courseId', referencedColumnName: 'courseId' })
+  course: LMSCourseIntegrationModel;
+}


### PR DESCRIPTION
# Description

Canvas Quizzes now supported! Also includes 4 levels of access-control, so that instructors can choose how much information from the quiz they want the chatbot to have access to.

TODO:
- [ ] Add integration tests 
- [ ] Edit some prompt on the chatbot side so that it is able to provide quiz answers for those quizzes with FULL ACCESS.
- [ ] Test for mobile view

Preview:

<img width="1793" height="490" alt="image" src="https://github.com/user-attachments/assets/8cf88335-e57e-4931-8e91-e5eef5c37caf" />

<img width="1915" height="1502" alt="image" src="https://github.com/user-attachments/assets/630fad22-a7ad-4457-be74-1e5255c827d2" />




Closes #343

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

manually for now but will be adding integration tests


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing tests pass *locally* with my changes
- [ ] Any work that this PR is dependent on has been merged into the main branch
- [ ] Any UI changes have been checked to work on desktop, tablet, and mobile
