### PR TITLE
Module-linked pages toggle

### DIFF
--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -1790,6 +1790,7 @@ export type LMSPage = {
   syncEnabled?: boolean
   modified?: Date
   uploaded?: Date
+  isModuleLinked?: boolean
 }
 
 export type LMSFile = {
@@ -1801,6 +1802,22 @@ export type LMSFile = {
   syncEnabled?: boolean
   modified?: Date
   uploaded?: Date
+}
+
+export type LMSModule = {
+  id: number
+  name: string
+  items_url?: string
+  items?: LMSModuleItem[]
+}
+
+export type LMSModuleItem = {
+  id: number
+  title: string
+  type: string
+  content_id?: number
+  html_url?: string
+  page_url?: string
 }
 
 export enum LMSQuizAccessLevel {

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -1753,6 +1753,7 @@ export class LMSCourseIntegrationPartial {
   lmsSynchronize!: boolean
   isExpired!: boolean
   selectedResourceTypes?: LMSResourceType[]
+  moduleLinkedPagesOnly?: boolean
 }
 
 export type LMSCourseAPIResponse = {

--- a/packages/frontend/app/api/index.ts
+++ b/packages/frontend/app/api/index.ts
@@ -1440,6 +1440,16 @@ class APIClient {
       this.req('POST', `/api/v1/lms/course/${courseId}/resources`, undefined, {
         selectedResourceTypes,
       }),
+    updateModuleLinkedPagesOnly: async (
+      courseId: number,
+      moduleLinkedPagesOnly: boolean,
+    ): Promise<string> =>
+      this.req(
+        'PUT',
+        `/api/v1/lms/course/${courseId}/module-pages-only`,
+        undefined,
+        { moduleLinkedPagesOnly },
+      ),
     testIntegration: async (
       courseId: number,
       props: TestLMSIntegrationParams,

--- a/packages/server/src/lmsIntegration/lmsCourseIntegration.entity.ts
+++ b/packages/server/src/lmsIntegration/lmsCourseIntegration.entity.ts
@@ -69,6 +69,9 @@ export class LMSCourseIntegrationModel extends BaseEntity {
   @OneToMany((type) => LMSPageModel, (page) => page.course)
   pages: LMSPageModel[];
 
+  @Column({ type: 'boolean', default: false })
+  moduleLinkedPagesOnly: boolean;
+
   @OneToMany((type) => LMSFileModel, (file) => file.course)
   files: LMSFileModel[];
 

--- a/packages/server/src/lmsIntegration/lmsIntegration.controller.ts
+++ b/packages/server/src/lmsIntegration/lmsIntegration.controller.ts
@@ -10,7 +10,7 @@ import {
   Post,
   UseGuards,
 } from '@nestjs/common';
-import { Get } from '@nestjs/common/decorators';
+import { Get, Put } from '@nestjs/common/decorators';
 import {
   ERROR_MESSAGES,
   LMSApiResponseStatus,
@@ -877,5 +877,26 @@ export class LMSIntegrationController {
     await LMSCourseIntegrationModel.save(integration);
 
     return `Successfully updated selected resource types for course ${courseId}.`;
+  }
+
+  @Put('course/:courseId/module-pages-only')
+  @UseGuards(JwtAuthGuard, CourseRolesGuard)
+  @Roles(Role.PROFESSOR)
+  async updateModuleLinkedPagesOnly(
+    @Param('courseId', ParseIntPipe) courseId: number,
+    @Body() body: { moduleLinkedPagesOnly: boolean },
+  ): Promise<string> {
+    const integration = await LMSCourseIntegrationModel.findOne({
+      where: { courseId },
+    });
+
+    if (!integration) {
+      throw new HttpException('Integration not found', HttpStatus.NOT_FOUND);
+    }
+
+    integration.moduleLinkedPagesOnly = body.moduleLinkedPagesOnly;
+    await LMSCourseIntegrationModel.save(integration);
+
+    return `Successfully updated module pages setting for course ${courseId}.`;
   }
 }

--- a/packages/server/src/lmsIntegration/lmsIntegration.controller.ts
+++ b/packages/server/src/lmsIntegration/lmsIntegration.controller.ts
@@ -510,14 +510,6 @@ export class LMSIntegrationController {
       );
     }
 
-    const selectedResources: LMSResourceType[] =
-      integration.selectedResourceTypes;
-    if (!selectedResources.includes(LMSResourceType.QUIZZES)) {
-      throw new BadRequestException(
-        ERROR_MESSAGES.lmsController.resourceDisabled,
-      );
-    }
-
     return await this.integrationService.getItems(courseId, LMSGet.Quizzes);
   }
 

--- a/packages/server/src/lmsIntegration/lmsIntegration.service.ts
+++ b/packages/server/src/lmsIntegration/lmsIntegration.service.ts
@@ -580,6 +580,11 @@ export class LMSIntegrationService {
           break;
         case LMSUpload.Pages:
           items = result.pages;
+          if (courseIntegration.moduleLinkedPagesOnly) {
+            items = (items as LMSPage[]).filter(
+              (page) => page.isModuleLinked === true,
+            );
+          }
           break;
         case LMSUpload.Files:
           items = result.files;
@@ -1316,6 +1321,7 @@ export class LMSIntegrationService {
         lmsIntegration.apiKeyExpiry != undefined &&
         new Date(lmsIntegration.apiKeyExpiry).getTime() < new Date().getTime(),
       selectedResourceTypes: lmsIntegration.selectedResourceTypes,
+      moduleLinkedPagesOnly: lmsIntegration.moduleLinkedPagesOnly,
     } satisfies LMSCourseIntegrationPartial;
   }
 

--- a/packages/server/src/lmsIntegration/lmsIntegration.service.ts
+++ b/packages/server/src/lmsIntegration/lmsIntegration.service.ts
@@ -330,6 +330,7 @@ export class LMSIntegrationService {
               modified: pages[idx].modified ?? found.modified,
               uploaded: found.uploaded,
               syncEnabled: found.syncEnabled,
+              isModuleLinked: found.isModuleLinked,
             };
           }
         }

--- a/packages/server/src/lmsIntegration/lmsPage.entity.ts
+++ b/packages/server/src/lmsIntegration/lmsPage.entity.ts
@@ -47,6 +47,9 @@ export class LMSPageModel extends BaseEntity {
   @Column({ type: 'boolean', default: true })
   syncEnabled: boolean;
 
+  @Column({ type: 'boolean', default: false })
+  isModuleLinked: boolean;
+
   @ManyToOne(
     (type) => LMSCourseIntegrationModel,
     (integration) => integration.pages,


### PR DESCRIPTION
# Description

Adds a toggle for only ingesting module-linked pages to the vector store; namely the chatbot context.

I suppose this was a request by some of the instructors using our Canvas Pages Integration.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

Hv to test more; so not ready to merge yet!!!


# Checklist:

- [ ] I have performed a code review of my own code (under the "Files Changed" tab on github) to ensure nothing is committed that shouldn't be (e.g. leftover `console.log`s, leftover unused logic, or anything else that was accidentally committed)
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing tests pass *locally* with my changes
- [ ] Any work that this PR is dependent on has been merged into the main branch
- [ ] Any UI changes have been checked to work on desktop, tablet, and mobile
