### PR TITLE
Fix wrong avatars + overflow in queue chat

### DIFF
--- a/packages/frontend/app/(dashboard)/course/[cid]/components/QueueChat.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/components/QueueChat.tsx
@@ -171,7 +171,7 @@ const QueueChat: React.FC<QueueChatProps> = ({
                     {message.isStaff == isStaff ? (
                       <div className="mb-2 flex flex-row items-start justify-end gap-2">
                         <div className="flex max-w-[70%] flex-col rounded-xl bg-blue-900 p-2 text-white">
-                          <span className="text-wrap text-sm">
+                          <span className="break-words text-sm">
                             {message.message}
                           </span>
                           <span className="text-xs">
@@ -190,7 +190,7 @@ const QueueChat: React.FC<QueueChatProps> = ({
                         <UserAvatar
                           size="small"
                           username={
-                            !isStaff
+                            message.isStaff
                               ? `${queueChatData.staff.firstName} ${queueChatData.staff.lastName ?? ''}`
                               : `${queueChatData.student.firstName} ${queueChatData.student.lastName ?? ''}`
                           }
@@ -206,7 +206,7 @@ const QueueChat: React.FC<QueueChatProps> = ({
                         <UserAvatar
                           size="small"
                           username={
-                            !isStaff
+                            message.isStaff
                               ? `${queueChatData.staff.firstName} ${queueChatData.staff.lastName ?? ''}`
                               : `${queueChatData.student.firstName} ${queueChatData.student.lastName ?? ''}`
                           }
@@ -217,7 +217,9 @@ const QueueChat: React.FC<QueueChatProps> = ({
                           }
                         />
                         <div className="flex max-w-[70%] flex-col rounded-xl bg-slate-100 p-2 text-slate-900">
-                          <span className="text-sm">{message.message}</span>
+                          <span className="break-words text-sm">
+                            {message.message}
+                          </span>
                           <span className="text-xs">
                             {new Date(message.timestamp).toLocaleTimeString(
                               undefined,


### PR DESCRIPTION
# Description

Fixed a falty boolean check that led to the user's avatar being rendered always. Also added a tailwind class to break long, space-less strings (keyboard smashes, perhaps) so they don't break UI.

Closes #411 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

Tested manually using accounts studentOne and Ramon@ubc

# Checklist:

- [x] I have performed a code review of my own code (under the "Files Changed" tab on github) to ensure nothing is committed that shouldn't be (e.g. leftover `console.log`s, leftover unused logic, or anything else that was accidentally committed)
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing tests pass *locally* with my changes
- [ ] Any work that this PR is dependent on has been merged into the main branch
- [ ] Any UI changes have been checked to work on desktop, tablet, and mobile
