### PR TITLE
Trigger Profile/Queue dropdown on click only

### DIFF
--- a/packages/frontend/app/(dashboard)/components/coursesSection.tsx
+++ b/packages/frontend/app/(dashboard)/components/coursesSection.tsx
@@ -55,17 +55,19 @@ const CoursesSection: React.FC<CoursesSectionProps> = ({
         if (semesterA && !semesterB) return -1
         if (semesterB && !semesterA) return 1
 
-        if (semesterA && semesterB) {
-          const diff =
-            new Date(semesterB.endDate).getTime() -
-            new Date(semesterA.endDate).getTime()
-          if (diff === 0) {
-            return a.course.name.localeCompare(b.course.name)
-          } else {
-            return diff
-          }
+        // Treat missing endDate as -Infinity
+        const aEnd = semesterA?.endDate
+          ? new Date(semesterA.endDate).getTime()
+          : -Infinity
+        const bEnd = semesterB?.endDate
+          ? new Date(semesterB.endDate).getTime()
+          : -Infinity
+        const diff = bEnd - aEnd
+        if (diff === 0) {
+          return a.course.name.localeCompare(b.course.name)
+        } else {
+          return diff
         }
-        return 0
       })
   }, [userInfo.courses, semesters])
 

--- a/packages/frontend/app/(dashboard)/components/coursesSection.tsx
+++ b/packages/frontend/app/(dashboard)/components/coursesSection.tsx
@@ -55,19 +55,17 @@ const CoursesSection: React.FC<CoursesSectionProps> = ({
         if (semesterA && !semesterB) return -1
         if (semesterB && !semesterA) return 1
 
-        // Treat missing endDate as -Infinity
-        const aEnd = semesterA?.endDate
-          ? new Date(semesterA.endDate).getTime()
-          : -Infinity
-        const bEnd = semesterB?.endDate
-          ? new Date(semesterB.endDate).getTime()
-          : -Infinity
-        const diff = bEnd - aEnd
-        if (diff === 0) {
-          return a.course.name.localeCompare(b.course.name)
-        } else {
-          return diff
+        if (semesterA && semesterB) {
+          const diff =
+            new Date(semesterB.endDate).getTime() -
+            new Date(semesterA.endDate).getTime()
+          if (diff === 0) {
+            return a.course.name.localeCompare(b.course.name)
+          } else {
+            return diff
+          }
         }
+        return 0
       })
   }, [userInfo.courses, semesters])
 

--- a/packages/frontend/app/components/HeaderBar.tsx
+++ b/packages/frontend/app/components/HeaderBar.tsx
@@ -217,9 +217,10 @@ const NavBar = ({
                         ? 'md:border-helpmeblue bg-zinc-300/80 md:border-b-2 md:bg-white'
                         : ''
                     }
-                    onFocus={setNavigationSubMenuLeftSide}
-                    onClick={setNavigationSubMenuLeftSide}
-                    onMouseEnter={setNavigationSubMenuLeftSide}
+                    onFocus={setNavigationSubMenuRightSide}
+                    onClick={setNavigationSubMenuRightSide}
+                    onPointerMove={(e) => e.preventDefault()}
+                    onPointerLeave={(e) => e.preventDefault()}
                   >
                     <UsersRound strokeWidth={1.5} className="mr-3" />
                     Queues
@@ -358,7 +359,8 @@ const NavBar = ({
               className={`!pl-4 ${isProfilePage ? 'md:border-helpmeblue md:border-b-2' : ''}`}
               onFocus={setNavigationSubMenuRightSide}
               onClick={setNavigationSubMenuRightSide}
-              onMouseEnter={setNavigationSubMenuRightSide}
+              onPointerMove={(e) => e.preventDefault()}
+              onPointerLeave={(e) => e.preventDefault()}
             >
               <SelfAvatar size={40} className="mr-2" />
               {userInfo?.firstName}

--- a/packages/frontend/app/components/HeaderBar.tsx
+++ b/packages/frontend/app/components/HeaderBar.tsx
@@ -217,8 +217,8 @@ const NavBar = ({
                         ? 'md:border-helpmeblue bg-zinc-300/80 md:border-b-2 md:bg-white'
                         : ''
                     }
-                    onFocus={setNavigationSubMenuRightSide}
-                    onClick={setNavigationSubMenuRightSide}
+                    onFocus={setNavigationSubMenuLeftSide}
+                    onClick={setNavigationSubMenuLeftSide}
                     onPointerMove={(e) => e.preventDefault()}
                     onPointerLeave={(e) => e.preventDefault()}
                   >


### PR DESCRIPTION
# Description

TIL the default trigger behavior for any navigation item is onPointerEnter. Suppressed these events and now only triggering the dropdown onClick. 

Closes #400 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:

# Checklist:

- [x] I have performed a code review of my own code (under the "Files Changed" tab on github) to ensure nothing is committed that shouldn't be (e.g. leftover `console.log`s, leftover unused logic, or anything else that was accidentally committed)
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing tests pass *locally* with my changes
- [ ] Any work that this PR is dependent on has been merged into the main branch
- [ ] Any UI changes have been checked to work on desktop, tablet, and mobile
