### PR TITLE
[BUGFIX] Cache Bust on Course Role Change

### DIFF
--- a/packages/server/src/course/course.controller.ts
+++ b/packages/server/src/course/course.controller.ts
@@ -15,13 +15,13 @@ import {
   QueuePartial,
   QueueTypes,
   Role,
+  SetTAExtraStatusParams,
   TACheckinTimesResponse,
   TACheckoutResponse,
   UBCOuserParam,
   UserCourse,
   UserTiny,
   validateQueueConfigInput,
-  SetTAExtraStatusParams,
 } from '@koh/common';
 import {
   BadRequestException,
@@ -827,7 +827,11 @@ export class CourseController {
     }
 
     try {
-      await UserCourseModel.update({ courseId, userId }, { role });
+      /*
+       pass in userId as well (even if it is the same) as that is the only way
+       it is passed to the subscribed afterUpdate event
+      */
+      await UserCourseModel.update({ courseId, userId }, { role, userId });
     } catch (err) {
       res.status(HttpStatus.BAD_REQUEST).send({ message: err.message });
       return;


### PR DESCRIPTION
# Description

It's one line that adds userId to the updated properties partial entity of a .update() event because entity subscribers are stupid

Closes #396

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

None yet **but if it breaks any I'll fix them.**


# Checklist:

- [x] I have performed a code review of my own code (under the "Files Changed" tab on github) to ensure nothing is committed that shouldn't be (e.g. leftover `console.log`s, leftover unused logic, or anything else that was accidentally committed)
- [x] I have commented my code where needed 
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing tests pass *locally* with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [x] Any UI changes have been checked to work on desktop, tablet, and mobile
