### PR TITLE
Fix Updating TA notes not updating state variables and Fix Updating Chunks resetting search

### DIFF
--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_knowledge_base/page.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_knowledge_base/page.tsx
@@ -78,6 +78,17 @@ export default function ChatbotDocuments(
       })
   }
 
+  const handleSearch = useCallback(
+    (e: { target: { value: string } }) => {
+      const searchTerm = e.target.value
+      setSearch(searchTerm)
+      const filtered = filterDocuments(documents, searchTerm)
+
+      setFilteredDocuments(filtered)
+    },
+    [documents],
+  )
+
   const fetchDocuments = useCallback(async () => {
     await API.chatbot.staffOnly
       .getAllDocumentChunks(courseId)
@@ -87,13 +98,13 @@ export default function ChatbotDocuments(
           key: doc.id,
         }))
         setDocuments(response)
-        setFilteredDocuments(response)
+        setFilteredDocuments(filterDocuments(response, search))
       })
       .catch((e) => {
         const errorMessage = getErrorMessage(e)
         message.error('Failed to load documents: ' + errorMessage)
       })
-  }, [courseId, setDocuments, setFilteredDocuments])
+  }, [courseId, setDocuments, setFilteredDocuments, search])
 
   useEffect(() => {
     if (courseId) {
@@ -217,22 +228,6 @@ export default function ChatbotDocuments(
         const errorMessage = getErrorMessage(e)
         message.error('Failed to delete document: ' + errorMessage)
       })
-  }
-
-  const handleSearch = (e: any) => {
-    setSearch(e.target.value)
-    const searchTerm = e.target.value.toLowerCase()
-    const filtered = documents.filter((doc) => {
-      const isNameMatch = doc.metadata?.name
-        ? doc.metadata.name.toLowerCase().includes(searchTerm)
-        : false
-      const isContentMatch = doc.pageContent
-        ? doc.pageContent.toLowerCase().includes(searchTerm)
-        : false
-      return isNameMatch || isContentMatch
-    })
-
-    setFilteredDocuments(filtered)
   }
 
   return (
@@ -381,4 +376,16 @@ export default function ChatbotDocuments(
       )}
     </div>
   )
