### PR TITLE
CreatedAt Migration Fix - Legacy data not getting set to null

### DIFF
--- a/packages/server/migration/1768954613282-add-created-at-various.ts
+++ b/packages/server/migration/1768954613282-add-created-at-various.ts
@@ -7,26 +7,51 @@ export class AddCreatedAtVarious1768954613282 implements MigrationInterface {
     await queryRunner.query(
       `ALTER TABLE "user_course_model" ADD "createdAt" TIMESTAMP WITH TIME ZONE DEFAULT now()`,
     );
+    // Set legacy data created_at to null. To be extra careful, it only does it where createdAt is +/- 1 hour from now().
+    await queryRunner.query(
+      `UPDATE "user_course_model" SET "createdAt" = null WHERE "createdAt" BETWEEN (now() - INTERVAL '1 hour') AND (now() + INTERVAL '1 hour')`,
+    );
     await queryRunner.query(
       `ALTER TABLE "question_type_model" ADD "createdAt" TIMESTAMP WITH TIME ZONE DEFAULT now()`,
+    );
+    await queryRunner.query(
+      `UPDATE "question_type_model" SET "createdAt" = null WHERE "createdAt" BETWEEN (now() - INTERVAL '1 hour') AND (now() + INTERVAL '1 hour')`,
     );
     await queryRunner.query(
       `ALTER TABLE "queue_invite_model" ADD "createdAt" TIMESTAMP WITH TIME ZONE DEFAULT now()`,
     );
     await queryRunner.query(
+      `UPDATE "queue_invite_model" SET "createdAt" = null WHERE "createdAt" BETWEEN (now() - INTERVAL '1 hour') AND (now() + INTERVAL '1 hour')`,
+    );
+    await queryRunner.query(
       `ALTER TABLE "queue_model" ADD "createdAt" TIMESTAMP WITH TIME ZONE DEFAULT now()`,
+    );
+    await queryRunner.query(
+      `UPDATE "queue_model" SET "createdAt" = null WHERE "createdAt" BETWEEN (now() - INTERVAL '1 hour') AND (now() + INTERVAL '1 hour')`,
     );
     await queryRunner.query(
       `ALTER TABLE "semester_model" ADD "createdAt" TIMESTAMP WITH TIME ZONE DEFAULT now()`,
     );
     await queryRunner.query(
+      `UPDATE "semester_model" SET "createdAt" = null WHERE "createdAt" BETWEEN (now() - INTERVAL '1 hour') AND (now() + INTERVAL '1 hour')`,
+    );
+    await queryRunner.query(
       `ALTER TABLE "organization_model" ADD "createdAt" TIMESTAMP WITH TIME ZONE DEFAULT now()`,
+    );
+    await queryRunner.query(
+      `UPDATE "organization_model" SET "createdAt" = null WHERE "createdAt" BETWEEN (now() - INTERVAL '1 hour') AND (now() + INTERVAL '1 hour')`,
     );
     await queryRunner.query(
       `ALTER TABLE "user_model" ADD "createdAt" TIMESTAMP WITH TIME ZONE DEFAULT now()`,
     );
     await queryRunner.query(
+      `UPDATE "user_model" SET "createdAt" = null WHERE "createdAt" BETWEEN (now() - INTERVAL '1 hour') AND (now() + INTERVAL '1 hour')`,
+    );
+    await queryRunner.query(
       `ALTER TABLE "course_model" ADD "createdAt" TIMESTAMP WITH TIME ZONE DEFAULT now()`,
+    );
+    await queryRunner.query(
+      `UPDATE "course_model" SET "createdAt" = null WHERE "createdAt" BETWEEN (now() - INTERVAL '1 hour') AND (now() + INTERVAL '1 hour')`,
     );
   }
 


### PR DESCRIPTION
# Description

Simple changes. I also ran one of the queries locally and it seems to work. If not for some reason, the tests should fail I believe.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?


# Checklist:

- [x] I have performed a code review of my own code (under the "Files Changed" tab on github) to ensure nothing is committed that shouldn't be (e.g. leftover `console.log`s, leftover unused logic, or anything else that was accidentally committed)
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing tests pass *locally* with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [ ] Any UI changes have been checked to work on desktop, tablet, and mobile
