### PR TITLE
Add Notification Feed for per-course-Alerts

### DIFF
--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -2234,6 +2234,18 @@ export enum AlertType {
   ASYNC_QUESTION_UPDATE = 'asyncQuestionUpdate',
 }
 
+// Allowed combinations to enforce front/back consistency
+export const FEED_ALERT_TYPES: AlertType[] = [
+  AlertType.DOCUMENT_PROCESSED,
+  AlertType.ASYNC_QUESTION_UPDATE,
+]
+
+export const MODAL_ALERT_TYPES: AlertType[] = [
+  AlertType.REPHRASE_QUESTION,
+  AlertType.EVENT_ENDED_CHECKOUT_STAFF,
+  AlertType.PROMPT_STUDENT_TO_LEAVE_QUEUE,
+]
+
 export enum AlertDeliveryMode {
   MODAL = 'modal',
   FEED = 'feed',
@@ -2358,6 +2370,9 @@ export class CreateAlertResponse extends Alert {}
 export class GetAlertsResponse {
   @Type(() => Alert)
   alerts!: Alert[]
+  @IsOptional()
+  @IsInt()
+  total?: number
 }
 
 // not used anywhere

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -2230,6 +2230,12 @@ export enum AlertType {
   REPHRASE_QUESTION = 'rephraseQuestion',
   EVENT_ENDED_CHECKOUT_STAFF = 'eventEndedCheckoutStaff',
   PROMPT_STUDENT_TO_LEAVE_QUEUE = 'promptStudentToLeaveQueue',
+  DOCUMENT_PROCESSED = 'documentProcessed',
+}
+
+export enum AlertDeliveryMode {
+  MODAL = 'modal',
+  FEED = 'feed',
 }
 
 export class AlertPayload {}
@@ -2238,11 +2244,18 @@ export class Alert {
   @IsEnum(AlertType)
   alertType!: AlertType
 
+  @IsEnum(AlertDeliveryMode)
+  deliveryMode!: AlertDeliveryMode
+
   @IsDate()
   sent!: Date
 
   @Type(() => AlertPayload)
   payload!: AlertPayload
+
+  @IsOptional()
+  @IsDate()
+  readAt?: Date
 
   @IsInt()
   id!: number
@@ -2264,6 +2277,14 @@ export class PromptStudentToLeaveQueuePayload extends AlertPayload {
   @IsInt()
   @IsOptional()
   queueQuestionId?: number
+}
+
+export class DocumentProcessedPayload extends AlertPayload {
+  @IsInt()
+  documentId!: number
+
+  @IsString()
+  documentName!: string
 }
 
 export class OrganizationCourseResponse {
@@ -2295,6 +2316,10 @@ export class OrganizationStatsResponse {
 export class CreateAlertParams {
   @IsEnum(AlertType)
   alertType!: AlertType
+
+  @IsOptional()
+  @IsEnum(AlertDeliveryMode)
+  deliveryMode?: AlertDeliveryMode
 
   @IsInt()
   courseId!: number

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -2231,6 +2231,7 @@ export enum AlertType {
   EVENT_ENDED_CHECKOUT_STAFF = 'eventEndedCheckoutStaff',
   PROMPT_STUDENT_TO_LEAVE_QUEUE = 'promptStudentToLeaveQueue',
   DOCUMENT_PROCESSED = 'documentProcessed',
+  ASYNC_QUESTION_UPDATE = 'asyncQuestionUpdate',
 }
 
 export enum AlertDeliveryMode {
@@ -2238,7 +2239,11 @@ export enum AlertDeliveryMode {
   FEED = 'feed',
 }
 
-export class AlertPayload {}
+export class AlertPayload {
+  @IsOptional()
+  @IsInt()
+  courseId?: number
+}
 
 export class Alert {
   @IsEnum(AlertType)
@@ -2267,9 +2272,6 @@ export class RephraseQuestionPayload extends AlertPayload {
 
   @IsInt()
   queueId!: number
-
-  @IsInt()
-  courseId!: number
 }
 
 export class PromptStudentToLeaveQueuePayload extends AlertPayload {
@@ -2285,6 +2287,27 @@ export class DocumentProcessedPayload extends AlertPayload {
 
   @IsString()
   documentName!: string
+}
+
+export class AsyncQuestionUpdatePayload extends AlertPayload {
+  @IsInt()
+  questionId!: number
+
+  @IsInt()
+  courseId!: number
+
+  @IsString()
+  @IsOptional()
+  subtype?:
+    | 'commentOnMyPost'
+    | 'commentOnOthersPost'
+    | 'humanAnswered'
+    | 'statusChanged'
+    | 'upvoted'
+
+  @IsString()
+  @IsOptional()
+  summary?: string
 }
 
 export class OrganizationCourseResponse {

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -2239,11 +2239,7 @@ export enum AlertDeliveryMode {
   FEED = 'feed',
 }
 
-export class AlertPayload {
-  @IsOptional()
-  @IsInt()
-  courseId?: number
-}
+export class AlertPayload {}
 
 export class Alert {
   @IsEnum(AlertType)
@@ -2272,6 +2268,9 @@ export class RephraseQuestionPayload extends AlertPayload {
 
   @IsInt()
   queueId!: number
+
+  @IsInt()
+  courseId!: number
 }
 
 export class PromptStudentToLeaveQueuePayload extends AlertPayload {

--- a/packages/frontend/app/(dashboard)/course/[cid]/layout.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/layout.tsx
@@ -1,7 +1,10 @@
 'use client'
-import { use } from 'react'
+import { use, useEffect } from 'react'
+import useSWR from 'swr'
 
 import AlertsContainer from '@/app/components/AlertsContainer'
+import { useAlertsContext } from '@/app/contexts/alertsContext'
+import { API } from '@/app/api'
 
 type Params = Promise<{ cid: string }>
 
@@ -14,6 +17,24 @@ export default function Layout(props: {
   const { children } = props
 
   const { cid } = params
+
+  const { setThisCourseAlerts, clearThisCourseAlerts } = useAlertsContext()
+
+  const { data } = useSWR(
+    `/api/v1/alerts/course/${cid}`,
+    async () => API.alerts.get(Number(cid)),
+    { refreshInterval: 60000 },
+  )
+
+  useEffect(() => {
+    setThisCourseAlerts(data?.alerts ?? [])
+  }, [data?.alerts])
+
+  useEffect(() => {
+    return () => {
+      clearThisCourseAlerts()
+    }
+  }, [])
 
   return (
     <>

--- a/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/TAQuestionCardButtons.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/components/TAQuestionCardButtons.tsx
@@ -7,6 +7,7 @@ import {
   UndoOutlined,
 } from '@ant-design/icons'
 import {
+  AlertDeliveryMode,
   AlertType,
   ClosedQuestionStatus,
   ERROR_MESSAGES,
@@ -159,6 +160,7 @@ const TAQuestionCardButtons: React.FC<TAQuestionCardButtonsProps> = ({
         courseId,
         payload,
         targetUserId: question.creatorId,
+        deliveryMode: AlertDeliveryMode.FEED,
       })
       // await mutateQuestions()
       message.success('Successfully asked student to rephrase their question.')

--- a/packages/frontend/app/(dashboard)/layout.tsx
+++ b/packages/frontend/app/(dashboard)/layout.tsx
@@ -15,6 +15,7 @@ import ChatbotContextProvider from './course/[cid]/components/chatbot/ChatbotPro
 import FooterBar from './components/FooterBar'
 import { AsyncToasterProvider } from '../contexts/AsyncToasterContext'
 import { LogoutOutlined, ReloadOutlined } from '@ant-design/icons'
+import { AlertsProvider } from '../contexts/alertsContext'
 import { getErrorMessage } from '../utils/generalUtils'
 
 const Layout: React.FC<LayoutProps> = ({ children }) => {
@@ -96,37 +97,39 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   ) : (
     <AsyncToasterProvider>
       <UserInfoProvider profile={profile}>
-        <header className={`border-b border-b-zinc-200 bg-white`}>
-          <StandardPageContainer className="!pl-0">
-            <Link href={'#skip-link-target'} className="skip-link">
-              Skip to main content
-            </Link>
-            <HeaderBar />
-          </StandardPageContainer>
-        </header>
-        {/* This flex flex-grow is needed so that the scroll bar doesn't show up on every page */}
-        <main className="flex flex-grow flex-col">
-          <ChatbotContextProvider>
-            {pathname === '/courses' && (
-              <Image
-                src={`/api/v1/organization/${profile.organization.orgId}/get_banner/${profile.organization.organizationBannerUrl}`}
-                alt="Organization Banner"
-                className="h-[15vh] w-full object-cover object-center md:h-[20vh]"
-                width={100}
-                height={100}
-              />
-            )}
-            {/* On certain pages (like pages with big tables), we want to let the width take up the whole page */}
-            {URLSegments[4] === 'edit_questions' ||
-            URLSegments[4] === 'chatbot_questions' ? (
-              <div className="p-1">{children}</div>
-            ) : (
-              <StandardPageContainer className="flex-grow">
-                {children}
-              </StandardPageContainer>
-            )}
-          </ChatbotContextProvider>
-        </main>
+        <AlertsProvider>
+          <header className={`border-b border-b-zinc-200 bg-white`}>
+            <StandardPageContainer className="!pl-0">
+              <Link href={'#skip-link-target'} className="skip-link">
+                Skip to main content
+              </Link>
+              <HeaderBar />
+            </StandardPageContainer>
+          </header>
+          {/* This flex flex-grow is needed so that the scroll bar doesn't show up on every page */}
+          <main className="flex flex-grow flex-col">
+            <ChatbotContextProvider>
+              {pathname === '/courses' && (
+                <Image
+                  src={`/api/v1/organization/${profile.organization.orgId}/get_banner/${profile.organization.organizationBannerUrl}`}
+                  alt="Organization Banner"
+                  className="h-[15vh] w-full object-cover object-center md:h-[20vh]"
+                  width={100}
+                  height={100}
+                />
+              )}
+              {/* On certain pages (like pages with big tables), we want to let the width take up the whole page */}
+              {URLSegments[4] === 'edit_questions' ||
+              URLSegments[4] === 'chatbot_questions' ? (
+                <div className="p-1">{children}</div>
+              ) : (
+                <StandardPageContainer className="flex-grow">
+                  {children}
+                </StandardPageContainer>
+              )}
+            </ChatbotContextProvider>
+          </main>
+        </AlertsProvider>
         <FooterBar />
       </UserInfoProvider>
     </AsyncToasterProvider>

--- a/packages/frontend/app/api/index.ts
+++ b/packages/frontend/app/api/index.ts
@@ -37,6 +37,7 @@ import {
   DesktopNotifPartial,
   EditCourseInfoParams,
   GetAlertsResponse,
+  AlertDeliveryMode,
   GetAvailableModelsBody,
   GetChatbotHistoryResponse,
   GetCourseResponse,
@@ -1080,6 +1081,14 @@ class APIClient {
   alerts = {
     get: async (courseId: number): Promise<GetAlertsResponse> =>
       this.req('GET', `/api/v1/alerts/${courseId}`),
+    getAll: async (
+      mode: AlertDeliveryMode = AlertDeliveryMode.FEED,
+      includeRead: boolean = false,
+    ): Promise<GetAlertsResponse> =>
+      this.req('GET', `/api/v1/alerts`, undefined, undefined, {
+        mode,
+        includeRead: includeRead ? 'true' : 'false',
+      }),
     create: async (params: CreateAlertParams): Promise<CreateAlertResponse> =>
       this.req('POST', `/api/v1/alerts`, CreateAlertResponse, params),
     close: async (alertId: number): Promise<void> =>

--- a/packages/frontend/app/api/index.ts
+++ b/packages/frontend/app/api/index.ts
@@ -1079,20 +1079,30 @@ class APIClient {
   }
 
   alerts = {
+    markReadAll: async (): Promise<void> =>
+      this.req('PATCH', `/api/v1/alerts/mark-read-all`),
     get: async (courseId: number): Promise<GetAlertsResponse> =>
       this.req('GET', `/api/v1/alerts/${courseId}`),
     getAll: async (
       mode: AlertDeliveryMode = AlertDeliveryMode.FEED,
-      includeRead: boolean = false,
+      includeRead: boolean = true,
+      limit?: number,
+      offset?: number,
     ): Promise<GetAlertsResponse> =>
       this.req('GET', `/api/v1/alerts`, undefined, undefined, {
         mode,
         includeRead: includeRead ? 'true' : 'false',
+        ...(limit !== undefined ? { limit: String(limit) } : {}),
+        ...(offset !== undefined ? { offset: String(offset) } : {}),
       }),
     create: async (params: CreateAlertParams): Promise<CreateAlertResponse> =>
       this.req('POST', `/api/v1/alerts`, CreateAlertResponse, params),
     close: async (alertId: number): Promise<void> =>
       this.req('PATCH', `/api/v1/alerts/${alertId}`),
+    markReadBulk: async (alertIds: number[]): Promise<void> =>
+      this.req('PATCH', `/api/v1/alerts/mark-read-bulk`, undefined, {
+        alertIds,
+      }),
   }
 
   organizations = {

--- a/packages/frontend/app/components/AlertsContainer.tsx
+++ b/packages/frontend/app/components/AlertsContainer.tsx
@@ -3,10 +3,10 @@ import {
   PromptStudentToLeaveQueuePayload,
   RephraseQuestionPayload,
 } from '@koh/common'
-import useSWR from 'swr'
 import { useRouter } from 'next/navigation'
 import StudentRephraseModal from '../(dashboard)/course/[cid]/queue/[qid]/components/modals/StudentRephraseModal'
 import { API } from '../api'
+import { useAlertsContext } from '@/app/contexts/alertsContext'
 import EventEndedCheckoutStaffModal from '../(dashboard)/course/[cid]/queue/[qid]/components/modals/EventEndedCheckoutStaffModal'
 import PromptStudentToLeaveQueueModal from '../(dashboard)/course/[cid]/queue/[qid]/components/modals/PromptStudentToLeaveQueueModal'
 
@@ -15,23 +15,15 @@ type AlertsContainerProps = {
 }
 const AlertsContainer: React.FC<AlertsContainerProps> = ({ courseId }) => {
   const router = useRouter()
-  const { data, mutate: mutateAlerts } = useSWR(
-    '/api/v1/alerts',
-    async () => API.alerts.get(courseId),
-    {
-      refreshInterval: 60000, // revalidate every minute
-    },
-  )
-  const alerts = data?.alerts
+  const { thisCourseAlerts, closeCourseAlert } = useAlertsContext()
+  const alerts = thisCourseAlerts
 
   const handleCloseRephrase = async (
     alertId: number,
     courseId: number,
     queueId: number,
   ) => {
-    await API.alerts.close(alertId)
-
-    await mutateAlerts()
+    await closeCourseAlert(alertId)
     router.push(`/course/${courseId}/queue/${queueId}?edit_question=true`)
   }
 
@@ -51,8 +43,7 @@ const AlertsContainer: React.FC<AlertsContainerProps> = ({ courseId }) => {
           <EventEndedCheckoutStaffModal
             courseId={courseId}
             handleClose={async () => {
-              await API.alerts.close(alert.id)
-              await mutateAlerts()
+              await closeCourseAlert(alert.id)
             }}
           />
         )
@@ -67,8 +58,7 @@ const AlertsContainer: React.FC<AlertsContainerProps> = ({ courseId }) => {
                 .queueQuestionId
             }
             handleClose={async () => {
-              await API.alerts.close(alert.id)
-              await mutateAlerts()
+              await closeCourseAlert(alert.id)
             }}
           />
         )

--- a/packages/frontend/app/components/HeaderBar.tsx
+++ b/packages/frontend/app/components/HeaderBar.tsx
@@ -39,6 +39,7 @@ import { Popconfirm } from 'antd'
 import { sortQueues } from '../(dashboard)/course/[cid]/utils/commonCourseFunctions'
 import { useCourseFeatures } from '../hooks/useCourseFeatures'
 import CenteredSpinner from './CenteredSpinner'
+import NotificationBell from './NotificationBell'
 import Image from 'next/image'
 import { useOrganizationSettings } from '@/app/hooks/useOrganizationSettings'
 
@@ -355,6 +356,11 @@ const NavBar = ({
           ) : null}
           {/* DESKTOP ONLY PART OF NAVBAR */}
           <NavigationMenuItem className="!ml-auto hidden md:block">
+            <div className="px-2">
+              <NotificationBell />
+            </div>
+          </NavigationMenuItem>
+          <NavigationMenuItem className="hidden md:block">
             <NavigationMenuTrigger
               className={`!pl-4 ${isProfilePage ? 'md:border-helpmeblue md:border-b-2' : ''}`}
               onFocus={setNavigationSubMenuRightSide}
@@ -508,6 +514,9 @@ const HeaderBar: React.FC = () => {
             {queueRoom}
           </h2>
         )}
+      </div>
+      <div className="flex items-center">
+        <NotificationBell />
       </div>
       <Drawer
         direction="left"

--- a/packages/frontend/app/components/NotificationBell.tsx
+++ b/packages/frontend/app/components/NotificationBell.tsx
@@ -40,7 +40,6 @@ type AlertMetadata = {
 
 type NotificationBellProps = {
   showText?: boolean
-  onAfterNavigate?: () => void
   className?: string
 }
 
@@ -85,7 +84,6 @@ const alertMeta: Record<AlertType, AlertMetadata> = {
 
 const NotificationBell: React.FC<NotificationBellProps> = ({
   showText = false,
-  onAfterNavigate,
   className,
 }) => {
   const router = useRouter()
@@ -173,7 +171,6 @@ const NotificationBell: React.FC<NotificationBellProps> = ({
     (alert: Alert, url: string) => async (): Promise<void> => {
       await markAsRead(alert)
       router.push(url)
-      onAfterNavigate?.()
     }
 
   const views: NotificationView[] = useMemo(() => {
@@ -276,164 +273,160 @@ const NotificationBell: React.FC<NotificationBellProps> = ({
   const isLoadingMore = isValidating && size > 0
   const hasMore = (pages[pages.length - 1]?.alerts?.length ?? 0) === PAGE_SIZE
 
-  const content = (
-    <div className="w-80 max-w-xs">
-      {isLoading ? (
-        <div className="py-6 text-center">
-          <Spin size="small" />
-        </div>
-      ) : views.length === 0 ? (
-        <Empty
-          description="No notifications"
-          image={Empty.PRESENTED_IMAGE_SIMPLE}
-        />
-      ) : (
-        <List
-          rowKey={(item) => item.key}
-          dataSource={views}
-          renderItem={(item) => (
-            <List.Item
-              className={`${item.isUnread ? 'bg-slate-100' : ''} transition-colors hover:bg-slate-50`}
-              style={{
-                padding: '8px 12px',
-                borderBottom: '1px solid #f0f0f0',
-              }}
-              actions={
-                item.ctaLabel
-                  ? [
-                      <Button
-                        key="cta"
-                        type="link"
-                        size="small"
-                        onClick={async (e) => {
-                          e.stopPropagation()
-                          if (item.onOpen) await item.onOpen()
-                        }}
+  return (
+    <Popover
+      content={
+        <div className="w-80 max-w-xs">
+          {isLoading ? (
+            <div className="py-6 text-center">
+              <Spin size="small" />
+            </div>
+          ) : views.length === 0 ? (
+            <Empty
+              description="No notifications"
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+            />
+          ) : (
+            <List
+              rowKey={(item) => item.key}
+              dataSource={views}
+              renderItem={(item) => (
+                <List.Item
+                  className={`${item.isUnread ? 'bg-slate-100' : ''} transition-colors hover:bg-slate-50`}
+                  style={{
+                    padding: '8px 12px',
+                    borderBottom: '1px solid #f0f0f0',
+                  }}
+                  actions={
+                    item.ctaLabel
+                      ? [
+                          <Button
+                            key="cta"
+                            type="link"
+                            size="small"
+                            onClick={async (e) => {
+                              e.stopPropagation()
+                              if (item.onOpen) await item.onOpen()
+                            }}
+                          >
+                            {item.ctaLabel}
+                          </Button>,
+                        ]
+                      : undefined
+                  }
+                >
+                  <List.Item.Meta
+                    style={{ margin: 0 }}
+                    title={
+                      <Space
+                        direction="vertical"
+                        size={1}
+                        style={{ width: '100%' }}
                       >
-                        {item.ctaLabel}
-                      </Button>,
-                    ]
-                  : undefined
-              }
-            >
-              <List.Item.Meta
-                style={{ margin: 0 }}
-                title={
-                  <Space
-                    direction="vertical"
-                    size={1}
-                    style={{ width: '100%' }}
-                  >
-                    <Text
-                      strong={item.isUnread}
-                      ellipsis={{ tooltip: item.title }}
-                      style={{
-                        display: 'block',
-                        maxWidth: '95%',
-                        fontSize: 14,
+                        <Text
+                          strong={item.isUnread}
+                          ellipsis={{ tooltip: item.title }}
+                          style={{
+                            display: 'block',
+                            maxWidth: '95%',
+                            fontSize: 14,
+                          }}
+                        >
+                          {item.title}
+                        </Text>
+                        {item.courseName && (
+                          <Tag
+                            color="blue"
+                            style={{
+                              fontSize: 11,
+                              padding: '0 6px',
+                              lineHeight: '18px',
+                              borderRadius: 6,
+                              width: 'fit-content',
+                            }}
+                          >
+                            {item.courseName}
+                          </Tag>
+                        )}
+                        <Text type="secondary" style={{ fontSize: 12 }}>
+                          {dayjs(item.sent).fromNow()}
+                        </Text>
+                      </Space>
+                    }
+                    description={
+                      item.description && (
+                        <Text
+                          type="secondary"
+                          ellipsis={{ tooltip: item.description }}
+                          style={{
+                            fontSize: 12,
+                            display: 'block',
+                            maxWidth: '95%',
+                            marginTop: 4,
+                          }}
+                        >
+                          {item.description}
+                        </Text>
+                      )
+                    }
+                  />
+                  {!item.ctaLabel && (
+                    <Button
+                      type="link"
+                      size="small"
+                      onClick={async (e) => {
+                        e.stopPropagation()
+                        if (item.onOpen) await item.onOpen()
                       }}
                     >
-                      {item.title}
-                    </Text>
+                      Mark as read
+                    </Button>
+                  )}
+                </List.Item>
+              )}
+            />
+          )}
 
-                    {item.courseName && (
-                      <Tag
-                        color="blue"
-                        style={{
-                          fontSize: 11,
-                          padding: '0 6px',
-                          lineHeight: '18px',
-                          borderRadius: 6,
-                          width: 'fit-content',
-                        }}
-                      >
-                        {item.courseName}
-                      </Tag>
-                    )}
-
-                    <Text type="secondary" style={{ fontSize: 12 }}>
-                      {dayjs(item.sent).fromNow()}
-                    </Text>
-                  </Space>
-                }
-                description={
-                  item.description && (
-                    <Text
-                      type="secondary"
-                      ellipsis={{ tooltip: item.description }}
-                      style={{
-                        fontSize: 12,
-                        display: 'block',
-                        maxWidth: '95%',
-                        marginTop: 4,
-                      }}
-                    >
-                      {item.description}
-                    </Text>
-                  )
-                }
-              />
-              {!item.ctaLabel && (
+          <div className="mt-2 flex items-center justify-between gap-2">
+            {total > 0 ? (
+              <div className="flex items-center gap-1">
                 <Button
                   type="link"
                   size="small"
-                  onClick={async (e) => {
-                    e.stopPropagation()
-                    if (item.onOpen) await item.onOpen()
+                  disabled={currentPage <= 0}
+                  onClick={() => setCurrentPage((p) => Math.max(0, p - 1))}
+                >
+                  Prev
+                </Button>
+                <Button
+                  type="link"
+                  size="small"
+                  disabled={(currentPage + 1) * PAGE_SIZE >= total}
+                  loading={isValidating && size > 0}
+                  onClick={() => {
+                    const next = currentPage + 1
+                    const requiredSize = next + 1
+                    if (size < requiredSize) setSize(requiredSize)
+                    setCurrentPage(next)
                   }}
                 >
-                  Mark as read
+                  Next
                 </Button>
-              )}
-            </List.Item>
-          )}
-        />
-      )}
-
-      <div className="mt-2 flex items-center justify-between gap-2">
-        {total > 0 ? (
-          <div className="flex items-center gap-1">
-            <Button
-              type="link"
-              size="small"
-              disabled={currentPage <= 0}
-              onClick={() => setCurrentPage((p) => Math.max(0, p - 1))}
-            >
-              Prev
-            </Button>
-            <Button
-              type="link"
-              size="small"
-              disabled={(currentPage + 1) * PAGE_SIZE >= total}
-              loading={isValidating && size > 0}
-              onClick={() => {
-                const next = currentPage + 1
-                const requiredSize = next + 1
-                if (size < requiredSize) setSize(requiredSize)
-                setCurrentPage(next)
-              }}
-            >
-              Next
-            </Button>
-            <Text type="secondary" style={{ fontSize: 12 }}>
-              {`${currentPage * PAGE_SIZE + 1}-${currentPage * PAGE_SIZE + (currentPageAlerts?.length || 0)} of ${total}`}
-            </Text>
+                <Text type="secondary" style={{ fontSize: 12 }}>
+                  {`${currentPage * PAGE_SIZE + 1}-${currentPage * PAGE_SIZE + (currentPageAlerts?.length || 0)} of ${total}`}
+                </Text>
+              </div>
+            ) : (
+              <span />
+            )}
+            {total > 0 && (
+              <Button type="link" size="small" onClick={markAllRead}>
+                Mark all as read
+              </Button>
+            )}
           </div>
-        ) : (
-          <span />
-        )}
-        {total > 0 && (
-          <Button type="link" size="small" onClick={markAllRead}>
-            Mark all as read
-          </Button>
-        )}
-      </div>
-    </div>
-  )
-
-  return (
-    <Popover
-      content={content}
+        </div>
+      }
       trigger="click"
       placement="bottomRight"
       open={open}

--- a/packages/frontend/app/components/NotificationBell.tsx
+++ b/packages/frontend/app/components/NotificationBell.tsx
@@ -1,0 +1,412 @@
+'use client'
+
+import React, { useMemo, useState } from 'react'
+import {
+  Alert,
+  AlertDeliveryMode,
+  AlertType,
+  DocumentProcessedPayload,
+  GetCourseResponse,
+  AsyncQuestionUpdatePayload,
+} from '@koh/common'
+import {
+  Badge,
+  Button,
+  Empty,
+  List,
+  Popover,
+  Space,
+  Spin,
+  Typography,
+  Tag,
+} from 'antd'
+import { BellOutlined } from '@ant-design/icons'
+import useSWR from 'swr'
+import dayjs from 'dayjs'
+import relativeTime from 'dayjs/plugin/relativeTime'
+import { API } from '@/app/api'
+import { useRouter } from 'next/navigation'
+
+const { Text } = Typography
+dayjs.extend(relativeTime)
+
+type AlertMetadata = {
+  title: string
+  description?: string
+  destination?: string
+}
+
+type NotificationBellProps = {
+  showText?: boolean
+  onAfterNavigate?: () => void
+  className?: string
+}
+
+type NotificationView = {
+  key: number
+  title: string
+  description?: string
+  ctaLabel?: string
+  onOpen?: () => Promise<void> | void
+  isUnread: boolean
+  sent: Date
+  courseName?: string
+}
+
+const alertMeta: Record<AlertType, AlertMetadata> = {
+  [AlertType.DOCUMENT_PROCESSED]: {
+    title: 'Document processed',
+    description:
+      'Your uploaded document has been processed and is ready to use.',
+    destination: '/settings/chatbot_knowledge_base',
+  },
+  [AlertType.REPHRASE_QUESTION]: {
+    title: 'Question rephrase requested',
+    description:
+      'You have been asked to add more detail to your question. Your place in line is reserved while you edit.',
+  },
+  [AlertType.PROMPT_STUDENT_TO_LEAVE_QUEUE]: {
+    title: 'Please leave the queue',
+    description:
+      'You have been inactive for a while. Please leave the queue if you no longer need assistance.',
+  },
+  [AlertType.EVENT_ENDED_CHECKOUT_STAFF]: {
+    title: 'Event has ended',
+    description:
+      'The event you were assisting with has ended. Please check out.',
+  },
+  [AlertType.ASYNC_QUESTION_UPDATE]: {
+    title: 'Anytime question update',
+    description: 'There was an update related to an Anytime Question.',
+  },
+}
+
+const NotificationBell: React.FC<NotificationBellProps> = ({
+  showText = false,
+  onAfterNavigate,
+  className,
+}) => {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+
+  const { data, isLoading, mutate } = useSWR(
+    ['alerts-feed'],
+    async () => API.alerts.getAll(AlertDeliveryMode.FEED),
+    { revalidateOnFocus: true },
+  )
+
+  const alerts: Alert[] = useMemo(() => data?.alerts ?? [], [data])
+
+  const unreadCount = useMemo(
+    () => alerts.filter((alert) => !alert.readAt).length,
+    [alerts],
+  )
+
+  const uniqueCourseIds = useMemo(() => {
+    const ids = new Set<number>()
+    for (const alert of alerts) {
+      if ((alert.payload as any)?.courseId) {
+        ids.add((alert.payload as any).courseId)
+      }
+    }
+    return Array.from(ids)
+  }, [alerts])
+
+  // fetch course names for each courseId in alerts
+  const { data: courseResponses } = useSWR(
+    uniqueCourseIds.length > 0 ? ['courses-for-alerts', uniqueCourseIds] : null,
+    async () => {
+      const results: Record<number, string> = {}
+      await Promise.all(
+        uniqueCourseIds.map(async (id) => {
+          try {
+            const course: GetCourseResponse = await API.course.get(id)
+            results[id] = course?.name ?? `Course ${id}`
+          } catch {
+            results[id] = `Course ${id}`
+          }
+        }),
+      )
+      return results
+    },
+    { revalidateOnFocus: false },
+  )
+
+  const courseNameMap = courseResponses ?? {}
+
+  const markAsRead = async (alert: Alert) => {
+    if (alert.readAt) return
+    // optimistic update
+    mutate(
+      (current) =>
+        current
+          ? {
+              ...current,
+              alerts: current.alerts.map((a) =>
+                a.id === alert.id ? { ...a, readAt: new Date() as any } : a,
+              ),
+            }
+          : current,
+      { revalidate: false },
+    )
+    try {
+      await API.alerts.close(alert.id)
+    } finally {
+      await mutate(undefined, { revalidate: true })
+    }
+  }
+
+  const handleNavigate =
+    (alert: Alert, url: string) => async (): Promise<void> => {
+      await markAsRead(alert)
+      router.push(url)
+      onAfterNavigate?.()
+    }
+
+  const views: NotificationView[] = useMemo(() => {
+    return alerts
+      .filter((alert) => alert.deliveryMode === AlertDeliveryMode.FEED)
+      .map((alert) => {
+        const sentAt = new Date(alert.sent)
+        const courseId = (alert.payload as any)?.courseId
+        const courseName = courseId ? courseNameMap[courseId] : undefined
+
+        if (alert.alertType === AlertType.DOCUMENT_PROCESSED) {
+          const payload = alert.payload as DocumentProcessedPayload
+          const destination = courseId
+            ? `/course/${courseId}/settings/chatbot_knowledge_base`
+            : undefined
+
+          return {
+            key: alert.id,
+            title: `Document "${payload.documentName}" is ready`,
+            description: 'Uploaded course document finished processing.',
+            ctaLabel: destination ? 'View document' : undefined,
+            onOpen: destination
+              ? handleNavigate(alert, destination)
+              : async () => await markAsRead(alert),
+            isUnread: !alert.readAt,
+            sent: sentAt,
+            courseName,
+          }
+        }
+
+        if (alert.alertType === AlertType.ASYNC_QUESTION_UPDATE) {
+          const payload = alert.payload as AsyncQuestionUpdatePayload
+          const destination = payload.courseId
+            ? `/course/${payload.courseId}/async_centre`
+            : undefined
+          const title =
+            payload.subtype === 'commentOnMyPost'
+              ? 'New comment on your Anytime Question'
+              : payload.subtype === 'commentOnOthersPost'
+                ? 'New comment on a followed Anytime Question'
+                : payload.subtype === 'humanAnswered'
+                  ? 'Your Anytime Question was answered'
+                  : payload.subtype === 'statusChanged'
+                    ? 'Anytime Question status changed'
+                    : payload.subtype === 'upvoted'
+                      ? 'Your Anytime Question was upvoted'
+                      : 'Anytime Question update'
+          return {
+            key: alert.id,
+            title,
+            description: payload.summary,
+            ctaLabel: destination ? 'Open' : undefined,
+            onOpen: destination
+              ? handleNavigate(alert, destination)
+              : async () => await markAsRead(alert),
+            isUnread: !alert.readAt,
+            sent: sentAt,
+            courseName,
+          }
+        }
+
+        const meta = alertMeta[alert.alertType]
+        return {
+          key: alert.id,
+          title: meta?.title,
+          description: meta?.description,
+          onOpen: async () => await markAsRead(alert),
+          isUnread: !alert.readAt,
+          sent: sentAt,
+          courseName,
+        }
+      })
+      .sort((a, b) => b.sent.getTime() - a.sent.getTime())
+  }, [alerts, courseNameMap])
+
+  const markAllRead = async () => {
+    const unread = alerts.filter((a) => !a.readAt)
+    if (!unread.length) return
+    // optimistic update for all
+    mutate(
+      (current) =>
+        current
+          ? {
+              ...current,
+              alerts: current.alerts.map((a) =>
+                a.readAt ? a : { ...a, readAt: new Date() as any },
+              ),
+            }
+          : current,
+      { revalidate: false },
+    )
+    try {
+      await Promise.all(unread.map((a) => API.alerts.close(a.id)))
+    } finally {
+      await mutate(undefined, { revalidate: true })
+    }
+  }
+
+  const content = (
+    <div className="w-80 max-w-xs">
+      {isLoading ? (
+        <div className="py-6 text-center">
+          <Spin size="small" />
+        </div>
+      ) : views.length === 0 ? (
+        <Empty
+          description="No notifications"
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+        />
+      ) : (
+        <List
+          rowKey={(item) => item.key}
+          dataSource={views}
+          renderItem={(item) => (
+            <List.Item
+              className={`${item.isUnread ? 'bg-slate-100' : ''} transition-colors hover:bg-slate-50`}
+              style={{
+                padding: '8px 12px',
+                borderBottom: '1px solid #f0f0f0',
+              }}
+              actions={
+                item.ctaLabel
+                  ? [
+                      <Button
+                        key="cta"
+                        type="link"
+                        size="small"
+                        onClick={async (e) => {
+                          e.stopPropagation()
+                          if (item.onOpen) await item.onOpen()
+                        }}
+                      >
+                        {item.ctaLabel}
+                      </Button>,
+                    ]
+                  : undefined
+              }
+            >
+              <List.Item.Meta
+                style={{ margin: 0 }}
+                title={
+                  <Space
+                    direction="vertical"
+                    size={1}
+                    style={{ width: '100%' }}
+                  >
+                    <Text
+                      strong={item.isUnread}
+                      ellipsis={{ tooltip: item.title }}
+                      style={{
+                        display: 'block',
+                        maxWidth: '95%',
+                        fontSize: 14,
+                      }}
+                    >
+                      {item.title}
+                    </Text>
+
+                    {item.courseName && (
+                      <Tag
+                        color="blue"
+                        style={{
+                          fontSize: 11,
+                          padding: '0 6px',
+                          lineHeight: '18px',
+                          borderRadius: 6,
+                          width: 'fit-content',
+                        }}
+                      >
+                        {item.courseName}
+                      </Tag>
+                    )}
+
+                    <Text type="secondary" style={{ fontSize: 12 }}>
+                      {dayjs(item.sent).fromNow()}
+                    </Text>
+                  </Space>
+                }
+                description={
+                  item.description && (
+                    <Text
+                      type="secondary"
+                      ellipsis={{ tooltip: item.description }}
+                      style={{
+                        fontSize: 12,
+                        display: 'block',
+                        maxWidth: '95%',
+                        marginTop: 4,
+                      }}
+                    >
+                      {item.description}
+                    </Text>
+                  )
+                }
+              />
+              {!item.ctaLabel && (
+                <Button
+                  type="link"
+                  size="small"
+                  onClick={async (e) => {
+                    e.stopPropagation()
+                    if (item.onOpen) await item.onOpen()
+                  }}
+                >
+                  Mark as read
+                </Button>
+              )}
+            </List.Item>
+          )}
+        />
+      )}
+
+      {views.length > 0 && unreadCount > 0 && (
+        <div className="mt-2 flex justify-end">
+          <Button type="link" size="small" onClick={markAllRead}>
+            Mark all as read
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+
+  const trigger = (
+    <Badge count={unreadCount} size="small">
+      <Button
+        type="text"
+        className={`flex items-center ${className ?? ''}`.trim()}
+        icon={<BellOutlined />}
+      >
+        {showText && <span className="ml-1">Notifications</span>}
+      </Button>
+    </Badge>
+  )
+
+  return (
+    <Popover
+      content={content}
+      trigger="click"
+      placement="bottomRight"
+      open={open}
+      onOpenChange={(visible) => setOpen(visible)}
+      overlayStyle={{ padding: 0, borderRadius: 8 }}
+    >
+      {trigger}
+    </Popover>
+  )
+}
+
+export default NotificationBell

--- a/packages/frontend/app/contexts/alertsContext.tsx
+++ b/packages/frontend/app/contexts/alertsContext.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import React, { createContext, useContext, useMemo, useState } from 'react'
+import useSWRInfinite from 'swr/infinite'
+import { API } from '@/app/api'
+import { Alert, AlertDeliveryMode, GetAlertsResponse } from '@koh/common'
+
+type AlertsContextValue = {
+  pages: GetAlertsResponse[]
+  total: number
+  isLoading: boolean
+  isValidating: boolean
+  size: number
+  setSize: (s: number) => void
+  mutate: (data?: any, opts?: any) => Promise<any>
+  currentPage: number
+  setCurrentPage: (p: number) => void
+  currentPageAlerts: Alert[]
+  markRead: (alertId: number) => Promise<void>
+  markAllRead: () => Promise<void>
+  pageSize: number
+  // course-level alerts state (populated by course layout)
+  thisCourseAlerts: Alert[]
+  setThisCourseAlerts: (alerts: Alert[]) => void
+  clearThisCourseAlerts: () => void
+  closeCourseAlert: (alertId: number) => Promise<void>
+}
+
+const AlertsContext = createContext<AlertsContextValue | undefined>(undefined)
+
+export const AlertsProvider: React.FC<{
+  children: React.ReactNode
+  pageSize?: number
+}> = ({ children, pageSize = 5 }) => {
+  const { data, isLoading, isValidating, size, setSize, mutate } =
+    useSWRInfinite(
+      (index) => ['alerts-feed', index, pageSize],
+      async ([, indexKey, ps]) =>
+        API.alerts.getAll(
+          AlertDeliveryMode.FEED,
+          false,
+          ps as number,
+          (indexKey as number) * (ps as number),
+        ),
+      { revalidateOnFocus: true },
+    )
+
+  const [currentPage, setCurrentPage] = useState(0)
+  const pages = data ?? []
+  const total = pages[0]?.total ?? 0
+  const currentPageAlerts: Alert[] = pages[currentPage]?.alerts ?? []
+
+  // course-level alerts
+  const [thisCourseAlerts, setThisCourseAlertsState] = useState<Alert[]>([])
+  const setThisCourseAlerts = (alerts: Alert[]) =>
+    setThisCourseAlertsState(alerts)
+  const clearThisCourseAlerts = () => setThisCourseAlertsState([])
+
+  const markRead = async (alertId: number) => {
+    // optimistic: remove from current page and decrement total
+    mutate(
+      (currentPages: GetAlertsResponse[] | undefined) =>
+        currentPages
+          ? currentPages.map((page, idx) => ({
+              ...page,
+              alerts:
+                idx === currentPage && Array.isArray(page.alerts)
+                  ? page.alerts.filter((a) => a.id !== alertId)
+                  : page.alerts,
+              total:
+                idx === 0 && typeof page.total === 'number'
+                  ? Math.max(0, (page.total ?? 0) - 1)
+                  : page.total,
+            }))
+          : currentPages,
+      { revalidate: false },
+    )
+    try {
+      await API.alerts.close(alertId)
+    } finally {
+      await mutate(undefined, { revalidate: true })
+    }
+  }
+
+  const markAllRead = async () => {
+    // optimistic: clear all and set total 0
+    mutate(
+      (currentPages: GetAlertsResponse[] | undefined) =>
+        currentPages
+          ? currentPages.map((p, idx) => ({
+              ...p,
+              alerts: [],
+              total: idx === 0 ? 0 : p.total,
+            }))
+          : currentPages,
+      { revalidate: false },
+    )
+    try {
+      await API.alerts.markReadAll()
+    } finally {
+      await mutate(undefined, { revalidate: true })
+    }
+  }
+
+  const closeCourseAlert = async (alertId: number) => {
+    // optimistic removal from course-level alerts, and refresh feed afterwards
+    setThisCourseAlertsState((prev) => prev.filter((a) => a.id !== alertId))
+    try {
+      await API.alerts.close(alertId)
+    } finally {
+      await mutate(undefined, { revalidate: true })
+    }
+  }
+
+  const value = useMemo<AlertsContextValue>(
+    () => ({
+      pages,
+      total,
+      isLoading,
+      isValidating,
+      size,
+      setSize,
+      mutate,
+      currentPage,
+      setCurrentPage,
+      currentPageAlerts,
+      markRead,
+      markAllRead,
+      pageSize,
+      thisCourseAlerts,
+      setThisCourseAlerts,
+      clearThisCourseAlerts,
+      closeCourseAlert,
+    }),
+    [
+      pages,
+      total,
+      isLoading,
+      isValidating,
+      size,
+      setSize,
+      mutate,
+      currentPage,
+      currentPageAlerts,
+      pageSize,
+      thisCourseAlerts,
+    ],
+  )
+
+  return (
+    <AlertsContext.Provider value={value}>{children}</AlertsContext.Provider>
+  )
+}
+
+export const useAlertsContext = (): AlertsContextValue => {
+  const ctx = useContext(AlertsContext)
+  if (!ctx)
+    throw new Error('useAlertsContext must be used within AlertsProvider')
+  return ctx
+}

--- a/packages/server/migration/1738540000000-alert-delivery-mode.ts
+++ b/packages/server/migration/1738540000000-alert-delivery-mode.ts
@@ -1,0 +1,49 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AlertDeliveryMode1738540000000 implements MigrationInterface {
+  name = 'AlertDeliveryMode1738540000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE "public"."alert_model_alerttype_enum" RENAME TO "alert_model_alerttype_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."alert_model_alerttype_enum" AS ENUM('rephraseQuestion', 'eventEndedCheckoutStaff', 'promptStudentToLeaveQueue', 'documentProcessed')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "alert_model" ALTER COLUMN "alertType" TYPE "public"."alert_model_alerttype_enum" USING "alertType"::text::"public"."alert_model_alerttype_enum"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."alert_model_alerttype_enum_old"`,
+    );
+
+    await queryRunner.query(
+      `CREATE TYPE "public"."alert_model_deliverymode_enum" AS ENUM('modal', 'feed')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "alert_model" ADD "deliveryMode" "public"."alert_model_deliverymode_enum" NOT NULL DEFAULT 'modal'`,
+    );
+    await queryRunner.query(`ALTER TABLE "alert_model" ADD "readAt" TIMESTAMP`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "alert_model" DROP COLUMN "readAt"`);
+    await queryRunner.query(
+      `ALTER TABLE "alert_model" DROP COLUMN "deliveryMode"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."alert_model_deliverymode_enum"`,
+    );
+
+    await queryRunner.query(
+      `CREATE TYPE "public"."alert_model_alerttype_enum_old" AS ENUM('rephraseQuestion', 'eventEndedCheckoutStaff', 'promptStudentToLeaveQueue')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "alert_model" ALTER COLUMN "alertType" TYPE "public"."alert_model_alerttype_enum_old" USING "alertType"::text::"public"."alert_model_alerttype_enum_old"`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."alert_model_alerttype_enum"`);
+    await queryRunner.query(
+      `ALTER TYPE "public"."alert_model_alerttype_enum_old" RENAME TO "alert_model_alerttype_enum"`,
+    );
+  }
+}

--- a/packages/server/migration/1755000000000-add-async-question-alert-type.ts
+++ b/packages/server/migration/1755000000000-add-async-question-alert-type.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAsyncQuestionAlertType1755000000000
+  implements MigrationInterface
+{
+  name = 'AddAsyncQuestionAlertType1755000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE "public"."alert_model_alerttype_enum" RENAME TO "alert_model_alerttype_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."alert_model_alerttype_enum" AS ENUM('rephraseQuestion', 'eventEndedCheckoutStaff', 'promptStudentToLeaveQueue', 'documentProcessed', 'asyncQuestionUpdate')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "alert_model" ALTER COLUMN "alertType" TYPE "public"."alert_model_alerttype_enum" USING "alertType"::text::"public"."alert_model_alerttype_enum"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."alert_model_alerttype_enum_old"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."alert_model_alerttype_enum_old" AS ENUM('rephraseQuestion', 'eventEndedCheckoutStaff', 'promptStudentToLeaveQueue', 'documentProcessed')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "alert_model" ALTER COLUMN "alertType" TYPE "public"."alert_model_alerttype_enum_old" USING "alertType"::text::"public"."alert_model_alerttype_enum_old"`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."alert_model_alerttype_enum"`);
+    await queryRunner.query(
+      `ALTER TYPE "public"."alert_model_alerttype_enum_old" RENAME TO "alert_model_alerttype_enum"`,
+    );
+  }
+}

--- a/packages/server/src/alerts/alerts-clean.service.ts
+++ b/packages/server/src/alerts/alerts-clean.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { AlertModel } from './alerts.entity';
+import { AlertDeliveryMode } from '@koh/common';
+
+@Injectable()
+export class AlertsCleanService {
+  // Daily cleanup: delete FEED alerts read more than 30 days ago
+  @Cron(CronExpression.EVERY_DAY_AT_3AM)
+  async pruneOldReadFeed(): Promise<void> {
+    const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    await AlertModel.createQueryBuilder()
+      .delete()
+      .from(AlertModel)
+      .where('"deliveryMode" = :mode', { mode: AlertDeliveryMode.FEED })
+      .andWhere('"readAt" IS NOT NULL')
+      .andWhere('"readAt" < :cutoff', { cutoff })
+      .execute();
+  }
+}

--- a/packages/server/src/alerts/alerts.entity.ts
+++ b/packages/server/src/alerts/alerts.entity.ts
@@ -1,4 +1,12 @@
-import { AlertDeliveryMode, AlertPayload, AlertType } from '@koh/common';
+import {
+  AlertDeliveryMode,
+  AlertPayload,
+  AlertType,
+  RephraseQuestionPayload,
+  PromptStudentToLeaveQueuePayload,
+  DocumentProcessedPayload,
+  AsyncQuestionUpdatePayload,
+} from '@koh/common';
 import { Exclude } from 'class-transformer';
 import {
   BaseEntity,
@@ -52,5 +60,10 @@ export class AlertModel extends BaseEntity {
   courseId: number;
 
   @Column({ type: 'json' })
-  payload: AlertPayload;
+  payload:
+    | AlertPayload
+    | RephraseQuestionPayload
+    | PromptStudentToLeaveQueuePayload
+    | DocumentProcessedPayload
+    | AsyncQuestionUpdatePayload;
 }

--- a/packages/server/src/alerts/alerts.entity.ts
+++ b/packages/server/src/alerts/alerts.entity.ts
@@ -1,4 +1,4 @@
-import { AlertPayload, AlertType } from '@koh/common';
+import { AlertDeliveryMode, AlertPayload, AlertType } from '@koh/common';
 import { Exclude } from 'class-transformer';
 import {
   BaseEntity,
@@ -19,11 +19,21 @@ export class AlertModel extends BaseEntity {
   @Column({ type: 'enum', enum: AlertType })
   alertType: AlertType;
 
+  @Column({
+    type: 'enum',
+    enum: AlertDeliveryMode,
+    default: AlertDeliveryMode.MODAL,
+  })
+  deliveryMode: AlertDeliveryMode;
+
   @Column()
   sent: Date;
 
   @Column({ nullable: true })
   resolved: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  readAt: Date;
 
   @ManyToOne((type) => UserModel, (user) => user.alerts)
   @JoinColumn({ name: 'userId' })

--- a/packages/server/src/alerts/alerts.module.ts
+++ b/packages/server/src/alerts/alerts.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AlertsController } from './alerts.controller';
 import { AlertsService } from './alerts.service';
+import { AlertsCleanService } from './alerts-clean.service';
 
 @Module({
+  imports: [],
   controllers: [AlertsController],
-  providers: [AlertsService],
+  providers: [AlertsService, AlertsCleanService],
 })
 export class AlertsModule {}

--- a/packages/server/src/alerts/alerts.service.ts
+++ b/packages/server/src/alerts/alerts.service.ts
@@ -40,14 +40,7 @@ export class AlertsService {
             await alert.save();
           } else {
             nonStaleAlerts.push(
-              pick(alert, [
-                'sent',
-                'alertType',
-                'payload',
-                'id',
-                'deliveryMode',
-                'readAt',
-              ]),
+              pick(alert, ['sent', 'alertType', 'payload', 'id']),
             );
           }
           break;

--- a/packages/server/src/alerts/alerts.service.ts
+++ b/packages/server/src/alerts/alerts.service.ts
@@ -6,6 +6,7 @@ import {
   RephraseQuestionPayload,
   PromptStudentToLeaveQueuePayload,
   DocumentProcessedPayload,
+  AsyncQuestionUpdatePayload,
 } from '@koh/common';
 import { pick } from 'lodash';
 import { Injectable } from '@nestjs/common';
@@ -54,6 +55,7 @@ export class AlertsService {
         case AlertType.EVENT_ENDED_CHECKOUT_STAFF:
         case AlertType.PROMPT_STUDENT_TO_LEAVE_QUEUE:
         case AlertType.DOCUMENT_PROCESSED:
+        case AlertType.ASYNC_QUESTION_UPDATE:
           nonStaleAlerts.push(
             pick(alert, [
               'sent',
@@ -94,12 +96,22 @@ export class AlertsService {
         );
 
       case AlertType.DOCUMENT_PROCESSED:
+      case AlertType.ASYNC_QUESTION_UPDATE:
         const docPayload = payload as DocumentProcessedPayload;
-        return (
-          typeof docPayload.documentId === 'number' &&
-          typeof docPayload.documentName === 'string' &&
-          docPayload.documentName.trim().length > 0
-        );
+        // For async question update, ensure course/question IDs exist; for document processed, ensure doc info exists
+        if ((alertType as AlertType) === AlertType.DOCUMENT_PROCESSED) {
+          return (
+            typeof docPayload.documentId === 'number' &&
+            typeof docPayload.documentName === 'string' &&
+            docPayload.documentName.trim().length > 0
+          );
+        } else {
+          const asyncPayload = payload as AsyncQuestionUpdatePayload;
+          return (
+            typeof (asyncPayload as any).courseId === 'number' &&
+            typeof (asyncPayload as any).questionId === 'number'
+          );
+        }
 
       default:
         return true;

--- a/packages/server/src/asyncQuestion/asyncQuestion.controller.ts
+++ b/packages/server/src/asyncQuestion/asyncQuestion.controller.ts
@@ -122,7 +122,7 @@ export class asyncQuestionController {
 
     // Check if the question was upvoted and send email if subscribed
     if (newValue === 1 && userId !== updatedQuestion.creator.id) {
-      await this.asyncQuestionService.sendUpvotedEmail(updatedQuestion);
+      await this.asyncQuestionService.sendUpvotedEmailAndAlert(updatedQuestion);
     }
 
     return res.status(HttpStatus.OK).send({
@@ -382,7 +382,7 @@ export class asyncQuestionController {
       // don't send status change email if its deleted
       // (I don't like the vibes of notifying a student that their question was deleted by staff)
       // Though technically speaking this isn't even really used yet since there isn't a status that the TA would really turn it to that isn't HumanAnswered or TADeleted
-      await this.asyncQuestionService.sendGenericStatusChangeEmail(
+      await this.asyncQuestionService.sendGenericStatusChangeEmailAndAlert(
         question,
         body.status,
       );
@@ -516,7 +516,7 @@ export class asyncQuestionController {
 
     // don't send email if its a comment on your own post
     if (question.creatorId !== user.id) {
-      await this.asyncQuestionService.sendNewCommentOnMyQuestionEmail(
+      await this.asyncQuestionService.sendNewCommentOnMyQuestionEmailAndAlert(
         user,
         courseRole,
         updatedQuestion,
@@ -524,7 +524,7 @@ export class asyncQuestionController {
       );
     }
     // send emails out to all users that have posted a comment on this question (it also performs checks)
-    await this.asyncQuestionService.sendNewCommentOnOtherQuestionEmail(
+    await this.asyncQuestionService.sendNewCommentOnOtherQuestionEmailAndAlert(
       user,
       courseRole,
       question.creatorId,

--- a/packages/server/src/asyncQuestion/asyncQuestion.service.ts
+++ b/packages/server/src/asyncQuestion/asyncQuestion.service.ts
@@ -22,7 +22,7 @@ import { AlertModel } from '../alerts/alerts.entity';
 export class AsyncQuestionService {
   constructor(private mailService: MailService) {}
 
-  async sendNewCommentOnMyQuestionEmail(
+  async sendNewCommentOnMyQuestionEmailAndAlert(
     commenter: UserModel,
     commenterRole: Role,
     question: AsyncQuestionModel,
@@ -84,7 +84,7 @@ export class AsyncQuestionService {
   /*send emails out to all users that have posted a comment on this question.
       Note that updatedQuestion must have comments and comments.creator relations
       */
-  async sendNewCommentOnOtherQuestionEmail(
+  async sendNewCommentOnOtherQuestionEmailAndAlert(
     commenter: UserModel,
     commenterRole: Role,
     questionCreatorId: number,
@@ -138,7 +138,6 @@ export class AsyncQuestionService {
         }
       });
     });
-    // FEED alerts for participants (exclude commenter and creator via the query)
     // FEED alerts to all participants who commented (excluding current commenter and creator), regardless of email subscriptions
     const participantIds = Array.from(
       new Set(
@@ -304,7 +303,7 @@ export class AsyncQuestionService {
   }
 
   /* Not really used right now since the only status that staff can change is changing it to "Human Answered" */
-  async sendGenericStatusChangeEmail(
+  async sendGenericStatusChangeEmailAndAlert(
     question: AsyncQuestionModel,
     status: string,
   ) {
@@ -352,7 +351,7 @@ export class AsyncQuestionService {
     }
   }
 
-  async sendUpvotedEmail(updatedQuestion: AsyncQuestionModel) {
+  async sendUpvotedEmailAndAlert(updatedQuestion: AsyncQuestionModel) {
     const subscription = await UserSubscriptionModel.findOne({
       where: {
         userId: updatedQuestion.creator.id,

--- a/packages/server/src/asyncQuestion/asyncQuestion.service.ts
+++ b/packages/server/src/asyncQuestion/asyncQuestion.service.ts
@@ -73,7 +73,7 @@ export class AsyncQuestionService {
           questionId: question.id,
           subtype: 'commentOnMyPost',
           summary: `${commenterIsStaff ? commenter.name : 'Someone'} commented on your question`,
-        } as any,
+        },
       }).save();
     }
   }
@@ -149,7 +149,7 @@ export class AsyncQuestionService {
             questionId: updatedQuestion.id,
             subtype: 'commentOnOthersPost',
             summary: `${commenterIsStaff ? commenter.name : 'Someone'} commented on an Anytime Question you follow`,
-          } as any,
+          },
         }).save(),
       ),
     );
@@ -336,7 +336,7 @@ export class AsyncQuestionService {
           questionId: question.id,
           subtype: 'statusChanged',
           summary: `Your Anytime Question status changed to ${status}`,
-        } as any,
+        },
       }).save();
     }
   }
@@ -381,7 +381,7 @@ export class AsyncQuestionService {
           questionId: updatedQuestion.id,
           subtype: 'upvoted',
           summary: 'Your Anytime Question was upvoted',
-        } as any,
+        },
       }).save();
     }
   }

--- a/packages/server/src/calendar/calendar.service.ts
+++ b/packages/server/src/calendar/calendar.service.ts
@@ -10,7 +10,7 @@ import { EntityManager } from 'typeorm';
 import { UserModel } from '../profile/user.entity';
 import { CalendarModel } from './calendar.entity';
 import { AlertModel } from '../alerts/alerts.entity';
-import { AlertType, ERROR_MESSAGES } from '@koh/common';
+import { AlertDeliveryMode, AlertType, ERROR_MESSAGES } from '@koh/common';
 import { QueueModel } from '../queue/queue.entity';
 import { EventModel, EventType } from '../profile/event-model.entity';
 import { CronJob } from 'cron';
@@ -235,6 +235,7 @@ export class CalendarService implements OnModuleInit {
     try {
       alert = await AlertModel.create({
         alertType: AlertType.EVENT_ENDED_CHECKOUT_STAFF,
+        deliveryMode: AlertDeliveryMode.MODAL,
         sent: now,
         userId: userId,
         courseId: courseId,

--- a/packages/server/src/queue/queue-clean/queue-clean.service.ts
+++ b/packages/server/src/queue/queue-clean/queue-clean.service.ts
@@ -218,7 +218,7 @@ export class QueueCleanService {
           sent: new Date(),
           userId: student.studentId,
           courseId: student.courseId,
-          payload: { queueId, queueQuestionId: student.questionId } as any,
+          payload: { queueId, queueQuestionId: student.questionId },
         }).save();
         // if the student does not respond in 10 minutes, resolve the alert and mark the question as LeftDueToNoStaff
         const jobName = `prompt-student-to-leave-queue-${queueId}-${student.studentId}`;

--- a/packages/server/src/queue/queue-clean/queue-clean.service.ts
+++ b/packages/server/src/queue/queue-clean/queue-clean.service.ts
@@ -1,4 +1,5 @@
 import {
+  AlertDeliveryMode,
   AlertType,
   ClosedQuestionStatus,
   LimboQuestionStatus,
@@ -104,6 +105,9 @@ export class QueueCleanService {
       .andWhere("(alert.payload ->> 'queueId')::INTEGER = :queueId ", {
         queueId,
       })
+      .andWhere('alert."deliveryMode" = :deliveryMode', {
+        deliveryMode: AlertDeliveryMode.MODAL,
+      })
       .getMany();
 
     questions.forEach((q: QuestionModel) => {
@@ -201,12 +205,16 @@ export class QueueCleanService {
           .andWhere('alert.payload::jsonb @> :payload', {
             payload: JSON.stringify({ queueId }),
           })
+          .andWhere('alert."deliveryMode" = :deliveryMode', {
+            deliveryMode: AlertDeliveryMode.MODAL,
+          })
           .getOne();
         if (existingAlert) {
           return;
         }
         const alert = await AlertModel.create({
           alertType: AlertType.PROMPT_STUDENT_TO_LEAVE_QUEUE,
+          deliveryMode: AlertDeliveryMode.MODAL,
           sent: new Date(),
           userId: student.studentId,
           courseId: student.courseId,

--- a/packages/server/src/queue/queue-clean/queue-clean.service.ts
+++ b/packages/server/src/queue/queue-clean/queue-clean.service.ts
@@ -214,11 +214,15 @@ export class QueueCleanService {
         }
         const alert = await AlertModel.create({
           alertType: AlertType.PROMPT_STUDENT_TO_LEAVE_QUEUE,
-          deliveryMode: AlertDeliveryMode.MODAL,
           sent: new Date(),
           userId: student.studentId,
           courseId: student.courseId,
-          payload: { queueId, queueQuestionId: student.questionId },
+          payload: {
+            queueId,
+            ...(student.questionId !== undefined
+              ? { queueQuestionId: student.questionId }
+              : {}),
+          },
         }).save();
         // if the student does not respond in 10 minutes, resolve the alert and mark the question as LeftDueToNoStaff
         const jobName = `prompt-student-to-leave-queue-${queueId}-${student.studentId}`;

--- a/packages/server/src/queue/queue-clean/queue-clean.service.ts
+++ b/packages/server/src/queue/queue-clean/queue-clean.service.ts
@@ -218,7 +218,7 @@ export class QueueCleanService {
           sent: new Date(),
           userId: student.studentId,
           courseId: student.courseId,
-          payload: { queueId, queueQuestionId: student.questionId },
+          payload: { queueId, queueQuestionId: student.questionId } as any,
         }).save();
         // if the student does not respond in 10 minutes, resolve the alert and mark the question as LeftDueToNoStaff
         const jobName = `prompt-student-to-leave-queue-${queueId}-${student.studentId}`;


### PR DESCRIPTION
# Description

Added a notification feed on the header bar, using REPHRASE_QUESTION and Anytime Question updates as examples.
Extended the existing Alert infrastructure, adding a `deliveryMode` field to switch between modals, and the notification field. 

Closes #356 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

Tested manually using interactions between the admin user and studentOne.

# Checklist:

- [x] I have performed a code review of my own code (under the "Files Changed" tab on github) to ensure nothing is committed that shouldn't be (e.g. leftover `console.log`s, leftover unused logic, or anything else that was accidentally committed)
- [x] I have commented my code where needed 
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing tests pass *locally* with my changes
- [ ] Any work that this PR is dependent on has been merged into the main branch
- [x] Any UI changes have been checked to work on desktop, tablet, and mobile

# Demo


https://github.com/user-attachments/assets/15748030-5e5a-4366-aa82-d358001effd3

