### PR TITLE
Added bugfix

### DIFF
--- a/packages/server/src/guards/org-or-course-roles.guard.ts
+++ b/packages/server/src/guards/org-or-course-roles.guard.ts
@@ -129,9 +129,7 @@ export class OrgOrCourseRolesGuard implements CanActivate {
       }>();
 
     if (!orgCourseUser) {
-      throw new NotFoundException(
-        'This course does not exist in your organization',
-      );
+      return false;
     }
 
     // then check if the user has the right org roles

--- a/packages/server/src/organization/organization.controller.ts
+++ b/packages/server/src/organization/organization.controller.ts
@@ -607,11 +607,11 @@ export class OrganizationController {
   @Patch(':oid/update_course_access/:cid')
   @UseGuards(
     JwtAuthGuard,
-    OrganizationRolesGuard,
-    OrganizationGuard,
+    OrgOrCourseRolesGuard,
     EmailVerifiedGuard,
   )
-  @Roles(OrganizationRole.ADMIN)
+  @CourseRoles(Role.PROFESSOR)
+  @OrgRoles(OrganizationRole.ADMIN, OrganizationRole.PROFESSOR)
   async updateCourseAccess(
     @Res() res: Response,
     @Param('oid', ParseIntPipe) oid: number,


### PR DESCRIPTION
# Description

Fixed the `OrgOrCourseRolesGuard` to allow course professors to archive their own courses by modifying the `matchOrgRoles` method to return false instead of throwing an exception when users don't have the required organization role.

The `OrgOrCourseRolesGuard.matchOrgRoles()` method was throwing a `NotFoundException` when users lacked the required organization role, preventing the course role check from executing. This caused the guard to fail even when users had the required course professor role.



Closes # (362)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?
- Created a dummy course `COSC 404` and assigned `orgProfessor@ubc.ca` to it, however the user was unable to archive the course they are a professor for.
- Verified user has organization professor role (not admin) in UBCO.
- Tested database queries to ensure proper role relationships exist.
- Since the professor was unable to delete their course, checked if the admin (Ramon@ubc.ca) was able to delete it, and it was successful.
- Added console statements to isolate the root cause,
- Found the root cause and deleted the exception, replaced it with a  `return false` line. 


# Checklist:

- [ ] I have performed a code review of my own code (under the "Files Changed" tab on github) to ensure nothing is committed that shouldn't be (e.g. leftover `console.log`s, leftover unused logic, or anything else that was accidentally committed)
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing tests pass *locally* with my changes
- [ ] Any work that this PR is dependent on has been merged into the main branch
- [ ] Any UI changes have been checked to work on desktop, tablet, and mobile
