### PR TITLE
Tablet Navbar issues fixed

### DIFF
--- a/packages/frontend/app/components/HeaderBar.tsx
+++ b/packages/frontend/app/components/HeaderBar.tsx
@@ -188,21 +188,12 @@ const NavBar = ({
   const compactTopLevelClass = isCompactDesktop ? '!pl-1.5 !pr-2' : ''
   const drawerTopLevelItemClass = showDrawerPresentation ? 'w-full' : ''
   const horizontalInsetClass = !showDrawerPresentation ? 'md:pl-8' : ''
-  const horizontalInsetImportantClass = !showDrawerPresentation
-    ? '!md:pl-8'
-    : ''
   const selectedNavItemClass =
     'bg-zinc-300/80 hover:bg-zinc-300/80 focus:bg-zinc-300/80'
   const sortedQueues = useMemo(() => {
     if (!course?.queues) return []
     return sortQueues(course.queues)
   }, [course?.queues])
-  const queueDropdownListClass = showDrawerPresentation
-    ? `grid w-full gap-1 p-4 ${sortedQueues.length > 6 ? 'grid-cols-2' : 'grid-cols-1'}`
-    : `grid gap-1 p-4 md:grid-cols-2 lg:w-[600px] lg:gap-2 ${sortedQueues.length > 6 ? 'w-[95vw] grid-cols-2' : 'w-[60vw]'}`
-  const emptyQueueStateClass = showDrawerPresentation
-    ? 'w-full p-4 text-center text-sm text-gray-500'
-    : `w-[60vw] p-4 text-center text-sm text-gray-500 ${role === Role.PROFESSOR ? 'lg:w-[600px]' : 'lg:w-[400px]'}`
 
   // This is to move the "Queues" and "Profile" submenu to show on the left or right side (there is only one component, so it needs to be moved around like this)
   const setNavigationSubMenuRightSide = useCallback(() => {
@@ -317,7 +308,22 @@ const NavBar = ({
                       <NavigationMenuContent>
                         {/* On mobile, if there are more than 6 queues, put the queue list into two columns */}
                         {sortedQueues.length > 0 ? (
-                          <ul className={queueDropdownListClass}>
+                          <ul
+                            className={cn(
+                              'grid gap-1 p-4',
+                              showDrawerPresentation
+                                ? 'w-full'
+                                : 'md:grid-cols-2 lg:w-[600px] lg:gap-2',
+                              sortedQueues.length > 6
+                                ? 'grid-cols-2'
+                                : showDrawerPresentation
+                                  ? 'grid-cols-1'
+                                  : 'w-[60vw]',
+                              !showDrawerPresentation &&
+                                sortedQueues.length > 6 &&
+                                'w-[95vw]',
+                            )}
+                          >
                             {sortedQueues.map((queue) => (
                               <ListItem
                                 key={queue.id}
@@ -336,7 +342,16 @@ const NavBar = ({
                             ))}
                           </ul>
                         ) : (
-                          <div className={emptyQueueStateClass}>
+                          <div
+                            className={cn(
+                              'p-4 text-center text-sm text-gray-500',
+                              showDrawerPresentation
+                                ? 'w-full'
+                                : role === Role.PROFESSOR
+                                  ? 'w-[60vw] lg:w-[600px]'
+                                  : 'w-[60vw] lg:w-[400px]',
+                            )}
+                          >
                             <p>There are no queues in this course</p>
                             {role === Role.PROFESSOR && (
                               <p>
@@ -482,7 +497,7 @@ const NavBar = ({
                   <NavigationMenuItem>
                     <Link
                       className={cn(
-                        horizontalInsetImportantClass,
+                        !showDrawerPresentation && '!md:pl-8',
                         isAnOrganizationSettingsPage && selectedNavItemClass,
                       )}
                       href="/organization/settings"

--- a/packages/frontend/app/components/HeaderBar.tsx
+++ b/packages/frontend/app/components/HeaderBar.tsx
@@ -559,8 +559,8 @@ const NavBar = ({
           )}
           {/* MOBILE ONLY PART OF NAVBAR */}
           {showDrawerPresentation && (
-            <div className="mt-auto w-full pt-3">
-              <div className="-mx-5 mb-2 block w-[calc(100%+2.5rem)] border-b border-b-zinc-200" />
+            <>
+              <div className="-mx-5 !mt-auto mb-2 block w-[calc(100%+2.5rem)] border-b border-b-zinc-200" />
               {!isLti && (
                 <NavigationMenuItem>
                   <Link
@@ -629,7 +629,7 @@ const NavBar = ({
                   </Link>
                 </Popconfirm>
               </NavigationMenuItem>
-            </div>
+            </>
           )}
         </NavigationMenuList>
       </NavigationMenu>
@@ -832,7 +832,7 @@ const HeaderBar: React.FC = () => {
             </DrawerTrigger>
             <DrawerContent aria-description="Drawer for main navigation menu">
               {/* INSIDE DRAWER */}
-              <div className="flex flex-col items-start justify-start">
+              <div className="flex min-h-[100dvh] flex-col items-start justify-start">
                 <DrawerTitle className="my-1 flex w-full items-center justify-center border-b border-b-zinc-200 bg-white py-1 pr-5">
                   <Image
                     width={48}

--- a/packages/frontend/app/components/HeaderBar.tsx
+++ b/packages/frontend/app/components/HeaderBar.tsx
@@ -3,7 +3,10 @@
 import React, {
   HTMLAttributeAnchorTarget,
   useCallback,
+  useEffect,
+  useLayoutEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react'
 import { useUserInfo } from '@/app/contexts/userContext'
@@ -68,6 +71,7 @@ const Link = ({
   isSubMenuLink,
   onClick,
   target,
+  isCompactDesktop = false,
 }: {
   ref?: React.Ref<HTMLAnchorElement>
   href: string
@@ -76,6 +80,7 @@ const Link = ({
   isSubMenuLink?: boolean
   onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void
   target?: HTMLAttributeAnchorTarget
+  isCompactDesktop?: boolean
 }) => {
   const pathname = usePathname()
   const isActive = href === pathname
@@ -89,7 +94,7 @@ const Link = ({
         className={
           (isSubMenuLink
             ? navigationMenuTriggerStyleForSubMenu()
-            : navigationMenuTriggerStyle()) +
+            : cn(navigationMenuTriggerStyle(), isCompactDesktop && '!px-2')) +
           ' ' +
           className
         }
@@ -150,6 +155,10 @@ const NavBar = ({
   isProfilePage = false,
   orientation = 'horizontal',
   isLti = false,
+  isCompactDesktop = false,
+  forceDrawerPresentation = false,
+  className = '',
+  showViewport = true,
 }: {
   userInfo: User
   courseId?: number
@@ -162,13 +171,23 @@ const NavBar = ({
   isProfilePage?: boolean
   orientation?: 'horizontal' | 'vertical'
   isLti?: boolean
+  isCompactDesktop?: boolean
+  forceDrawerPresentation?: boolean
+  className?: string
+  showViewport?: boolean
 }) => {
   const organizationSettings = useOrganizationSettings(
     userInfo?.organization?.orgId ?? -1,
   )
   const router = useRouter()
+  const showDesktopPresentation =
+    orientation === 'horizontal' && !forceDrawerPresentation
+  const showDrawerPresentation =
+    orientation === 'vertical' || forceDrawerPresentation
   const courseFeatures = useCourseFeatures(courseId)
   const role = courseId ? getRoleInCourse(userInfo, courseId) : null
+  const compactTopLevelClass = isCompactDesktop ? '!pl-1.5 !pr-2' : ''
+
   const sortedQueues = useMemo(() => {
     if (!course?.queues) return []
     return sortQueues(course.queues)
@@ -207,40 +226,46 @@ const NavBar = ({
     const coursePrefix = isLti ? '/lti' : '/course'
     const logoutUrl = '/api/v1/logout' + (isLti ? '?lti=true' : '')
     return (
-      <NavigationMenu orientation={orientation}>
+      <NavigationMenu
+        orientation={orientation}
+        className={className}
+        showViewport={showViewport}
+      >
         <NavigationMenuList>
-          <NextLink
-            href={
-              course
-                ? `${coursePrefix}/${courseId}`
-                : isLti
-                  ? '/lti'
-                  : '/courses'
-            }
-            aria-hidden="true"
-            className="hidden md:block"
-            tabIndex={-1}
-            onClick={() => setIsDrawerOpen && setIsDrawerOpen(false)}
-          >
-            {/* This organization logo is only visible on desktop */}
-            <Image
-              width={48}
-              height={48}
-              className={cn(
-                'h-12 w-full object-contain p-1',
-                isLti ? 'pl-4' : 'pr-4',
-              )}
-              alt="Organization Logo"
-              src={`/api/v1/organization/${userInfo.organization?.orgId}/get_logo/${userInfo.organization?.organizationLogoUrl}`}
-            />
-          </NextLink>
+          {showDesktopPresentation && (
+            <NextLink
+              href={
+                course
+                  ? `${coursePrefix}/${courseId}`
+                  : isLti
+                    ? '/lti'
+                    : '/courses'
+              }
+              aria-hidden="true"
+              tabIndex={-1}
+              onClick={() => setIsDrawerOpen && setIsDrawerOpen(false)}
+            >
+              {/* This organization logo is only visible on desktop */}
+              <Image
+                width={48}
+                height={48}
+                className={cn(
+                  'h-12 w-full object-contain p-1',
+                  isLti ? 'pl-4' : 'pr-4',
+                )}
+                alt="Organization Logo"
+                src={`/api/v1/organization/${userInfo.organization?.orgId}/get_logo/${userInfo.organization?.organizationLogoUrl}`}
+              />
+            </NextLink>
+          )}
           {course ? (
             <>
               <NavigationMenuItem>
                 <Link
-                  className="!font-bold "
+                  className={cn('!font-bold', compactTopLevelClass)}
                   href={`${coursePrefix}/${courseId}`}
                   onClick={() => setIsDrawerOpen && setIsDrawerOpen(false)}
+                  isCompactDesktop={isCompactDesktop}
                 >
                   {/* <House strokeWidth={1.5} className='mr-3' /> */}
                   <HomeOutlined className="mr-3 text-2xl" />
@@ -252,6 +277,8 @@ const NavBar = ({
                   <Link
                     href={`/lti/${course.id}/integration`}
                     onClick={() => setIsDrawerOpen && setIsDrawerOpen(false)}
+                    className={compactTopLevelClass}
+                    isCompactDesktop={isCompactDesktop}
                   >
                     <SyncOutlined className="mr-3 text-2xl" />
                     Integration
@@ -264,11 +291,12 @@ const NavBar = ({
                     <NavigationMenuItem>
                       {/* This "NavigationMenuTrigger" is just the "Queues" button */}
                       <NavigationMenuTrigger
-                        className={
+                        className={cn(
+                          compactTopLevelClass,
                           isAQueuePage
                             ? 'md:border-helpmeblue bg-zinc-300/80 md:border-b-2 md:bg-white'
-                            : ''
-                        }
+                            : '',
+                        )}
                         onFocus={setNavigationSubMenuLeftSide}
                         onClick={setNavigationSubMenuLeftSide}
                         onPointerMove={(e) => e.preventDefault()}
@@ -340,6 +368,8 @@ const NavBar = ({
                         onClick={() =>
                           setIsDrawerOpen && setIsDrawerOpen(false)
                         }
+                        className={compactTopLevelClass}
+                        isCompactDesktop={isCompactDesktop}
                       >
                         <MessageCircleQuestion
                           strokeWidth={1.5}
@@ -356,6 +386,8 @@ const NavBar = ({
                         onClick={() =>
                           setIsDrawerOpen && setIsDrawerOpen(false)
                         }
+                        className={compactTopLevelClass}
+                        isCompactDesktop={isCompactDesktop}
                       >
                         <CalendarDays strokeWidth={1.5} className="mr-3" />
                         Schedule
@@ -372,10 +404,12 @@ const NavBar = ({
                       }
                     >
                       <Link
+                        className={compactTopLevelClass}
                         href={`/course/${courseId}/settings${role === Role.TA ? '/edit_questions' : ''}`}
                         onClick={() =>
                           setIsDrawerOpen && setIsDrawerOpen(false)
                         }
+                        isCompactDesktop={isCompactDesktop}
                       >
                         <Settings strokeWidth={1.5} className="mr-3" />
                         Course Settings
@@ -389,6 +423,8 @@ const NavBar = ({
                         onClick={() =>
                           setIsDrawerOpen && setIsDrawerOpen(false)
                         }
+                        className={compactTopLevelClass}
+                        isCompactDesktop={isCompactDesktop}
                       >
                         <LineChart strokeWidth={1.5} className="mr-3" />
                         Insights
@@ -401,6 +437,8 @@ const NavBar = ({
                 <Link
                   href={isLti ? '/lti' : '/courses'}
                   onClick={() => setIsDrawerOpen && setIsDrawerOpen(false)}
+                  className={compactTopLevelClass}
+                  isCompactDesktop={isCompactDesktop}
                 >
                   <Undo2 strokeWidth={1.5} className="mr-3" />
                   My Courses
@@ -418,6 +456,7 @@ const NavBar = ({
                       router.back()
                       if (setIsDrawerOpen) setIsDrawerOpen(false)
                     }}
+                    isCompactDesktop={isCompactDesktop}
                   >
                     <Undo2 strokeWidth={1.5} className="mr-3" />
                     Back
@@ -429,6 +468,7 @@ const NavBar = ({
                   href={isLti ? '/lti' : '/courses'}
                   className="md:pl-8"
                   onClick={() => setIsDrawerOpen && setIsDrawerOpen(false)}
+                  isCompactDesktop={isCompactDesktop}
                 >
                   My Courses
                 </Link>
@@ -448,6 +488,7 @@ const NavBar = ({
                       )}
                       href="/organization/settings"
                       onClick={() => setIsDrawerOpen && setIsDrawerOpen(false)}
+                      isCompactDesktop={isCompactDesktop}
                     >
                       {userInfo?.organization?.organizationRole ===
                       OrganizationRole.PROFESSOR
@@ -467,6 +508,7 @@ const NavBar = ({
                         : '',
                     )}
                     onClick={() => setIsDrawerOpen && setIsDrawerOpen(false)}
+                    isCompactDesktop={isCompactDesktop}
                   >
                     Admin Panel
                   </Link>
@@ -475,30 +517,31 @@ const NavBar = ({
             </>
           ) : null}
           {/* DESKTOP ONLY PART OF NAVBAR */}
-          <NavigationMenuItem className="!ml-auto hidden md:block">
-            <NavigationMenuTrigger
-              className={cn(
-                '!pl-4',
-                isProfilePage ? 'md:border-helpmeblue md:border-b-2' : '',
-              )}
-              onFocus={setNavigationSubMenuRightSide}
-              onClick={setNavigationSubMenuRightSide}
-              onPointerMove={(e) => e.preventDefault()}
-              onPointerLeave={(e) => e.preventDefault()}
-            >
-              <SelfAvatar size={40} className="mr-2" />
-              {userInfo?.firstName}
-            </NavigationMenuTrigger>
-            <NavigationMenuContent className="hidden md:flex">
-              <ul className="grid w-max min-w-[200px] grid-cols-1 gap-1 p-2">
-                {!isLti && (
-                  <ListItem key="profile" title="Profile" href="/profile">
-                    {userInfo?.email}
-                  </ListItem>
+          {showDesktopPresentation && (
+            <NavigationMenuItem className="!ml-auto">
+              <NavigationMenuTrigger
+                className={cn(
+                  isCompactDesktop ? '!pl-2 !pr-2' : '!pl-4',
+                  compactTopLevelClass,
+                  isProfilePage ? 'md:border-helpmeblue md:border-b-2' : '',
                 )}
-                {isLti && (
-                  <>
-                    <NavigationMenuItem className="hidden w-full md:block">
+                onFocus={setNavigationSubMenuRightSide}
+                onClick={setNavigationSubMenuRightSide}
+                onPointerMove={(e) => e.preventDefault()}
+                onPointerLeave={(e) => e.preventDefault()}
+              >
+                <SelfAvatar size={40} className="mr-2" />
+                {userInfo?.firstName}
+              </NavigationMenuTrigger>
+              <NavigationMenuContent className="flex">
+                <ul className="grid w-max min-w-[200px] grid-cols-1 gap-1 p-2">
+                  {!isLti && (
+                    <ListItem key="profile" title="Profile" href="/profile">
+                      {userInfo?.email}
+                    </ListItem>
+                  )}
+                  {isLti && (
+                    <NavigationMenuItem className="w-full">
                       <div className="!ml-2 flex flex-col px-2 text-xs text-gray-500">
                         <span className={'flex items-center'}>
                           <MailOutlined className={'mr-2'} />
@@ -506,86 +549,91 @@ const NavBar = ({
                         </span>
                       </div>
                     </NavigationMenuItem>
-                    <div className="-mr-5 block h-0.5 w-[calc(100%+1.25rem)] border-b border-b-zinc-200 md:hidden" />
-                  </>
-                )}
-                <ListItem
-                  key="logout"
-                  title="Logout"
-                  titleElement={<span className="text-red-700">Log Out</span>}
-                  href={logoutUrl}
-                ></ListItem>
-              </ul>
-            </NavigationMenuContent>
-          </NavigationMenuItem>
-          {/* MOBILE ONLY PART OF NAVBAR */}
-          <div className="!mb-2 !mt-auto -mr-5 block w-[calc(100%+1.25rem)] border-b border-b-zinc-200 md:hidden" />
-          {!isLti && (
-            <NavigationMenuItem className="md:hidden">
-              <Link
-                href="/profile"
-                className="!pl-0"
-                onClick={() => setIsDrawerOpen && setIsDrawerOpen(false)}
-              >
-                <SelfAvatar size={40} className="mr-2" />
-                {userInfo?.firstName}
-              </Link>
+                  )}
+                  <ListItem
+                    key="logout"
+                    title="Logout"
+                    titleElement={<span className="text-red-700">Log Out</span>}
+                    href={logoutUrl}
+                  ></ListItem>
+                </ul>
+              </NavigationMenuContent>
             </NavigationMenuItem>
           )}
-          {isLti && (
+          {/* MOBILE ONLY PART OF NAVBAR */}
+          {showDrawerPresentation && (
             <>
-              <NavigationMenuItem className="w-full md:hidden">
-                <div className="!ml-2 flex flex-col gap-2 px-2 text-xs text-gray-500">
-                  <div className="flex items-center">
-                    <SelfAvatar size={20} className="mr-2" />
-                    <span>
-                      {userInfo?.firstName}
-                      {userInfo?.lastName ? ` ${userInfo.lastName}` : ''}
-                    </span>
-                  </div>
-                  <span className={'flex items-center'}>
-                    <MailOutlined
-                      style={{
-                        fontSize: '10px',
-                        paddingLeft: '5px',
-                        paddingRight: '5px',
-                      }}
-                      className={'mr-2'}
+              <div className="!mb-2 !mt-auto -mr-5 block w-[calc(100%+1.25rem)] border-b border-b-zinc-200" />
+              {!isLti && (
+                <NavigationMenuItem>
+                  <Link
+                    href="/profile"
+                    className="!pl-0"
+                    onClick={() => setIsDrawerOpen && setIsDrawerOpen(false)}
+                  >
+                    <SelfAvatar size={40} className="mr-2" />
+                    {userInfo?.firstName}
+                  </Link>
+                </NavigationMenuItem>
+              )}
+              {isLti && (
+                <>
+                  <NavigationMenuItem className="w-full">
+                    <div className="!ml-2 flex flex-col gap-2 px-2 text-xs text-gray-500">
+                      <div className="flex items-center">
+                        <SelfAvatar size={20} className="mr-2" />
+                        <span>
+                          {userInfo?.firstName}
+                          {userInfo?.lastName ? ` ${userInfo.lastName}` : ''}
+                        </span>
+                      </div>
+                      <span className={'flex items-center'}>
+                        <MailOutlined
+                          style={{
+                            fontSize: '10px',
+                            paddingLeft: '5px',
+                            paddingRight: '5px',
+                          }}
+                          className={'mr-2'}
+                        />
+                        {userInfo?.email}
+                      </span>
+                    </div>
+                  </NavigationMenuItem>
+                  <div className="-mr-5 block h-0.5 w-[calc(100%+1.25rem)] border-b border-b-zinc-200" />
+                </>
+              )}
+              <NavigationMenuItem className="mb-2">
+                <Popconfirm
+                  title="Are you sure you want to log out?"
+                  onConfirm={() => {
+                    router.push(logoutUrl)
+                    if (setIsDrawerOpen) setIsDrawerOpen(false)
+                  }}
+                  okText="Yes"
+                  cancelText="No"
+                  // this places the Popconfirm just below the Link in the DOM rather than at the very bottom of the DOM (important for accessibility and prevent buttons being clicked underneath the Popconfirm)
+                  getPopupContainer={(trigger) =>
+                    trigger.parentNode as HTMLElement
+                  }
+                >
+                  <Link
+                    href={logoutUrl}
+                    className="text-red-700"
+                    onClick={(e) => {
+                      e.preventDefault()
+                    }}
+                  >
+                    <LogoutOutlined
+                      size={40}
+                      className="mr-2 rotate-180 text-2xl"
                     />
-                    {userInfo?.email}
-                  </span>
-                </div>
+                    Log Out
+                  </Link>
+                </Popconfirm>
               </NavigationMenuItem>
-              <div className="-mr-5 block h-0.5 w-[calc(100%+1.25rem)] border-b border-b-zinc-200 md:hidden" />
             </>
           )}
-          <NavigationMenuItem className="mb-2 md:hidden">
-            <Popconfirm
-              title="Are you sure you want to log out?"
-              onConfirm={() => {
-                router.push(logoutUrl)
-                if (setIsDrawerOpen) setIsDrawerOpen(false)
-              }}
-              okText="Yes"
-              cancelText="No"
-              // this places the Popconfirm just below the Link in the DOM rather than at the very bottom of the DOM (important for accessibility and prevent buttons being clicked underneath the Popconfirm)
-              getPopupContainer={(trigger) => trigger.parentNode as HTMLElement}
-            >
-              <Link
-                href={logoutUrl}
-                className="text-red-700"
-                onClick={(e) => {
-                  e.preventDefault()
-                }}
-              >
-                <LogoutOutlined
-                  size={40}
-                  className="mr-2 rotate-180 text-2xl"
-                />
-                Log Out
-              </Link>
-            </Popconfirm>
-          </NavigationMenuItem>
         </NavigationMenuList>
       </NavigationMenu>
     )
@@ -595,10 +643,18 @@ const NavBar = ({
 /**
  * Navbar component that is rendered on each page.
  */
+
+type NavMode = 'desktop' | 'compact' | 'drawer'
+
 const HeaderBar: React.FC = () => {
   const { userInfo } = useUserInfo()
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
-  const isDesktop = useMediaQuery('(min-width: 768px)')
+  const [navMode, setNavMode] = useState<NavMode>('drawer')
+  const isPhone = useMediaQuery('(max-width: 640px)')
+  const availableWidthRef = useRef<HTMLDivElement>(null)
+  const regularMeasureRef = useRef<HTMLDivElement>(null)
+  const compactMeasureRef = useRef<HTMLDivElement>(null)
+
   // This is not the usual way to get the courseId from the URL
   // (normally you're supposed to use `params` for the page.tsx and then pass it down as a prop).
   // However, doing it this way makes it much easier to add the navbar to layout.tsx.
@@ -633,104 +689,192 @@ const HeaderBar: React.FC = () => {
     ? course?.queues?.find((queue) => queue.id === queueId)?.room
     : ''
 
-  // DESKTOP HEADER
-  return isDesktop ? (
-    <NavBar
-      userInfo={userInfo}
-      courseId={courseId}
-      course={course}
-      isAQueuePage={isAQueuePage}
-      isACourseSettingsPage={isACourseSettingsPage}
-      isAnOrganizationSettingsPage={isAnOrganizationSettingsPage}
-      isAnAdminPanelPage={isAnAdminPanelPage}
-      isProfilePage={isProfilePage}
-      isLti={isLti}
-    />
-  ) : (
-    // MOBILE HEADER AND NAV DRAWER
-    <div className="flex items-center justify-between">
-      <Image
-        width={48}
-        height={48}
-        className="h-12 object-contain p-1"
-        alt="Organization Logo"
-        src={`/api/v1/organization/${userInfo.organization?.orgId}/get_logo/${userInfo.organization?.organizationLogoUrl}`}
-      />
-      <div className="flex h-14 grow flex-col items-center justify-center">
-        <h1
-          className={cn(
-            'leading-none',
-            !course?.name
-              ? ''
-              : course.name.length > 35
-                ? 'text-xs'
-                : course.name.length > 30
-                  ? 'text-sm'
-                  : course.name.length > 25
-                    ? 'text-base'
-                    : course.name.length > 20
-                      ? 'text-lg'
-                      : course.name.length > 15
-                        ? 'text-xl'
-                        : '',
-          )}
-        >
-          {isProfilePage ? 'Profile' : course?.name}
-        </h1>
-        {queueRoom && (
-          <h2
-            className={cn(
-              'leading-none text-slate-500',
-              queueRoom.length > 35
-                ? 'text-xs'
-                : queueRoom.length > 30
-                  ? 'text-sm'
-                  : 'text-base',
-            )}
-          >
-            {queueRoom}
-          </h2>
-        )}
+  const updateNavMode = useCallback(() => {
+    if (isPhone) {
+      setNavMode('drawer')
+      return
+    }
+
+    const availableWidth =
+      availableWidthRef.current?.getBoundingClientRect().width ?? 0
+    const regularWidth =
+      regularMeasureRef.current?.getBoundingClientRect().width ?? 0
+    const compactWidth =
+      compactMeasureRef.current?.getBoundingClientRect().width ?? 0
+    const buffer = 24
+
+    if (regularWidth > 0 && regularWidth <= availableWidth - buffer) {
+      setNavMode('desktop')
+      return
+    }
+
+    if (compactWidth > 0 && compactWidth <= availableWidth - buffer) {
+      setNavMode('compact')
+      return
+    }
+
+    setNavMode('drawer')
+  }, [isPhone])
+
+  useLayoutEffect(() => {
+    updateNavMode()
+  }, [updateNavMode, pathname, course, userInfo])
+
+  useEffect(() => {
+    const nodes = [
+      availableWidthRef.current,
+      regularMeasureRef.current,
+      compactMeasureRef.current,
+    ].filter(Boolean) as HTMLElement[]
+
+    if (nodes.length === 0) return
+
+    const observer = new ResizeObserver(() => {
+      updateNavMode()
+    })
+
+    nodes.forEach((node) => observer.observe(node))
+    updateNavMode()
+
+    return () => observer.disconnect()
+  }, [updateNavMode, pathname, course, userInfo])
+
+  return (
+    <div ref={availableWidthRef} className="relative w-full">
+      <div className="pointer-events-none invisible absolute left-0 top-0 -z-10 h-0 overflow-hidden">
+        <div ref={regularMeasureRef} className="w-max">
+          <NavBar
+            userInfo={userInfo}
+            courseId={courseId}
+            course={course}
+            isAQueuePage={isAQueuePage}
+            isACourseSettingsPage={isACourseSettingsPage}
+            isAnOrganizationSettingsPage={isAnOrganizationSettingsPage}
+            isAnAdminPanelPage={isAnAdminPanelPage}
+            isProfilePage={isProfilePage}
+            isLti={isLti}
+            className="w-max"
+            showViewport={false}
+          />
+        </div>
+        <div ref={compactMeasureRef} className="w-max">
+          <NavBar
+            userInfo={userInfo}
+            courseId={courseId}
+            course={course}
+            isAQueuePage={isAQueuePage}
+            isACourseSettingsPage={isACourseSettingsPage}
+            isAnOrganizationSettingsPage={isAnOrganizationSettingsPage}
+            isAnAdminPanelPage={isAnAdminPanelPage}
+            isProfilePage={isProfilePage}
+            isLti={isLti}
+            isCompactDesktop={true}
+            className="w-max"
+            showViewport={false}
+          />
+        </div>
       </div>
-      <Drawer
-        direction="left"
-        open={isDrawerOpen}
-        onOpenChange={setIsDrawerOpen}
-      >
-        <DrawerTrigger>
-          <MenuIcon size={40} className="ml-2" />
-        </DrawerTrigger>
-        <DrawerContent aria-description="Drawer for main navigation menu">
-          {/* INSIDE DRAWER */}
-          <div className="flex h-screen flex-col items-start justify-start">
-            <DrawerTitle className="my-1 flex w-full items-center justify-center border-b border-b-zinc-200 bg-white py-1 pr-5">
-              <Image
-                width={48}
-                height={48}
-                className="h-12 object-contain"
-                alt="Organization Logo"
-                src={`/api/v1/organization/${userInfo.organization?.orgId}/get_logo/${userInfo.organization?.organizationLogoUrl}`}
-              />
-              <span className="text-2xl font-semibold leading-none">
-                {userInfo?.organization?.organizationName}
-              </span>
-            </DrawerTitle>
-            <NavBar
-              userInfo={userInfo}
-              courseId={courseId}
-              course={course}
-              isAQueuePage={isAQueuePage}
-              isACourseSettingsPage={isACourseSettingsPage}
-              isAnOrganizationSettingsPage={isAnOrganizationSettingsPage}
-              isAnAdminPanelPage={isAnAdminPanelPage}
-              orientation="vertical"
-              isProfilePage={isProfilePage}
-              setIsDrawerOpen={setIsDrawerOpen}
-              isLti={isLti}
-            />
+
+      {navMode === 'drawer' ? (
+        <div className="flex items-center justify-between">
+          <Image
+            width={48}
+            height={48}
+            className="h-12 object-contain p-1"
+            alt="Organization Logo"
+            src={`/api/v1/organization/${userInfo.organization?.orgId}/get_logo/${userInfo.organization?.organizationLogoUrl}`}
+          />
+          <div className="flex h-14 grow flex-col items-center justify-center">
+            <h1
+              className={cn(
+                'leading-none',
+                !course?.name
+                  ? ''
+                  : course.name.length > 35
+                    ? 'text-xs'
+                    : course.name.length > 30
+                      ? 'text-sm'
+                      : course.name.length > 25
+                        ? 'text-base'
+                        : course.name.length > 20
+                          ? 'text-lg'
+                          : course.name.length > 15
+                            ? 'text-xl'
+                            : '',
+              )}
+            >
+              {isProfilePage ? 'Profile' : course?.name}
+            </h1>
+            {queueRoom && (
+              <h2
+                className={cn(
+                  'leading-none text-slate-500',
+                  queueRoom.length > 35
+                    ? 'text-xs'
+                    : queueRoom.length > 30
+                      ? 'text-sm'
+                      : 'text-base',
+                )}
+              >
+                {queueRoom}
+              </h2>
+            )}
           </div>
-        </DrawerContent>
-      </Drawer>
+          <Drawer
+            direction="left"
+            open={isDrawerOpen}
+            onOpenChange={setIsDrawerOpen}
+          >
+            <DrawerTrigger>
+              <MenuIcon size={40} className="ml-2" />
+            </DrawerTrigger>
+            <DrawerContent aria-description="Drawer for main navigation menu">
+              {/* INSIDE DRAWER */}
+              <div className="flex h-screen flex-col items-start justify-start">
+                <DrawerTitle className="my-1 flex w-full items-center justify-center border-b border-b-zinc-200 bg-white py-1 pr-5">
+                  <Image
+                    width={48}
+                    height={48}
+                    className="h-12 object-contain"
+                    alt="Organization Logo"
+                    src={`/api/v1/organization/${userInfo.organization?.orgId}/get_logo/${userInfo.organization?.organizationLogoUrl}`}
+                  />
+                  <span className="text-2xl font-semibold leading-none">
+                    {userInfo?.organization?.organizationName}
+                  </span>
+                </DrawerTitle>
+                <NavBar
+                  userInfo={userInfo}
+                  courseId={courseId}
+                  course={course}
+                  isAQueuePage={isAQueuePage}
+                  isACourseSettingsPage={isACourseSettingsPage}
+                  isAnOrganizationSettingsPage={isAnOrganizationSettingsPage}
+                  isAnAdminPanelPage={isAnAdminPanelPage}
+                  orientation="vertical"
+                  isProfilePage={isProfilePage}
+                  setIsDrawerOpen={setIsDrawerOpen}
+                  isLti={isLti}
+                  forceDrawerPresentation={true}
+                />
+              </div>
+            </DrawerContent>
+          </Drawer>
+        </div>
+      ) : (
+        <NavBar
+          userInfo={userInfo}
+          courseId={courseId}
+          course={course}
+          isAQueuePage={isAQueuePage}
+          isACourseSettingsPage={isACourseSettingsPage}
+          isAnOrganizationSettingsPage={isAnOrganizationSettingsPage}
+          isAnAdminPanelPage={isAnAdminPanelPage}
+          isProfilePage={isProfilePage}
+          isLti={isLti}
+          isCompactDesktop={navMode === 'compact'}
+        />
+      )}
     </div>
   )
 }

--- a/packages/frontend/app/components/HeaderBar.tsx
+++ b/packages/frontend/app/components/HeaderBar.tsx
@@ -3,7 +3,6 @@
 import React, {
   HTMLAttributeAnchorTarget,
   useCallback,
-  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -20,6 +19,7 @@ import {
   NavigationMenuTrigger,
   navigationMenuTriggerStyle,
   navigationMenuTriggerStyleForSubMenu,
+  useNavigationOrientation,
 } from '@/app/components/ui/navigation-menu'
 import NextLink from 'next/link'
 import { SelfAvatar } from './UserAvatar'
@@ -83,6 +83,7 @@ const Link = ({
   isCompactDesktop?: boolean
 }) => {
   const pathname = usePathname()
+  const { orientation } = useNavigationOrientation()
   const isActive = href === pathname
   const isLogout = href.startsWith('/api/v1/logout')
 
@@ -91,13 +92,13 @@ const Link = ({
       <NextLink
         href={href}
         prefetch={isLogout ? false : undefined}
-        className={
-          (isSubMenuLink
+        className={cn(
+          isSubMenuLink
             ? navigationMenuTriggerStyleForSubMenu()
-            : cn(navigationMenuTriggerStyle(), isCompactDesktop && '!px-2')) +
-          ' ' +
-          className
-        }
+            : navigationMenuTriggerStyle(orientation),
+          isCompactDesktop && '!px-2',
+          className,
+        )}
         onClick={onClick}
         target={target}
       >
@@ -180,18 +181,28 @@ const NavBar = ({
     userInfo?.organization?.orgId ?? -1,
   )
   const router = useRouter()
-  const showDesktopPresentation =
-    orientation === 'horizontal' && !forceDrawerPresentation
   const showDrawerPresentation =
     orientation === 'vertical' || forceDrawerPresentation
   const courseFeatures = useCourseFeatures(courseId)
   const role = courseId ? getRoleInCourse(userInfo, courseId) : null
   const compactTopLevelClass = isCompactDesktop ? '!pl-1.5 !pr-2' : ''
-
+  const drawerTopLevelItemClass = showDrawerPresentation ? 'w-full' : ''
+  const horizontalInsetClass = !showDrawerPresentation ? 'md:pl-8' : ''
+  const horizontalInsetImportantClass = !showDrawerPresentation
+    ? '!md:pl-8'
+    : ''
+  const selectedNavItemClass =
+    'bg-zinc-300/80 hover:bg-zinc-300/80 focus:bg-zinc-300/80'
   const sortedQueues = useMemo(() => {
     if (!course?.queues) return []
     return sortQueues(course.queues)
   }, [course?.queues])
+  const queueDropdownListClass = showDrawerPresentation
+    ? `grid w-full gap-1 p-4 ${sortedQueues.length > 6 ? 'grid-cols-2' : 'grid-cols-1'}`
+    : `grid gap-1 p-4 md:grid-cols-2 lg:w-[600px] lg:gap-2 ${sortedQueues.length > 6 ? 'w-[95vw] grid-cols-2' : 'w-[60vw]'}`
+  const emptyQueueStateClass = showDrawerPresentation
+    ? 'w-full p-4 text-center text-sm text-gray-500'
+    : `w-[60vw] p-4 text-center text-sm text-gray-500 ${role === Role.PROFESSOR ? 'lg:w-[600px]' : 'lg:w-[400px]'}`
 
   // This is to move the "Queues" and "Profile" submenu to show on the left or right side (there is only one component, so it needs to be moved around like this)
   const setNavigationSubMenuRightSide = useCallback(() => {
@@ -232,7 +243,7 @@ const NavBar = ({
         showViewport={showViewport}
       >
         <NavigationMenuList>
-          {showDesktopPresentation && (
+          {!showDrawerPresentation && (
             <NextLink
               href={
                 course
@@ -260,7 +271,7 @@ const NavBar = ({
           )}
           {course ? (
             <>
-              <NavigationMenuItem>
+              <NavigationMenuItem className={drawerTopLevelItemClass}>
                 <Link
                   className={cn('!font-bold', compactTopLevelClass)}
                   href={`${coursePrefix}/${courseId}`}
@@ -273,7 +284,7 @@ const NavBar = ({
                 </Link>
               </NavigationMenuItem>
               {isLti && [Role.PROFESSOR].includes(role ?? Role.STUDENT) && (
-                <NavigationMenuItem>
+                <NavigationMenuItem className={drawerTopLevelItemClass}>
                   <Link
                     href={`/lti/${course.id}/integration`}
                     onClick={() => setIsDrawerOpen && setIsDrawerOpen(false)}
@@ -288,14 +299,12 @@ const NavBar = ({
               {!isLti && (
                 <>
                   {courseFeatures?.queueEnabled && (
-                    <NavigationMenuItem>
+                    <NavigationMenuItem className={drawerTopLevelItemClass}>
                       {/* This "NavigationMenuTrigger" is just the "Queues" button */}
                       <NavigationMenuTrigger
                         className={cn(
                           compactTopLevelClass,
-                          isAQueuePage
-                            ? 'md:border-helpmeblue bg-zinc-300/80 md:border-b-2 md:bg-white'
-                            : '',
+                          isAQueuePage && selectedNavItemClass,
                         )}
                         onFocus={setNavigationSubMenuLeftSide}
                         onClick={setNavigationSubMenuLeftSide}
@@ -308,9 +317,7 @@ const NavBar = ({
                       <NavigationMenuContent>
                         {/* On mobile, if there are more than 6 queues, put the queue list into two columns */}
                         {sortedQueues.length > 0 ? (
-                          <ul
-                            className={`grid gap-1 p-4 md:grid-cols-2 lg:w-[600px] lg:gap-2 ${sortedQueues.length > 6 ? 'w-[95vw] grid-cols-2' : 'w-[60vw]'}`}
-                          >
+                          <ul className={queueDropdownListClass}>
                             {sortedQueues.map((queue) => (
                               <ListItem
                                 key={queue.id}
@@ -329,9 +336,7 @@ const NavBar = ({
                             ))}
                           </ul>
                         ) : (
-                          <div
-                            className={`w-[60vw] p-4 text-center text-sm text-gray-500 ${role === Role.PROFESSOR ? 'lg:w-[600px]' : 'lg:w-[400px]'}`}
-                          >
+                          <div className={emptyQueueStateClass}>
                             <p>There are no queues in this course</p>
                             {role === Role.PROFESSOR && (
                               <p>
@@ -362,7 +367,7 @@ const NavBar = ({
                     </NavigationMenuItem>
                   )}
                   {courseFeatures?.asyncQueueEnabled && (
-                    <NavigationMenuItem>
+                    <NavigationMenuItem className={drawerTopLevelItemClass}>
                       <Link
                         href={`/course/${courseId}/async_centre`}
                         onClick={() =>
@@ -380,7 +385,7 @@ const NavBar = ({
                     </NavigationMenuItem>
                   )}
                   {courseFeatures?.queueEnabled && (
-                    <NavigationMenuItem>
+                    <NavigationMenuItem className={drawerTopLevelItemClass}>
                       <Link
                         href={`/course/${courseId}/schedule`}
                         onClick={() =>
@@ -395,16 +400,12 @@ const NavBar = ({
                     </NavigationMenuItem>
                   )}
                   {(role === Role.TA || role === Role.PROFESSOR) && (
-                    <NavigationMenuItem
-                      className={
-                        isACourseSettingsPage
-                          ? // the hover:border-none is because the inner link has a hover effect that adds another border
-                            'md:border-helpmeblue bg-zinc-300/80 md:border-b-2 md:bg-white md:hover:border-none md:focus:border-none'
-                          : ''
-                      }
-                    >
+                    <NavigationMenuItem className={drawerTopLevelItemClass}>
                       <Link
-                        className={compactTopLevelClass}
+                        className={cn(
+                          compactTopLevelClass,
+                          isACourseSettingsPage && selectedNavItemClass,
+                        )}
                         href={`/course/${courseId}/settings${role === Role.TA ? '/edit_questions' : ''}`}
                         onClick={() =>
                           setIsDrawerOpen && setIsDrawerOpen(false)
@@ -417,7 +418,7 @@ const NavBar = ({
                     </NavigationMenuItem>
                   )}
                   {role === Role.PROFESSOR && (
-                    <NavigationMenuItem>
+                    <NavigationMenuItem className={drawerTopLevelItemClass}>
                       <Link
                         href={`/course/${courseId}/insights`}
                         onClick={() =>
@@ -433,7 +434,7 @@ const NavBar = ({
                   )}
                 </>
               )}
-              <NavigationMenuItem>
+              <NavigationMenuItem className={drawerTopLevelItemClass}>
                 <Link
                   href={isLti ? '/lti' : '/courses'}
                   onClick={() => setIsDrawerOpen && setIsDrawerOpen(false)}
@@ -451,7 +452,7 @@ const NavBar = ({
                 <NavigationMenuItem>
                   <Link
                     href=""
-                    className="md:pl-8"
+                    className={horizontalInsetClass}
                     onClick={() => {
                       router.back()
                       if (setIsDrawerOpen) setIsDrawerOpen(false)
@@ -466,7 +467,7 @@ const NavBar = ({
               <NavigationMenuItem>
                 <Link
                   href={isLti ? '/lti' : '/courses'}
-                  className="md:pl-8"
+                  className={horizontalInsetClass}
                   onClick={() => setIsDrawerOpen && setIsDrawerOpen(false)}
                   isCompactDesktop={isCompactDesktop}
                 >
@@ -481,10 +482,8 @@ const NavBar = ({
                   <NavigationMenuItem>
                     <Link
                       className={cn(
-                        '!md:pl-8',
-                        isAnOrganizationSettingsPage
-                          ? 'md:border-helpmeblue md:border-b-2'
-                          : '',
+                        horizontalInsetImportantClass,
+                        isAnOrganizationSettingsPage && selectedNavItemClass,
                       )}
                       href="/organization/settings"
                       onClick={() => setIsDrawerOpen && setIsDrawerOpen(false)}
@@ -502,10 +501,8 @@ const NavBar = ({
                   <Link
                     href="/admin"
                     className={cn(
-                      'md:pl-8',
-                      isAnAdminPanelPage
-                        ? 'md:border-helpmeblue md:border-b-2'
-                        : '',
+                      horizontalInsetClass,
+                      isAnAdminPanelPage && selectedNavItemClass,
                     )}
                     onClick={() => setIsDrawerOpen && setIsDrawerOpen(false)}
                     isCompactDesktop={isCompactDesktop}
@@ -517,13 +514,13 @@ const NavBar = ({
             </>
           ) : null}
           {/* DESKTOP ONLY PART OF NAVBAR */}
-          {showDesktopPresentation && (
+          {!showDrawerPresentation && (
             <NavigationMenuItem className="!ml-auto">
               <NavigationMenuTrigger
                 className={cn(
                   isCompactDesktop ? '!pl-2 !pr-2' : '!pl-4',
                   compactTopLevelClass,
-                  isProfilePage ? 'md:border-helpmeblue md:border-b-2' : '',
+                  isProfilePage && selectedNavItemClass,
                 )}
                 onFocus={setNavigationSubMenuRightSide}
                 onClick={setNavigationSubMenuRightSide}
@@ -562,8 +559,8 @@ const NavBar = ({
           )}
           {/* MOBILE ONLY PART OF NAVBAR */}
           {showDrawerPresentation && (
-            <>
-              <div className="!mb-2 !mt-auto -mr-5 block w-[calc(100%+1.25rem)] border-b border-b-zinc-200" />
+            <div className="mt-auto w-full pt-3">
+              <div className="-mx-5 mb-2 block w-[calc(100%+2.5rem)] border-b border-b-zinc-200" />
               {!isLti && (
                 <NavigationMenuItem>
                   <Link
@@ -600,7 +597,7 @@ const NavBar = ({
                       </span>
                     </div>
                   </NavigationMenuItem>
-                  <div className="-mr-5 block h-0.5 w-[calc(100%+1.25rem)] border-b border-b-zinc-200" />
+                  <div className="-mx-5 block h-0.5 w-[calc(100%+2.5rem)] border-b border-b-zinc-200" />
                 </>
               )}
               <NavigationMenuItem className="mb-2">
@@ -632,7 +629,7 @@ const NavBar = ({
                   </Link>
                 </Popconfirm>
               </NavigationMenuItem>
-            </>
+            </div>
           )}
         </NavigationMenuList>
       </NavigationMenu>
@@ -650,7 +647,7 @@ const HeaderBar: React.FC = () => {
   const { userInfo } = useUserInfo()
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
   const [navMode, setNavMode] = useState<NavMode>('drawer')
-  const isPhone = useMediaQuery('(max-width: 640px)')
+  const isPhone = useMediaQuery('(max-width: 768px)')
   const availableWidthRef = useRef<HTMLDivElement>(null)
   const regularMeasureRef = useRef<HTMLDivElement>(null)
   const compactMeasureRef = useRef<HTMLDivElement>(null)
@@ -716,32 +713,37 @@ const HeaderBar: React.FC = () => {
     setNavMode('drawer')
   }, [isPhone])
 
+  // Recalculate nav mode before paint based on the measured widths of the
+  // available space plus the regular/compact hidden navbars. Those measured
+  // widths change when route/course/user state changes which top-level nav
+  // items exist (organization vs course, professor vs TA vs student, queue
+  // features on/off, etc.), so observing the measurement nodes lets us react
+  // without depending on a larger arbitrary dependency list here.
   useLayoutEffect(() => {
-    updateNavMode()
-  }, [updateNavMode, pathname, course, userInfo])
-
-  useEffect(() => {
     const nodes = [
       availableWidthRef.current,
       regularMeasureRef.current,
       compactMeasureRef.current,
     ].filter(Boolean) as HTMLElement[]
 
-    if (nodes.length === 0) return
-
     const observer = new ResizeObserver(() => {
       updateNavMode()
     })
 
-    nodes.forEach((node) => observer.observe(node))
     updateNavMode()
+    nodes.forEach((node) => observer.observe(node))
 
     return () => observer.disconnect()
-  }, [updateNavMode, pathname, course, userInfo])
+  }, [updateNavMode])
 
   return (
     <div ref={availableWidthRef} className="relative w-full">
-      <div className="pointer-events-none invisible absolute left-0 top-0 -z-10 h-0 overflow-hidden">
+      {/* These hidden navbars are only used for width measurement. One renders
+      the regular desktop nav and the other renders the compact desktop nav so
+      we can choose the visible presentation. Below the md breakpoint we force
+      drawer mode, which keeps CSS/mobile shrinking from affecting these
+      desktop-width measurements. */}
+      <div className="pointer-events-none invisible absolute left-0 top-0 -z-10 h-0 w-0 overflow-hidden">
         <div ref={regularMeasureRef} className="w-max">
           <NavBar
             userInfo={userInfo}
@@ -830,7 +832,7 @@ const HeaderBar: React.FC = () => {
             </DrawerTrigger>
             <DrawerContent aria-description="Drawer for main navigation menu">
               {/* INSIDE DRAWER */}
-              <div className="flex h-screen flex-col items-start justify-start">
+              <div className="flex flex-col items-start justify-start">
                 <DrawerTitle className="my-1 flex w-full items-center justify-center border-b border-b-zinc-200 bg-white py-1 pr-5">
                   <Image
                     width={48}

--- a/packages/frontend/app/components/ui/drawer.tsx
+++ b/packages/frontend/app/components/ui/drawer.tsx
@@ -55,7 +55,7 @@ const DrawerContent = React.forwardRef<
           (!direction || direction === 'bottom') &&
             'inset-x-0 bottom-0 mt-24 rounded-t-[10px]',
           direction === 'left' &&
-            'left-0 top-0 h-full w-[60vw] max-w-80 rounded-r-[10px]',
+            'left-0 top-0 max-h-[100dvh] w-[60vw] max-w-80 overflow-y-auto overflow-x-hidden rounded-r-[10px]',
           className,
         )}
         style={{

--- a/packages/frontend/app/components/ui/drawer.tsx
+++ b/packages/frontend/app/components/ui/drawer.tsx
@@ -55,7 +55,7 @@ const DrawerContent = React.forwardRef<
           (!direction || direction === 'bottom') &&
             'inset-x-0 bottom-0 mt-24 rounded-t-[10px]',
           direction === 'left' &&
-            'left-0 top-0 max-h-[100dvh] w-[60vw] max-w-80 overflow-y-auto overflow-x-hidden rounded-r-[10px]',
+            'left-0 top-0 h-full w-[46vw] max-w-60 rounded-r-[10px]',
           className,
         )}
         style={{

--- a/packages/frontend/app/components/ui/navigation-menu.tsx
+++ b/packages/frontend/app/components/ui/navigation-menu.tsx
@@ -8,6 +8,12 @@ const NavigationContext = React.createContext<{
   orientation?: 'vertical' | 'horizontal'
 }>({})
 
+type NavigationMenuProps = React.ComponentPropsWithoutRef<
+  typeof NavigationMenuPrimitive.Root
+> & {
+  showViewport?: boolean
+}
+
 /**
  * This is a shadcn navigation menu component. It is mostly the same as the default except with darker hover styles as well as more padding on its elements.
  * It also has custom styles for the submenu (i.e. the "Queues" tab) and support for vertical orientation
@@ -16,8 +22,8 @@ const NavigationContext = React.createContext<{
  */
 const NavigationMenu = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Root>
->(({ className, children, ...props }, ref) => (
+  NavigationMenuProps
+>(({ className, children, showViewport = true, ...props }, ref) => (
   <NavigationContext.Provider value={{ orientation: props.orientation }}>
     <NavigationMenuPrimitive.Root
       ref={ref}
@@ -32,7 +38,7 @@ const NavigationMenu = React.forwardRef<
       {...props}
     >
       {children}
-      <NavigationMenuViewport />
+      {showViewport && <NavigationMenuViewport />}
     </NavigationMenuPrimitive.Root>
   </NavigationContext.Provider>
 ))

--- a/packages/frontend/app/components/ui/navigation-menu.tsx
+++ b/packages/frontend/app/components/ui/navigation-menu.tsx
@@ -8,6 +8,11 @@ const NavigationContext = React.createContext<{
   orientation?: 'vertical' | 'horizontal'
 }>({})
 
+const isHorizontalNavigation = (orientation?: 'vertical' | 'horizontal') =>
+  !orientation || orientation === 'horizontal'
+
+const useNavigationOrientation = () => React.useContext(NavigationContext)
+
 type NavigationMenuProps = React.ComponentPropsWithoutRef<
   typeof NavigationMenuPrimitive.Root
 > & {
@@ -17,7 +22,8 @@ type NavigationMenuProps = React.ComponentPropsWithoutRef<
 /**
  * This is a shadcn navigation menu component. It is mostly the same as the default except with darker hover styles as well as more padding on its elements.
  * It also has custom styles for the submenu (i.e. the "Queues" tab) and support for vertical orientation
- * It also has a bunch of other styles changed (e.g. blue borders/links instead of darkened background on desktop).
+ * It also has a bunch of other styles changed (e.g. shared mobile-like
+ * active/hover states plus support for drawer-specific layout behavior).
  * I would not recommend updating this component to future shadcn versions of the component.
  */
 const NavigationMenu = React.forwardRef<
@@ -31,7 +37,7 @@ const NavigationMenu = React.forwardRef<
         'child-divs-w-full relative z-10 flex w-full flex-1 justify-start bg-white',
         (!props.orientation || props.orientation === 'horizontal') &&
           'items-center',
-        props.orientation === 'vertical' && 'flex-col items-end pr-5',
+        props.orientation === 'vertical' && 'flex-col items-start px-5',
         className,
       )}
       orientation={props.orientation}
@@ -55,7 +61,7 @@ const NavigationMenuList = React.forwardRef<
       className={cn(
         'group flex w-full flex-1 list-none justify-start',
         (!orientation || orientation === 'horizontal') && 'items-center',
-        orientation === 'vertical' && 'h-full flex-col items-end space-y-1',
+        orientation === 'vertical' && 'h-full flex-col items-start space-y-1',
         className,
       )}
       {...props}
@@ -69,50 +75,42 @@ const NavigationMenuItem = NavigationMenuPrimitive.Item
 /**
  * These are the styles that get applied to the links
  */
-const navigationMenuTriggerStyle = cva([
-  'group', // Grouping for hover and focus states
-  'inline-flex', // Display type
-  'h-10', // Height
-  'w-[50vw]', // on mobile devices, each link is 40% of the viewport width
-  'max-w-72', // For tablet-size, make sure the width of links isn't too wide
-  'md:w-max', // On desktop devices use max width
-  'items-center', // Vertical alignment
-  'justify-start md:justify-center', // Horizontal alignment
-  'rounded-md md:rounded-none', // Border radius (none on desktop)
-  'disabled:pointer-events-none', // Disabled state pointer events
-  'disabled:opacity-50', // Disabled state opacity
-  'text-black',
-  'bg-white', // Background color
-  'pl-4 pr-8', // Horizontal padding
-  'py-7', // Vertical padding
-  'text-sm', // Text size
-  'font-medium', // Font weight
-  'transition-colors', // Transition for color changes
-  'data-[state=open]:bg-zinc-300/50', // Open state background color
-  'focus:outline-none', // Focus outline removal
-  // Hover and focus styles on DESKTOP
-  'md:data-[active]:border-b-2 md:data-[active]:border-helpmeblue', // blue border on active state
-  'md:focus:border-b-2 md:focus:border-helpmeblue', // blue border on focus
-  'md:hover:border-b-2 md:hover:border-helpmeblue', // blue border on hover
-  'md:focus:text-helpmeblue md:hover:text-helpmeblue', // blue text on focus and hover
-  'md:data-[state=open]:text-helpmeblue', // blue text on open state
-  'md:data-[state=open]:border-b-2 md:data-[state=open]:border-helpmeblue', // blue border on open state
-  'md:data-[state=open]:bg-white md:focus:bg-white md:hover:bg-white md:data-[active]:bg-white', // keep background white on open & active state, focus, and hover
-  // Hover and focus styles on MOBILE
-  'hover:text-zinc-900', // Hover text color
-  'focus:text-zinc-900', // Focus text color
-  'hover:bg-zinc-200/70', // Hover background color
-  'focus:bg-zinc-200', // Focus background color
-  'data-[active]:bg-zinc-300/80', // Active state background color
-  // Dark mode styles (came with shadcn, haven't touched them)
-  'dark:bg-zinc-950', // Dark mode background color
-  'dark:hover:bg-zinc-800', // Dark mode hover background color
-  'dark:hover:text-zinc-50', // Dark mode hover text color
-  'dark:focus:bg-zinc-800', // Dark mode focus background color
-  'dark:focus:text-zinc-50', // Dark mode focus text color
-  'dark:data-[active]:bg-zinc-800/50', // Dark mode active state background color
-  'dark:data-[state=open]:bg-zinc-800/50', // Dark mode open state background color
-])
+const navigationMenuTriggerStyle = (orientation?: 'vertical' | 'horizontal') =>
+  cn(
+    'group', // Grouping for hover and focus states
+    'inline-flex', // Display type
+    'h-10', // Height
+    'items-center', // Vertical alignment
+    'justify-start', // Horizontal alignment
+    'rounded-md', // Border radius
+    'disabled:pointer-events-none', // Disabled state pointer events
+    'disabled:opacity-50', // Disabled state opacity
+    'text-black',
+    'bg-white', // Background color
+    'pl-4 pr-8', // Horizontal padding
+    'py-7', // Vertical padding
+    'text-sm', // Text size
+    'font-medium', // Font weight
+    'transition-colors', // Transition for color changes
+    'data-[state=open]:bg-zinc-300/50', // Open state background color
+    'focus:outline-none', // Focus outline removal
+    'hover:text-zinc-900', // Hover text color
+    'focus:text-zinc-900', // Focus text color
+    'hover:bg-zinc-200/70', // Hover background color
+    'focus:bg-zinc-200', // Focus background color
+    'data-[active]:bg-zinc-300/80', // Active state background color
+    // Dark mode styles (came with shadcn, haven't touched them)
+    'dark:bg-zinc-950', // Dark mode background color
+    'dark:hover:bg-zinc-800', // Dark mode hover background color
+    'dark:hover:text-zinc-50', // Dark mode hover text color
+    'dark:focus:bg-zinc-800', // Dark mode focus background color
+    'dark:focus:text-zinc-50', // Dark mode focus text color
+    'dark:data-[active]:bg-zinc-800/50', // Dark mode active state background color
+    'dark:data-[state=open]:bg-zinc-800/50', // Dark mode open state background color
+    isHorizontalNavigation(orientation)
+      ? 'w-max max-w-none'
+      : 'w-full max-w-none',
+  )
 
 /**
  * This is the same as above except without the text and formatting changes.
@@ -135,34 +133,47 @@ const navigationMenuTriggerStyleForSubMenu = cva([
 const NavigationMenuTrigger = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
-  <NavigationMenuPrimitive.Trigger
-    ref={ref}
-    className={cn(navigationMenuTriggerStyle(), 'group', className)}
-    {...props}
-  >
-    {children}
-    <ChevronDown
-      className="relative top-[1px] ml-1 h-3 w-3 transition duration-200 group-data-[state=open]:rotate-180"
-      aria-hidden="true"
-    />
-  </NavigationMenuPrimitive.Trigger>
-))
+>(({ className, children, ...props }, ref) => {
+  const { orientation } = useNavigationOrientation()
+
+  return (
+    <NavigationMenuPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        navigationMenuTriggerStyle(orientation),
+        'group',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronDown
+        className="relative top-[1px] ml-1 h-3 w-3 transition duration-200 group-data-[state=open]:rotate-180"
+        aria-hidden="true"
+      />
+    </NavigationMenuPrimitive.Trigger>
+  )
+})
 NavigationMenuTrigger.displayName = NavigationMenuPrimitive.Trigger.displayName
 
 const NavigationMenuContent = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Content>
->(({ className, ...props }, ref) => (
-  <NavigationMenuPrimitive.Content
-    ref={ref}
-    className={cn(
-      'data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 left-0 top-0 w-full md:absolute md:w-auto',
-      className,
-    )}
-    {...props}
-  />
-))
+>(({ className, ...props }, ref) => {
+  const { orientation } = useNavigationOrientation()
+
+  return (
+    <NavigationMenuPrimitive.Content
+      ref={ref}
+      className={cn(
+        'data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 left-0 top-0 w-full',
+        isHorizontalNavigation(orientation) && 'absolute w-auto',
+        className,
+      )}
+      {...props}
+    />
+  )
+})
 NavigationMenuContent.displayName = NavigationMenuPrimitive.Content.displayName
 
 const NavigationMenuLink = NavigationMenuPrimitive.Link
@@ -171,7 +182,7 @@ const NavigationMenuViewport = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Viewport>,
   React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Viewport>
 >(({ className, ...props }, ref) => {
-  const { orientation } = React.useContext(NavigationContext)
+  const { orientation } = useNavigationOrientation()
   return (
     <div
       id="navigation-menu-viewport"
@@ -183,7 +194,9 @@ const NavigationMenuViewport = React.forwardRef<
     >
       <NavigationMenuPrimitive.Viewport
         className={cn(
-          'origin-top-center data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border border-zinc-200 bg-white text-zinc-950 shadow-lg md:w-[var(--radix-navigation-menu-viewport-width)] dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-50',
+          'origin-top-center data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border border-zinc-200 bg-white text-zinc-950 shadow-lg dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-50',
+          isHorizontalNavigation(orientation) &&
+            'w-[var(--radix-navigation-menu-viewport-width)]',
           className,
         )}
         ref={ref}
@@ -216,6 +229,7 @@ NavigationMenuIndicator.displayName =
 export {
   navigationMenuTriggerStyle,
   navigationMenuTriggerStyleForSubMenu,
+  useNavigationOrientation,
   NavigationMenu,
   NavigationMenuList,
   NavigationMenuItem,


### PR DESCRIPTION
# Description

This PR fixes the responsive course header behavior for issue #418. Previously, the header switched to the drawer menu only at a fixed breakpoint (768px). On tablet/smaller desktop widths, role/course-dependent nav items (especially professor links like Course Settings and Insights) could overflow, causing a horizontal scrollbar and dropdown placement issues.

The header now uses a 3-mode system:
- desktop
- compact (reduced top-level nav padding)
- drawer (hamburger)

Mode selection is based on measured rendered width (not fixed nav-item-count estimates), so it helps with student vs professor nav differences, enabled course features, zoom/larger font size scenarios.

Additionally, NavigationMenu now supports an optional showViewport prop so hidden measurement navbars can skip rendering an extra viewport element.

No dependencies, env changes, DB changes, or install steps are required.

Closes #418 

## Screenshots

1. Professor course at ~1024px
<img width="547" height="706" alt="Screenshot 2026-03-05 at 3 56 56 PM" src="https://github.com/user-attachments/assets/94b02aa3-9b0b-4a9b-a1fb-24ce97623c62" />

2. Professor course at ~1280px
<img width="684" height="437" alt="Screenshot 2026-03-05 at 3 57 53 PM" src="https://github.com/user-attachments/assets/c10d311e-9e82-4150-b5ff-43c6a58f446f" />

3. Student course at ~1024px
<img width="554" height="706" alt="Screenshot 2026-03-05 at 3 59 41 PM" src="https://github.com/user-attachments/assets/a4eecb2e-eb0e-422c-9489-97e7a1a0286d" />

4. Narrow tablet width ~820px (student or professor)
<img width="431" height="605" alt="Screenshot 2026-03-05 at 4 01 07 PM" src="https://github.com/user-attachments/assets/577ff09c-66da-429d-a75a-fa1e5718e363" />

5. Queues dropdown near a threshold width (~820px)
<img width="445" height="611" alt="Screenshot 2026-03-05 at 4 01 49 PM" src="https://github.com/user-attachments/assets/eacbe023-d389-45d3-95b2-7cc009ca3067" />

6. Profile dropdown near a threshold width (~1024px)
<img width="545" height="708" alt="Screenshot 2026-03-05 at 4 02 45 PM" src="https://github.com/user-attachments/assets/a4249b7e-1ad2-4ddf-9f5b-594c3f55c876" />

All screenshots show no horizontal scrollbar and correct nav mode for width/role.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:

# How Has This Been Tested?

Manually tested on course pages with different roles and feature sets, focusing on widths where overflow previously occurred.

Repro steps:

1. Open a student course home page and a professor course home page.
2. Resize viewport across tablet/smaller desktop widths (for example around 820px, 1024px, 1280px).
3. Verify the header switches between desktop, compact, and drawer based on fit.
4. Confirm there is no horizontal scrollbar.
5. Open the profile dropdown and queue dropdown near threshold widths and verify positioning/interaction.
7. Repeat checks at browser zoom levels (125%, 150%) and confirm nav switches mode instead of overflowing.

Zoom testing note: I could only test zoom reliably at desktop width. At 100% zoom, all nav elements are shown in desktop mode; after zooming in enough, the navbar shifts to drawer mode without introducing a horizontal scrollbar.  I couldn’t reliably test zoom at other widths in DevTools device mode.

# Checklist:

- [x] I have performed a code review of my own code (under the "Files Changed" tab on github) to ensure nothing is committed that shouldn't be (e.g. leftover `console.log`s, leftover unused logic, or anything else that was accidentally committed)
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing tests pass *locally* with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [x] Any UI changes have been checked to work on desktop, tablet, and mobile
