### PR TITLE
Remove chatbot modality indicators for course settings

### DIFF
--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_settings/components/ChatbotSettingsModal.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_settings/components/ChatbotSettingsModal.tsx
@@ -35,7 +35,6 @@ import LLMTypeDisplay from '@/app/(dashboard)/organization/ai/components/LLMType
 
 interface ChatbotSettingsModalProps {
   open: boolean
-  organizationId: number
   courseId: number
   onClose: () => void
   updateCourseSettings?: (settings: CourseChatbotSettings) => void
@@ -45,7 +44,6 @@ interface ChatbotSettingsModalProps {
 
 const ChatbotSettingsModal: React.FC<ChatbotSettingsModalProps> = ({
   open,
-  organizationId,
   courseId,
   onClose,
   preLoadedProviders,
@@ -90,7 +88,7 @@ const ChatbotSettingsModal: React.FC<ChatbotSettingsModalProps> = ({
       form.setFieldsValue({ ...sets, ...formValues })
       setFormValues({ ...sets, ...formValues })
     }
-    // eslint-disable-next-line
+     
   }, [courseSettings, form])
 
   const areParamsDefault = useMemo(() => {
@@ -401,6 +399,7 @@ const ChatbotSettingsModal: React.FC<ChatbotSettingsModalProps> = ({
                                       isDefaultVision={
                                         provider.defaultModel?.id == model.id
                                       }
+                                      showModality={false}
                                     />
                                   </div>
                                 </Tooltip>

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_settings/page.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_settings/page.tsx
@@ -31,10 +31,6 @@ export default function ChatbotSettings(
   const params = use(props.params)
   const { userInfo } = useUserInfo()
   const courseId = useMemo(() => Number(params.cid), [params.cid])
-  const organizationId = useMemo(
-    () => userInfo?.organization?.orgId ?? -1,
-    [userInfo?.organization?.orgId],
-  )
   const [chatbotParameterModalOpen, setChatbotParameterModalOpen] =
     useState(false)
   const [addDocumentModalOpen, setAddDocumentModalOpen] = useState(false)
@@ -310,7 +306,6 @@ export default function ChatbotSettings(
         ) : (
           <ChatbotSettingsModal
             open={chatbotParameterModalOpen}
-            organizationId={organizationId}
             courseId={courseId}
             onClose={() => setChatbotParameterModalOpen(false)}
           />

--- a/packages/frontend/app/(dashboard)/organization/ai/components/CourseSettingTable.tsx
+++ b/packages/frontend/app/(dashboard)/organization/ai/components/CourseSettingTable.tsx
@@ -16,7 +16,6 @@ import ChatbotSettingsModal from '@/app/(dashboard)/course/[cid]/(settings)/sett
 import { cn } from '@/app/utils/generalUtils'
 
 type OrganizationChatbotSettingsFormProps = {
-  organizationId: number
   organizationSettings: OrganizationChatbotSettings
   courseSettingsInstances: CourseChatbotSettings[]
   onUpdate: (courseSettings: CourseChatbotSettings) => void
@@ -24,7 +23,6 @@ type OrganizationChatbotSettingsFormProps = {
 }
 
 const CourseSettingTable: React.FC<OrganizationChatbotSettingsFormProps> = ({
-  organizationId,
   organizationSettings,
   courseSettingsInstances,
   onUpdate,
@@ -254,7 +252,6 @@ const CourseSettingTable: React.FC<OrganizationChatbotSettingsFormProps> = ({
       {editingSettings != undefined && (
         <ChatbotSettingsModal
           courseId={(editingSettings as any).courseId}
-          organizationId={organizationId}
           onClose={cancelUpdate}
           open={!!editingSettings}
           updateCourseSettings={(sets) => onUpdate(sets)}

--- a/packages/frontend/app/(dashboard)/organization/ai/components/LLMTypeDisplay.tsx
+++ b/packages/frontend/app/(dashboard)/organization/ai/components/LLMTypeDisplay.tsx
@@ -1,18 +1,13 @@
-import { Button, Checkbox, Collapse, Input, List, message, Tooltip } from 'antd'
+import { Checkbox, Collapse, Tooltip } from 'antd'
 import {
-  CheckOutlined,
-  CloseOutlined,
-  EditOutlined,
   EyeOutlined,
   FontSizeOutlined,
   InfoCircleOutlined,
   MessageOutlined,
-  PlusOutlined,
   StarFilled,
-  StarOutlined,
 } from '@ant-design/icons'
 import { cn } from '@/app/utils/generalUtils'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import AdditionalNotesList from '@/app/(dashboard)/organization/ai/components/AdditionalNotesList'
 
 type LLMTypeDisplayProps = {
@@ -37,6 +32,8 @@ type LLMTypeDisplayProps = {
 
   allowRecommendedEdit?: boolean
   onUpdateRecommended?: (modelName: string, isRecommended: boolean) => void
+
+  showModality?: boolean
 }
 
 const LLMTypeDisplay: React.FC<LLMTypeDisplayProps> = ({
@@ -50,6 +47,7 @@ const LLMTypeDisplay: React.FC<LLMTypeDisplayProps> = ({
   shortenButtons,
   allowRecommendedEdit,
   onUpdateRecommended,
+  showModality,
 }) => {
   const [isRecommended, setIsRecommended] = useState<boolean>(
     model.isRecommended,
@@ -90,25 +88,36 @@ const LLMTypeDisplay: React.FC<LLMTypeDisplayProps> = ({
             'flex flex-row items-center justify-center gap-1 p-2 text-lg'
           }
         >
-          {model.isText && (
+          {!showModality && isDefault && (
             <LLMModeDisplay
-              icon={<FontSizeOutlined />}
-              title={`This model can process text input.${isDefault ? ' This is the default text model for this provider.' : ''}`}
-              canSetActive={setDefault != undefined}
+              icon={<StarFilled />}
+              title={`${isDefault ? ' This is the default model for this provider.' : ''}`}
               active={isDefault}
-              toggleActive={() => setDefault && setDefault(model.modelName)}
             />
           )}
-          {model.isVision && (
-            <LLMModeDisplay
-              icon={<EyeOutlined />}
-              title={`This model can process visual inputs.${isDefaultVision ? ' This is the default vision model for this provider.' : ''}`}
-              canSetActive={setDefault != undefined}
-              active={isDefaultVision}
-              toggleActive={() =>
-                setDefault && setDefault(model.modelName, true)
-              }
-            />
+          {showModality && (
+            <>
+              {model.isText && (
+                <LLMModeDisplay
+                  icon={<FontSizeOutlined />}
+                  title={`This model can process text input.${isDefault ? ' This is the default text model for this provider.' : ''}`}
+                  canSetActive={setDefault != undefined}
+                  active={isDefault}
+                  toggleActive={() => setDefault && setDefault(model.modelName)}
+                />
+              )}
+              {model.isVision && (
+                <LLMModeDisplay
+                  icon={<EyeOutlined />}
+                  title={`This model can process visual inputs.${isDefaultVision ? ' This is the default vision model for this provider.' : ''}`}
+                  canSetActive={setDefault != undefined}
+                  active={isDefaultVision}
+                  toggleActive={() =>
+                    setDefault && setDefault(model.modelName, true)
+                  }
+                />
+              )}
+            </>
           )}
           {model.isThinking && (
             <LLMModeDisplay

--- a/packages/frontend/app/(dashboard)/organization/ai/page.tsx
+++ b/packages/frontend/app/(dashboard)/organization/ai/page.tsx
@@ -3,15 +3,11 @@
 import React, { ReactElement, useEffect, useMemo, useState } from 'react'
 import { useUserInfo } from '@/app/contexts/userContext'
 import { API } from '@/app/api'
-import {
-  CourseChatbotSettings,
-  LLMType,
-  OrganizationChatbotSettings,
-} from '@koh/common'
+import { CourseChatbotSettings, OrganizationChatbotSettings } from '@koh/common'
 import OrganizationChatbotSettingsForm from '@/app/(dashboard)/organization/ai/components/OrganizationChatbotSettingsForm'
 import CenteredSpinner from '@/app/components/CenteredSpinner'
 import { getErrorMessage } from '@/app/utils/generalUtils'
-import { Divider, Input, message, Pagination, Table, Tabs, Tooltip } from 'antd'
+import { Divider, message, Tabs } from 'antd'
 import CourseSettingTable from '@/app/(dashboard)/organization/ai/components/CourseSettingTable'
 import { useRouter, useSearchParams } from 'next/navigation'
 
@@ -134,7 +130,6 @@ export default function OrganizationChatbotSettingsPage(): ReactElement {
                 label: 'Chatbot Settings for Courses',
                 children: (
                   <CourseSettingTable
-                    organizationId={organizationId}
                     organizationSettings={organizationSettings}
                     courseSettingsInstances={courseChatbotSettingsInstances}
                     onUpdate={(courseSettings: CourseChatbotSettings) => {


### PR DESCRIPTION
# Description

Removed the indicator that showed 'this model can process visual input' and 'this model can process text input' in course chatbot settings. Replaced simply with 'star' icon that shows up only if it's the default model for the organization's default provider

Closes #404 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

It's pure frontend, so manual

# Checklist:

- [x] I have performed a code review of my own code (under the "Files Changed" tab on github) to ensure nothing is committed that shouldn't be (e.g. leftover `console.log`s, leftover unused logic, or anything else that was accidentally committed)
- [x] I have commented my code where needed 
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing tests pass *locally* with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [x] Any UI changes have been checked to work on desktop, tablet, and mobile
