### PR TITLE
Allow LMS API Key to be used even if not allowed by organization

### DIFF
--- a/packages/server/src/lmsIntegration/lmsIntegration.adapter.ts
+++ b/packages/server/src/lmsIntegration/lmsIntegration.adapter.ts
@@ -20,7 +20,6 @@ import { LMSAuthStateModel } from './lms-auth-state.entity';
 import { ConfigService } from '@nestjs/config';
 import express from 'express';
 import { LMSAccessToken, LMSAccessTokenModel } from './lms-access-token.entity';
-import { OrganizationSettingsModel } from '../organization/organization_settings.entity';
 import * as crypto from 'crypto';
 
 @Injectable()
@@ -182,12 +181,14 @@ export abstract class AbstractLMSAdapter {
   }
 
   async getAuthorization() {
-    const orgSettings = await OrganizationSettingsModel.findOne({
-      where: {
-        organizationId: this.integration.orgIntegration.organizationId,
-      },
-    });
-    if (this.integration.apiKey != undefined && orgSettings?.allowLMSApiKey) {
+    // const orgSettings = await OrganizationSettingsModel.findOne({
+    //   where: {
+    //     organizationId: this.integration.orgIntegration.organizationId,
+    //   },
+    // });
+    // TODO: TEMPORARY: Allow API Keys through even if organization settings disallows adding them
+    if (this.integration.apiKey != undefined) {
+      // && orgSettings?.allowLMSApiKey) {
       if (
         this.integration.apiKeyExpiry &&
         this.integration.apiKeyExpiry.getTime() < Date.now()


### PR DESCRIPTION
# Description

Solves the issue where a course has a previously defined API key prior to organization policy changes to still be able to use their integration, but not be able to update and continue to use an API key in the future once expired

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

Does not break any tests

# Checklist:

- [x] I have performed a code review of my own code (under the "Files Changed" tab on github) to ensure nothing is committed that shouldn't be (e.g. leftover `console.log`s, leftover unused logic, or anything else that was accidentally committed)
- [x] I have commented my code where needed 
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing tests pass *locally* with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [x] Any UI changes have been checked to work on desktop, tablet, and mobile
