### PR TITLE
Now shows 'No queues in this course' in HeaderBar

### DIFF
--- a/packages/frontend/app/components/HeaderBar.tsx
+++ b/packages/frontend/app/components/HeaderBar.tsx
@@ -49,7 +49,7 @@ import {
   MailOutlined,
   SyncOutlined,
 } from '@ant-design/icons'
-import { Empty, Popconfirm } from 'antd'
+import { Popconfirm } from 'antd'
 import { sortQueues } from '../(dashboard)/course/[cid]/utils/commonCourseFunctions'
 import { useCourseFeatures } from '../hooks/useCourseFeatures'
 import CenteredSpinner from './CenteredSpinner'
@@ -304,11 +304,9 @@ const NavBar = ({
                           <div
                             className={`w-[60vw] p-4 text-center text-sm text-gray-500 ${role === Role.PROFESSOR ? 'lg:w-[600px]' : 'lg:w-[400px]'}`}
                           >
-                            <p className="">
-                              There are no queues in this course
-                            </p>
+                            <p>There are no queues in this course</p>
                             {role === Role.PROFESSOR && (
-                              <p className="">
+                              <p>
                                 You can create a queue on the{' '}
                                 <NextLink
                                   href={`${coursePrefix}/${courseId}`}


### PR DESCRIPTION
# Description

Just something I sorta thought of doing on a whim while I was testing other stuff.

<img width="462" height="148" alt="image" src="https://github.com/user-attachments/assets/49fefbcf-80cc-4bf4-a48b-437658c2842d" />

For professors-only
<img width="657" height="154" alt="image" src="https://github.com/user-attachments/assets/dfb2e876-3884-4355-acf6-73dc405b2bbe" />

Looks fine on mobile
<img width="344" height="327" alt="image" src="https://github.com/user-attachments/assets/b78b5f50-d055-4199-977a-cbfd3385fa8e" />

For context, this is what it's like on prod:
<img width="703" height="137" alt="image" src="https://github.com/user-attachments/assets/7987545a-d2c2-471d-9f5d-1bc531da45a6" />


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

Manual testing

# Checklist:

- [x] I have performed a code review of my own code (under the "Files Changed" tab on github) to ensure nothing is committed that shouldn't be (e.g. leftover `console.log`s, leftover unused logic, or anything else that was accidentally committed)
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing tests pass *locally* with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [x] Any UI changes have been checked to work on desktop, tablet, and mobile
