### PR TITLE
[#382] Hide past semesters in dropdown when creating/editing a course

### DIFF
--- a/packages/frontend/app/(dashboard)/components/EditCourseForm.tsx
+++ b/packages/frontend/app/(dashboard)/components/EditCourseForm.tsx
@@ -236,14 +236,20 @@ const EditCourseForm: React.FC<EditCourseFormProps> = ({
             placeholder="Select Semester"
             notFoundContent="Your organization does not seem to have any semesters yet."
           >
-            {organization.semesters.map((semester) => (
-              <Select.Option key={semester.id} value={semester.id}>
-                <span>{`${semester.name}`}</span>{' '}
-                <span className="font-normal">
-                  {formatSemesterDate(semester)}
-                </span>
-              </Select.Option>
-            ))}
+            {organization.semesters
+              .filter(
+                (semester) =>
+                  new Date(semester.endDate) > new Date(1970) &&
+                  new Date(semester.endDate) > new Date(),
+              ) // filter out past semesters
+              .map((semester) => (
+                <Select.Option key={semester.id} value={semester.id}>
+                  <span>{`${semester.name}`}</span>{' '}
+                  <span className="font-normal">
+                    {formatSemesterDate(semester)}
+                  </span>
+                </Select.Option>
+              ))}
             <Select.Option key={'none'} value={-1}>
               <span>No semester</span>
             </Select.Option>

--- a/packages/frontend/app/(dashboard)/organization/course/add/page.tsx
+++ b/packages/frontend/app/(dashboard)/organization/course/add/page.tsx
@@ -86,7 +86,13 @@ export default function AddCoursePage(): ReactElement {
     API.semesters
       .get(userInfo.organization?.orgId || -1)
       .then((semesters) => {
-        setOrganizationSemesters(semesters)
+        setOrganizationSemesters(
+          semesters.filter(
+            (semester) =>
+              new Date(semester.endDate) > new Date(1970) &&
+              new Date(semester.endDate) > new Date(),
+          ), // filter out past semesters
+        )
       })
       .catch((_) => {
         message.error('Failed to fetch semesters for organization')
@@ -284,7 +290,7 @@ export default function AddCoursePage(): ReactElement {
                               key={semester.id}
                               value={semester.id}
                             >
-                              <span>{`${semester.name}`}</span>{' '}
+                              <span>{`${semester.name} `}</span>
                               <span className="font-normal">
                                 {formatSemesterDate(semester)}
                               </span>


### PR DESCRIPTION
# Description

This PR adds logic to hide past semesters from the semesters dropdown while trying to edit/add a course. Though the initial  suggestion was to display a warning, after discussion with @AdamFipke it was decided that hiding past semesters makes sense.

The `>1970` is to account for the Test Course semester that was hardcoded in by @AdamFipke 


Closes #382 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

Tested by adding a new semester to the seed data with end date > the current date. Made sure that the correct semesters are filtered out.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing tests pass *locally* with my changes
- [ ] Any work that this PR is dependent on has been merged into the main branch
- [x] Any UI changes have been checked to work on desktop, tablet, and mobile

# Screenshots:
<img width="1394" height="660" alt="image" src="https://github.com/user-attachments/assets/b2274a1f-437a-4dee-852b-daf4cfc97f5f" />

