### PR TITLE
Allow users to login with SSO into legacy accounts

### DIFF
--- a/packages/server/src/auth/auth.service.ts
+++ b/packages/server/src/auth/auth.service.ts
@@ -75,6 +75,9 @@ export class AuthService {
     const user = await UserModel.findOne({
       where: {
         email: mail,
+        organizationUser: {
+          organizationId: organizationId,
+        },
       },
       // not querying for AccountType or have any checks for it since
       // it's assumed that if they successfully logged in with shibboleth,


### PR DESCRIPTION
# Description

Removes the checks that prevents users from logging in with SSO into their Legacy accounts. Should give a lot less pain for some dozens of users who have created Legacy accounts but then tried to login with SSO.

For more context I think this was discussed at some point but I lost where it was discussed. This might be a terrible idea (or maybe just needs some tweaks first)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?




# Checklist:

- [ ] I have performed a code review of my own code (under the "Files Changed" tab on github) to ensure nothing is committed that shouldn't be (e.g. leftover `console.log`s, leftover unused logic, or anything else that was accidentally committed)
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing tests pass *locally* with my changes
- [ ] Any work that this PR is dependent on has been merged into the main branch
- [ ] Any UI changes have been checked to work on desktop, tablet, and mobile
