### PR TITLE
Show 'Test Semester' when creating courses

### DIFF
--- a/packages/frontend/app/(dashboard)/components/EditCourseForm.tsx
+++ b/packages/frontend/app/(dashboard)/components/EditCourseForm.tsx
@@ -215,7 +215,6 @@ const EditCourseForm: React.FC<EditCourseFormProps> = ({
           name="courseTimezone"
           tooltip="Timezone of the course"
           className="flex-1"
-          rules={[{ required: true, message: 'Please select a timezone' }]}
         >
           <Select>
             {COURSE_TIMEZONES.map((timezone) => (
@@ -230,7 +229,7 @@ const EditCourseForm: React.FC<EditCourseFormProps> = ({
           label="Semester"
           name="semesterId"
           className="flex-1"
-          rules={[{ required: false }]}
+          required
         >
           <Select
             placeholder="Select Semester"
@@ -243,7 +242,8 @@ const EditCourseForm: React.FC<EditCourseFormProps> = ({
                   {formatSemesterDate(semester)}
                 </span>
                 {semester.endDate &&
-                  new Date(semester.endDate) < new Date() && (
+                  new Date(semester.endDate) < new Date() &&
+                  !(new Date(semester.endDate) < new Date('1971-01-01')) && (
                     <span style={{ color: 'red', marginLeft: 6 }}>(ended)</span>
                   )}
               </Select.Option>

--- a/packages/frontend/app/(dashboard)/organization/course/add/page.tsx
+++ b/packages/frontend/app/(dashboard)/organization/course/add/page.tsx
@@ -88,7 +88,9 @@ export default function AddCoursePage(): ReactElement {
         setOrganizationSemesters(
           semesters.filter(
             (semester) =>
-              semester.endDate && new Date(semester.endDate) > new Date(),
+              semester.endDate &&
+              (new Date(semester.endDate) > new Date() ||
+                new Date(semester.endDate) < new Date('1971-01-01')), // show the test semester, which has an end date of before 1971
           ), // filter out past semesters
         )
       })
@@ -257,9 +259,6 @@ export default function AddCoursePage(): ReactElement {
                       label="Course Timezone"
                       name="courseTimezone"
                       tooltip="Timezone of the course"
-                      rules={[
-                        { required: true, message: 'Please select a timezone' },
-                      ]}
                     >
                       <Select>
                         {COURSE_TIMEZONES.map((timezone) => (
@@ -276,7 +275,7 @@ export default function AddCoursePage(): ReactElement {
                       label="Semester"
                       name="semesterId"
                       className="flex-1"
-                      rules={[{ required: false }]}
+                      rules={[{ required: true }]}
                     >
                       <Select
                         placeholder="Select Semester"

--- a/packages/frontend/app/utils/timeFormatUtils.ts
+++ b/packages/frontend/app/utils/timeFormatUtils.ts
@@ -159,6 +159,10 @@ export function formatSemesterDate(semester: SemesterPartial): string {
   const hasEnd = !!semester.endDate
   if (!hasStart && !hasEnd) return ''
 
+  if (hasEnd && new Date(semester.endDate!) < new Date('1971-01-01')) {
+    return '' // for test semester, don't show the start/end date
+  }
+
   let startMonth = '',
     startYear = 0,
     endMonth = '',


### PR DESCRIPTION
# Description

All this does is
- Remove required from timezone and added it to Semester (purely just for decorative purposes. You couldn't put nothing in those Selectors even if you wanted to)
- Make it so you can see semesters made before 1971 (test semesters) when creating courses 
- Hide the start and end dates for semesters made before 1971 (test semesters)

<img width="1245" height="592" alt="image" src="https://github.com/user-attachments/assets/6d3b75b0-f7b0-4961-ac48-a239c750a2b7" />

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

Manually tested it works fine

# Checklist:

- [x] I have performed a code review of my own code (under the "Files Changed" tab on github) to ensure nothing is committed that shouldn't be (e.g. leftover `console.log`s, leftover unused logic, or anything else that was accidentally committed)
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing tests pass *locally* with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [ ] Any UI changes have been checked to work on desktop, tablet, and mobile
