### PR TITLE
Fixed visibility of “Set question visible to all students” toggle in the Post Response modal

### DIFF
--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -1318,7 +1318,7 @@ export type AsyncQuestion = {
   closedAt?: Date
   isAnonymous?: boolean
   staffSetVisible?: boolean
-  authorSetVisible?: boolean
+  authorSetVisible: boolean
   verified: boolean
   votes?: AsyncQuestionVotes[]
   comments: AsyncQuestionComment[]

--- a/packages/frontend/app/(dashboard)/course/[cid]/async_centre/components/modals/PostResponseModal.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/async_centre/components/modals/PostResponseModal.tsx
@@ -51,7 +51,7 @@ const PostResponseModal: React.FC<PostResponseModalProps> = ({
   const [isLoading, setIsLoading] = useState(false)
   const [deleteLoading, setDeleteLoading] = useState(false)
   const [staffSetVisible, setStaffSetVisible] = useState<boolean>(
-    question.staffSetVisible ?? question.authorSetVisible ?? false,
+    question.staffSetVisible ?? question.authorSetVisible,
   )
   const [visiblePopConfirmVisible, setVisiblePopConfirmVisible] =
     useState<boolean>(false)
@@ -63,9 +63,7 @@ const PostResponseModal: React.FC<PostResponseModalProps> = ({
   const [confirmPopoverOpen, setConfirmPopoverOpen] = useState(false)
 
   useEffect(() => {
-    setStaffSetVisible(
-      question.staffSetVisible ?? question.authorSetVisible ?? false,
-    )
+    setStaffSetVisible(question.staffSetVisible ?? question.authorSetVisible)
   }, [question.authorSetVisible, question.staffSetVisible])
 
   const onFinish = async () => {


### PR DESCRIPTION
# Description

This PR fixes a bug where the “Set question visible to all students” toggle in the Post Response modal was defaulting to true, even when the question was previously private. This behaviour caused private questions to unintentionally become public when staff posted or edited a response — even without explicitly changing the toggle.

The visibility switch was initialized only once when the component was mounted. When a new question was loaded, the state was not updated, and the default logic incorrectly fell back to true when staffSetVisible was null.

Closes #433 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

I tested this fix using both student and professor accounts. First, I created a few dummy questions from a student account and then answered them from a professor account. When opening the Post Response modal, the “Set question visible to all students” toggle now correctly defaults to Hidden, and if I submit the response without touching the toggle, the question stays hidden as expected. I verified this by logging into a second student account and checking that the question was not visible. I also tested changing the toggle to Visible before submitting, and confirmed that the question then appeared for other students. Finally, I updated the visibility after posting by reopening the modal and switching the toggle again, and the visibility continued to match the toggle state. This confirmed that visibility only changes when staff explicitly change it and stays consistent after saving.

# Checklist:

- [x] I have performed a code review of my own code (under the "Files Changed" tab on github) to ensure nothing is committed that shouldn't be (e.g. leftover `console.log`s, leftover unused logic, or anything else that was accidentally committed)
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing tests pass *locally* with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [ ] Any UI changes have been checked to work on desktop, tablet, and mobile