+}
+
+const filterDocuments = (documents: SourceDocument[], search: string) => {
+  return documents.filter((doc) => {
+    const isNameMatch = doc.metadata?.name
+      ? doc.metadata.name.toLowerCase().includes(search.toLowerCase())
+      : false
+    const isContentMatch = doc.pageContent
+      ? doc.pageContent.toLowerCase().includes(search.toLowerCase())
+      : false
+    return isNameMatch || isContentMatch
+  })
 }

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/components/CourseRosterTable.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/components/CourseRosterTable.tsx
@@ -113,6 +113,8 @@ const CourseRosterTable: React.FC<CourseRosterTableProps> = ({
         courseId={courseId}
         userInfo={userInfo}
         role={role}
+        users={users}
+        setUsers={setUsers}
         isSensitiveInfoHidden={isSensitiveInfoHidden}
         handleRoleChange={handleRoleChange}
         onRoleChange={onRoleChange}
@@ -127,7 +129,13 @@ const CourseRosterTable: React.FC<CourseRosterTableProps> = ({
       <>
         <div className="bg-white">
           <div className="mb-2 flex">
-            <h3 className="text-lg font-semibold">{listTitle}</h3>
+            <h3
+              className="text-lg font-semibold"
+              title={`There are ${totalUsers} ${listTitle} in this course`}
+            >
+              {listTitle}
+              {totalUsers > 0 && ` (${totalUsers})`}
+            </h3>
             {/* Only show this button if the table hides sensitive info */}
             {hideSensitiveInformation && (
               <Button
@@ -174,6 +182,8 @@ const RosterItem: React.FC<{
   item: UserPartial
   courseId: number
   role: Role
+  users: UserPartial[]
+  setUsers: (users: UserPartial[]) => void
   isSensitiveInfoHidden: boolean
   userInfo: User
   handleRoleChange: (userId: number, newRole: Role, userName: string) => void
@@ -183,6 +193,8 @@ const RosterItem: React.FC<{
   item,
   courseId,
   role,
+  users,
+  setUsers,
   isSensitiveInfoHidden,
   userInfo,
   handleRoleChange,
@@ -302,6 +314,7 @@ const RosterItem: React.FC<{
           <Popover
             trigger="click"
             overlayClassName="min-w-80"
+            destroyOnHidden={!canSave}
             content={
               <div className="flex flex-col gap-y-2">
                 <TextArea
@@ -324,7 +337,14 @@ const RosterItem: React.FC<{
                         .then(() => {
                           setSaveSuccessful(true)
                           setCanSave(false)
-                          item.TANotes = tempTaNotes
+                          setUsers(
+                            users.map((user) => {
+                              if (user.id === item.id) {
+                                return { ...user, TANotes: tempTaNotes }
+                              }
+                              return user
+                            }),
+                          )
                           // saved goes away after 1s
                           setTimeout(() => {
                             setSaveSuccessful(false)

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/components/CourseRosterTable.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/components/CourseRosterTable.tsx
@@ -69,20 +69,14 @@ const CourseRosterTable: React.FC<CourseRosterTableProps> = ({
     setPage(1)
   }
 
-  const fetchUsers = async () => {
-    const data = await API.course.getUserInfo(courseId, page, role, search)
-    setUsers(data.users)
-    setTotalUsers(data.total)
-  }
-
   useEffect(() => {
+    const fetchUsers = async () => {
+      const data = await API.course.getUserInfo(courseId, page, role, search)
+      setUsers(data.users)
+      setTotalUsers(data.total)
+    }
     fetchUsers().then()
-  }, [page, search, role, courseId])
-
-  // everytime updateFlag changes, refresh the tables
-  useEffect(() => {
-    fetchUsers().then()
-  }, [updateFlag])
+  }, [page, search, role, courseId, updateFlag])
 
   const handleRoleChange = async (
     userId: number,

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/components/CourseRosterTables.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/components/CourseRosterTables.tsx
@@ -11,6 +11,12 @@ type CourseRosterTablesProps = {
 const CourseRosterTables: React.FC<CourseRosterTablesProps> = ({
   courseId,
 }) => {
+  // Note that you are NOT supposed to do React this way, since this basically breaks the 1-directional structure of react by allowing sibling components to update each other's state, making the code harder to follow.
+  // The way to actually do this is to move the states up here and pass it down to the components (see https://react.dev/learn/tutorial-tic-tac-toe#lifting-state-up for an example).
+  // This *would* result in a bunch of really similar state variables, in which case you would do either an array or object, e.g. const [users, setUsers] = useState<{profs: UserPartial[], students: UserPartial[], etc.}>
+  // Only reason why I'm leaving it like this is because this component is relatively isolated and it's not too hard to follow (also I'm lazy and the current solution works fine), but pretty much don't copy this pattern anywhere.
+  // Fun fact: this 'updateFlag' was one of the first changes I made to the codebase (because before if you changed someone's role, they wouldn't appear in the other table until you refreshed the page)
+  // - Adam
   const [updateFlag, setUpdateFlag] = useState(false)
   const refreshTables = () => {
     setUpdateFlag((prevFlag) => !prevFlag)

--- a/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/StaffList.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/StaffList.tsx
@@ -124,7 +124,7 @@ const StatusCard: React.FC<StatusCardProps> = ({
   return (
     <Popover
       open={popoverOpen || canSave}
-      destroyTooltipOnHide={false}
+      destroyOnHidden={false}
       onOpenChange={(open) => setPopoverOpen(open)}
       trigger={shouldShowEdit ? 'click' : 'hover'}
       mouseLeaveDelay={shouldShowEdit ? 0.5 : 0.1}

--- a/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/StaffList.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/StaffList.tsx
@@ -19,6 +19,7 @@ import { getErrorMessage, getRoleInCourse } from '@/app/utils/generalUtils'
 import { QuestionCircleOutlined } from '@ant-design/icons'
 import { useUserInfo } from '@/app/contexts/userContext'
 import MessageButton from './MessageButton'
+import { useQueue } from '@/app/hooks/useQueue'
 
 interface StaffListProps {
   queue: QueuePartial
@@ -87,7 +88,7 @@ const StaffList: React.FC<StaffListProps> = ({ queue, queueId, courseId }) => {
 
 interface StatusCardProps {
   courseId: number
-  queueId?: number
+  queueId: number
   myQuestionId?: number
   ta: StaffMember
   myRole?: Role
@@ -111,10 +112,7 @@ const StatusCard: React.FC<StatusCardProps> = ({
   grouped,
 }) => {
   const isBusy = !!helpedAt || !!ta.extraStatus
-  const [tempTaNotes, setTempTaNotes] = useState<string | undefined>(ta.TANotes)
   const [canSave, setCanSave] = useState(false)
-  const [saveLoading, setSaveLoading] = useState(false)
-  const [saveSuccessful, setSaveSuccessful] = useState(false)
   const [popoverOpen, setPopoverOpen] = useState(false)
   const isStaff = myRole === Role.TA || myRole === Role.PROFESSOR
 
@@ -140,68 +138,14 @@ const StatusCard: React.FC<StatusCardProps> = ({
                 {ta.TANotes}
               </div>
             ) : (
-              <>
-                <TextArea
-                  placeholder="Can answer questions about MATH 101, PHYS 102..."
-                  autoSize={{ minRows: 4, maxRows: 7 }}
-                  value={tempTaNotes}
-                  onChange={(e) => {
-                    setCanSave(e.target.value !== ta.TANotes)
-                    setTempTaNotes(e.target.value)
-                  }}
-                />
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center justify-start">
-                    <Button
-                      disabled={!canSave}
-                      loading={saveLoading}
-                      onClick={async () => {
-                        setSaveLoading(true)
-                        await API.course
-                          .updateTANotes(courseId, ta.id, tempTaNotes ?? '')
-                          .then(() => {
-                            setSaveSuccessful(true)
-                            setCanSave(false)
-                            // saved goes away after 1s
-                            setTimeout(() => {
-                              setSaveSuccessful(false)
-                            }, 1000)
-                          })
-                          .catch((e) => {
-                            const errorMessage = getErrorMessage(e)
-                            message.error(errorMessage)
-                          })
-                          .finally(() => {
-                            setSaveLoading(false)
-                          })
-                      }}
-                    >
-                      Save
-                    </Button>
-                    <div>
-                      {
-                        <span
-                          className={`ml-2 text-green-500 transition-opacity duration-300 ${
-                            saveSuccessful ? 'opacity-100' : 'opacity-0'
-                          }`}
-                        >
-                          Saved!
-                        </span>
-                      }
-                    </div>
-                  </div>
-                  <Button
-                    onClick={() => {
-                      setTempTaNotes(ta.TANotes)
-                      setCanSave(false)
-                      setPopoverOpen(false)
-                    }}
-                    danger={canSave}
-                  >
-                    Cancel
-                  </Button>
-                </div>
-              </>
+              <UpdateTANotesForm
+                courseId={courseId}
+                queueId={queueId}
+                ta={ta}
+                canSave={canSave}
+                setCanSave={setCanSave}
+                setPopoverOpen={setPopoverOpen}
+              />
             )}
           </div>
         )
@@ -274,6 +218,97 @@ const StatusCard: React.FC<StatusCardProps> = ({
   )
 }
 
+// Had to refactor this into its own component because it needs to use mutateQueue to update the frontend variables for the queue notes
+// and I can't use the useQueue hook in the StatusCard component since the queueInvitePage also uses StatusCard and I can't conditionally use hooks
+const UpdateTANotesForm: React.FC<{
+  courseId: number
+  queueId: number
+  ta: StaffMember
+  canSave: boolean
+  setCanSave: (canSave: boolean) => void
+  setPopoverOpen: (popoverOpen: boolean) => void
+}> = ({ courseId, queueId, ta, canSave, setCanSave, setPopoverOpen }) => {
+  const [tempTaNotes, setTempTaNotes] = useState<string | undefined>(ta.TANotes)
+  const [saveLoading, setSaveLoading] = useState(false)
+  const [saveSuccessful, setSaveSuccessful] = useState(false)
+  const { queue, mutateQueue } = useQueue(queueId)
+
+  return (
+    <>
+      <TextArea
+        placeholder="Can answer questions about MATH 101, PHYS 102..."
+        autoSize={{ minRows: 4, maxRows: 7 }}
+        value={tempTaNotes}
+        onChange={(e) => {
+          setCanSave(e.target.value !== ta.TANotes)
+          setTempTaNotes(e.target.value)
+        }}
+      />
+      <div className="flex items-center justify-between">
+        <div className="flex items-center justify-start">
+          <Button
+            disabled={!canSave}
+            loading={saveLoading}
+            onClick={async () => {
+              setSaveLoading(true)
+              await API.course
+                .updateTANotes(courseId, ta.id, tempTaNotes ?? '')
+                .then(async () => {
+                  if (queue && queue.staffList) {
+                    // update the local state variables so that the rest of the frontend also has the updated notes (and so no weird state mismatch behavior occurs)
+                    await mutateQueue({
+                      ...queue,
+                      staffList: queue.staffList.map((tempTA) =>
+                        tempTA.id === ta.id
+                          ? { ...ta, TANotes: tempTaNotes }
+                          : tempTA,
+                      ),
+                    })
+                  }
+                  setSaveSuccessful(true)
+                  setCanSave(false)
+                  // saved goes away after 1s
+                  setTimeout(() => {
+                    setSaveSuccessful(false)
+                  }, 1000)
+                })
+                .catch((e) => {
+                  const errorMessage = getErrorMessage(e)
+                  message.error(errorMessage)
+                })
+                .finally(() => {
+                  setSaveLoading(false)
+                })
+            }}
+          >
+            Save
+          </Button>
+          <div>
+            {
+              <span
+                className={`ml-2 text-green-500 transition-opacity duration-300 ${
+                  saveSuccessful ? 'opacity-100' : 'opacity-0'
+                }`}
+              >
+                Saved!
+              </span>
+            }
+          </div>
+        </div>
+        <Button
+          onClick={() => {
+            setTempTaNotes(ta.TANotes)
+            setCanSave(false)
+            setPopoverOpen(false)
+          }}
+          danger={canSave}
+        >
+          Cancel
+        </Button>
+      </div>
+    </>
+  )
+}
 interface HelpingForProps {
   studentName?: string
   extraTAStatus?: ExtraTAStatus

--- a/packages/frontend/app/qi/[qid]/page.tsx
+++ b/packages/frontend/app/qi/[qid]/page.tsx
@@ -344,6 +344,7 @@ export default function QueueInvitePage(
                     <StatusCard
                       key={ta.id}
                       courseId={queueInviteInfo.courseId}
+                      queueId={queueInviteInfo.queueId}
                       ta={ta}
                       helpedAt={ta.questionHelpedAt}
                     />

--- a/packages/server/src/chatbot/chatbot-api.service.ts
+++ b/packages/server/src/chatbot/chatbot-api.service.ts
@@ -402,6 +402,8 @@ export class ChatbotApiService {
 
       if (!response.ok) {
         const error = await response.json();
+        console.error('Error for url', url);
+        console.error(response);
         throw new HttpException(
           error.error || 'Failed to upload LMS file buffer',
           response.status,


### PR DESCRIPTION
# Description

- Fixes updating TA notes on the queue page not updating the state variables. It was a little annoying since I had to refactor some stuff a little
- Fixes the search on chatbot knowledge base page getting reset after updating or editing a chunk
- Fixes how TA notes were not actually appearing on the queue invites page (was just missing a backend piece)

I also added totals for the number of each role just for fun
<img width="1119" height="807" alt="image" src="https://github.com/user-attachments/assets/047f50d4-7d29-4fbc-8cad-f35c5e7763bc" />


Closes #387 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

All manual testing, pretty thoroughly. Also testing queue invites to make sure they didn't break (since they also use the StatusCard component).

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing tests pass *locally* with my changes
- [ ] Any work that this PR is dependent on has been merged into the main branch
- [ ] Any UI changes have been checked to work on desktop, tablet, and mobile
