### PR TITLE
Better tablet UI in general

### DIFF
--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/components/CourseSettingsMenu.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/components/CourseSettingsMenu.tsx
@@ -11,10 +11,12 @@ import {
   TableOutlined,
 } from '@ant-design/icons'
 import { CourseSettingsResponse, Role } from '@koh/common'
-import { Menu, MenuProps } from 'antd'
+import { Menu, MenuProps, Select } from 'antd'
 import { usePathname, useRouter } from 'next/navigation'
+import { ReactNode } from 'react'
 
 type MenuItem = Required<MenuProps>['items'][number]
+type MenuOption = { key: string; label: ReactNode }
 
 enum CourseAdminOptions {
   CHECK_IN = 'CHECK_IN',
@@ -87,6 +89,8 @@ const CourseSettingsMenu: React.FC<CourseSettingsManyProps> = ({
     ]
   }
 
+  const currentMenuItem = handleCurrentMenuItem()
+
   const baseMenuItems: MenuItem[] = [
     {
       key: CourseAdminOptions.QUEUE_INVITES,
@@ -154,13 +158,34 @@ const CourseSettingsMenu: React.FC<CourseSettingsManyProps> = ({
       ? [...professorMenuItems, ...baseMenuItems]
       : baseMenuItems
 
+  const mobileOptions = menuItems
+    .filter((item): item is MenuOption => {
+      return (
+        !!item && item.type !== 'divider' && 'key' in item && 'label' in item
+      )
+    })
+    .map((item) => ({
+      value: item.key,
+      label: item.label,
+    }))
+
   return (
-    <Menu
-      defaultSelectedKeys={[handleCurrentMenuItem()]}
-      onClick={(item) => handleMenuClick(item)}
-      className="bg-[#f8f9fb]"
-      items={menuItems}
-    />
+    <>
+      <div className="md:hidden">
+        <Select
+          value={currentMenuItem}
+          onChange={(value) => handleMenuClick({ key: value })}
+          className="w-full"
+          options={mobileOptions}
+        />
+      </div>
+      <Menu
+        selectedKeys={[currentMenuItem]}
+        onClick={(item) => handleMenuClick(item)}
+        className="hidden bg-[#f8f9fb] md:block"
+        items={menuItems}
+      />
+    </>
   )
 }
 

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/layout.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/layout.tsx
@@ -28,15 +28,26 @@ export default async function Layout(props: {
   const courseFeatures = await courseApi.getCourseFeatures(cid)
 
   return (
-    <div className="mb-10 mt-2 flex flex-col space-y-3 md:flex-row md:space-x-3 md:space-y-0">
-      <CourseSettingsMenu
-        courseRole={courseRole}
-        courseFeatures={courseFeatures}
-        courseId={cid}
-      />
-      <AddChatbot courseId={cid}>
-        <div className="flex-1">{children}</div>
-      </AddChatbot>
+    <div className="mb-10 mt-2">
+      <div className="md:hidden">
+        <CourseSettingsMenu
+          courseRole={courseRole}
+          courseFeatures={courseFeatures}
+          courseId={cid}
+        />
+      </div>
+      <div className="mt-3 flex flex-col md:mt-0 md:flex-row md:space-x-3">
+        <div className="hidden md:block">
+          <CourseSettingsMenu
+            courseRole={courseRole}
+            courseFeatures={courseFeatures}
+            courseId={cid}
+          />
+        </div>
+        <AddChatbot courseId={cid}>
+          <div className="flex-1">{children}</div>
+        </AddChatbot>
+      </div>
     </div>
   )
 }

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/check_in/page.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/check_in/page.tsx
@@ -112,7 +112,7 @@ export default function TACheckInCheckOutTimes(
         >
           <Spin />
         </div>
-        <div className="mb-5 text-sm">
+        <div className="ta-checkin-calendar mb-5 text-sm">
           <FullCalendar
             selectable={false}
             editable={false}

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/components/CourseRosterTable.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/components/CourseRosterTable.tsx
@@ -210,7 +210,7 @@ const RosterItem: React.FC<{
     <List.Item
       key={item.id}
       className={cn(
-        'flex flex-col items-center justify-between px-1 py-2 md:flex-row md:px-4 md:py-4',
+        'flex flex-col items-center justify-between px-1 py-2 md:px-4 md:py-4 lg:flex-row',
         className ?? '',
       )}
     >
@@ -220,7 +220,7 @@ const RosterItem: React.FC<{
             <UserAvatar photoURL={item.photoURL} username={item.name ?? ''} />
           }
           title={
-            <span className="mr-0 md:mr-2">
+            <span className="mr-0 lg:mr-2">
               {item.name}
               {item.namePronunciation ? ` (${item.namePronunciation})` : ''}
               {item.organizationRole == OrganizationRole.ADMIN && (
@@ -234,21 +234,23 @@ const RosterItem: React.FC<{
               )}
             </span>
           }
-          className="flex flex-grow items-center"
+          className="flex min-w-0 flex-grow items-center"
         />
         {isSensitiveInfoHidden ? (
-          <div className="text-gray-600">
+          <div className="max-w-[45%] break-all text-right text-gray-600">
             {item.email
               ?.substring(0, item.email?.indexOf('@'))
               .replace(/./g, '*')}
             {item.email?.substring(item.email?.indexOf('@'))}
           </div>
         ) : (
-          <div className="text-gray-600">{item.email}</div>
+          <div className="max-w-[45%] break-all text-right text-gray-600">
+            {item.email}
+          </div>
         )}
       </Row>
 
-      <Row className="flex w-full items-center justify-around md:justify-end">
+      <Row className="flex w-full flex-wrap items-center justify-around lg:justify-end">
         {userInfo.id !== item.id && (
           <Dropdown
             menu={{

--- a/packages/frontend/app/(dashboard)/organization/components/SidebarNavigation.tsx
+++ b/packages/frontend/app/(dashboard)/organization/components/SidebarNavigation.tsx
@@ -89,7 +89,7 @@ const SidebarNavigation: React.FC = () => {
             }))}
           />
         </div>
-        <div className="hidden md:col-span-2 md:block">
+        <div className="hidden md:col-span-3 md:block lg:col-span-2">
           <nav className="rounded bg-white shadow-md">
             {items.map((item) => {
               return (

--- a/packages/frontend/app/(dashboard)/organization/components/SidebarNavigation.tsx
+++ b/packages/frontend/app/(dashboard)/organization/components/SidebarNavigation.tsx
@@ -10,7 +10,8 @@ import {
   TeamOutlined,
   UserOutlined,
 } from '@ant-design/icons'
-import { usePathname } from 'next/navigation'
+import { Select } from 'antd'
+import { usePathname, useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { cn } from '@/app/utils/generalUtils'
 import { useUserInfo } from '@/app/contexts/userContext'
@@ -63,6 +64,7 @@ const items = [
 
 const SidebarNavigation: React.FC = () => {
   const pathname = usePathname()
+  const router = useRouter()
   const { userInfo } = useUserInfo()
 
   if (
@@ -70,29 +72,47 @@ const SidebarNavigation: React.FC = () => {
     userInfo.organization.organizationRole === OrganizationRole.ADMIN
   ) {
     return (
-      <div className="md:col-span-2">
-        <nav className="rounded bg-white shadow-md">
-          {items.map((item) => {
-            return (
-              <Link href={item.url} key={item.key}>
-                <div
-                  className={cn(
-                    'flex cursor-pointer items-center justify-between rounded bg-white p-4 hover:bg-gray-200 focus:bg-gray-200',
-                    pathname === item.url
-                      ? 'bg-[#e6f7ff] text-[#1890ff]'
-                      : 'text-black',
-                  )}
-                >
-                  <div className="flex items-center">
-                    {item.icon}
-                    <span className="ml-4">{item.label}</span>
+      <>
+        <div className="md:hidden">
+          <Select
+            value={items.find((item) => item.url === pathname)?.key}
+            onChange={(value) => {
+              const nextItem = items.find((item) => item.key === value)
+              if (nextItem) {
+                router.push(nextItem.url)
+              }
+            }}
+            className="w-full"
+            options={items.map((item) => ({
+              value: item.key,
+              label: item.label,
+            }))}
+          />
+        </div>
+        <div className="hidden md:col-span-2 md:block">
+          <nav className="rounded bg-white shadow-md">
+            {items.map((item) => {
+              return (
+                <Link href={item.url} key={item.key}>
+                  <div
+                    className={cn(
+                      'flex cursor-pointer items-center justify-between rounded bg-white p-4 hover:bg-gray-200 focus:bg-gray-200',
+                      pathname === item.url
+                        ? 'bg-[#e6f7ff] text-[#1890ff]'
+                        : 'text-black',
+                    )}
+                  >
+                    <div className="flex items-center">
+                      {item.icon}
+                      <span className="ml-4">{item.label}</span>
+                    </div>
                   </div>
-                </div>
-              </Link>
-            )
-          })}
-        </nav>
-      </div>
+                </Link>
+              )
+            })}
+          </nav>
+        </div>
+      </>
     )
   } else {
     // This is just to create a gap to center the content

--- a/packages/frontend/app/(dashboard)/organization/layout.tsx
+++ b/packages/frontend/app/(dashboard)/organization/layout.tsx
@@ -15,7 +15,7 @@ export default function OrganizationLayout({
       <h2>My Organization</h2>
       <div className="mt-5 gap-8 space-y-3 md:grid md:grid-cols-10 md:space-y-0">
         <SidebarNavigation />
-        <div className="md:col-span-8">{children}</div>
+        <div className="md:col-span-7 lg:col-span-8">{children}</div>
       </div>
     </div>
   )

--- a/packages/frontend/app/(dashboard)/organization/layout.tsx
+++ b/packages/frontend/app/(dashboard)/organization/layout.tsx
@@ -1,5 +1,6 @@
 import SidebarNavigation from './components/SidebarNavigation'
 import { Metadata } from 'next'
+import { ReactNode } from 'react'
 
 export const metadata: Metadata = {
   title: 'HelpMe | Organization Panel',
@@ -8,7 +9,7 @@ export const metadata: Metadata = {
 export default function OrganizationLayout({
   children, // will be a page or nested layout
 }: {
-  children: React.ReactNode
+  children: ReactNode
 }) {
   return (
     <div className="mt-2">

--- a/packages/frontend/app/globals.css
+++ b/packages/frontend/app/globals.css
@@ -260,6 +260,25 @@ Here's the issue on antd's github: https://github.com/ant-design/ant-design/issu
   padding: 0 !important;
 }
 
+@media (min-width: 768px) and (max-width: 800px) {
+  .ta-checkin-calendar .fc .fc-toolbar {
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .ta-checkin-calendar .fc .fc-toolbar-chunk {
+    display: flex;
+    width: auto;
+    flex-wrap: nowrap;
+    align-items: center;
+    gap: 0.25rem;
+  }
+
+  .ta-checkin-calendar .fc .fc-toolbar-title {
+    font-size: 1.125rem;
+  }
+}
+
 /* Fixes an issue with question tag element editor popover not having vertical form item styles rather than horizontal (which started happening in a random antd update).
   Not a super pretty fix, probably should be looked at in the future if there's a nicer way to get around this.
 */


### PR DESCRIPTION
# Description

This PR addresses the non-overflow responsive issues found while testing tablet and mobile widths across the site. Horizontal scrolling/overflow issues are intentionally deferred to another issue.

1. Issue: On mobile, in Course Settings and Organization Settings, the sidebar appears before the main content, so the actual content only appears after scrolling down.

<img width="257" height="491" alt="Image" src="https://github.com/user-attachments/assets/605b5599-f4af-4dca-998c-f27b76895489" />

<img width="205" height="344" alt="Image" src="https://github.com/user-attachments/assets/62be3667-86d8-4e07-826f-60d8d1154b88" />

Suggested Fix: Replace the mobile sidebar with a small dropdown at the top, then show the actual settings page content immediately below it. Desktop and tablet layouts remain unchanged.

<img width="198" height="387" alt="Image" src="https://github.com/user-attachments/assets/db7528d4-794b-473c-a7e0-13981dcdf981" />

<img width="204" height="391" alt="Image" src="https://github.com/user-attachments/assets/72ae5158-2f87-4432-aaad-8b4546ea9d7e" />

<img width="223" height="361" alt="Image" src="https://github.com/user-attachments/assets/f8c33adf-d7f1-441a-a360-50d9fd59e3aa" />

2. Issue: On organization pages at tablet widths around 820px, the left sidebar becomes too narrow, causing labels like “AI Settings”, “LMS Integrations”, and “Member Role History” to wrap awkwardly and make the navigation look cramped.

<img width="116" height="303" alt="Image" src="https://github.com/user-attachments/assets/f6906a82-613f-49f1-82b4-5284ff7e62e4" />

Suggested Fix: Increase the organization sidebar width at the md/tablet breakpoint by giving it an extra grid column, while reducing the content area by one column. Keep the original sidebar width on larger desktop screens and preserve the mobile dropdown navigation.

<img width="425" height="602" alt="Image" src="https://github.com/user-attachments/assets/aff75678-b680-4fc4-b3cf-a8416c9f8b36" />

3. Issue: On the course roster, student names and emails overlap in the student list at 820px and 1024px, respectively.

<img width="465" height="625" alt="Screenshot 2026-03-31 at 12 14 50 AM" src="https://github.com/user-attachments/assets/6c578445-4ada-4fd8-a685-850a5658ce70" />
<img width="401" height="526" alt="Screenshot 2026-03-31 at 2 45 13 PM" src="https://github.com/user-attachments/assets/0d98d1ff-c4c8-4060-bb73-5bab2566a787" />

Suggested Fix: Keep the course roster rows in the same stacked layout used on mobile through the tablet breakpoint range, and only switch to the wider desktop row layout at lg. This prevents names, emails, and action buttons from overlapping when the settings sidebar reduces the available width. Desktop and mobile layouts remain unchanged.

<img width="423" height="599" alt="Screenshot 2026-04-06 at 2 14 03 PM" src="https://github.com/user-attachments/assets/28746b40-a718-4d34-bcef-4fe7668f6444" />
<img width="394" height="513" alt="Screenshot 2026-04-06 at 2 14 30 PM" src="https://github.com/user-attachments/assets/1459a2e2-68c2-4aeb-883e-4f9e0e2b51fc" />

4. Issue: On TA check-in/check-out, the Month / Week / List / Today buttons look misaligned at 768px.

<img width="399" height="530" alt="Screenshot 2026-04-06 at 3 01 02 PM" src="https://github.com/user-attachments/assets/707dadf5-ac2a-48f6-a85d-fae4ebdda4c9" />

Suggested Fix: Add a page-scoped FullCalendar toolbar override for the TA check-in/check-out page at the narrow tablet breakpoint so the Month / Week / List / Today controls stay aligned cleanly at 768px. The default calendar layout is unchanged at wider tablet, desktop, and mobile widths.

<img width="424" height="600" alt="Screenshot 2026-04-06 at 3 33 10 PM" src="https://github.com/user-attachments/assets/4fe6d233-45df-40c0-852b-06edb6770443" />
<img width="397" height="520" alt="Screenshot 2026-04-06 at 3 33 23 PM" src="https://github.com/user-attachments/assets/4070b2e0-c7cf-4515-b715-a556a4b3ab05" />

5. Issue: Rechecked the queue page responsiveness after the earlier concern about tablet-width layout. Tested at tablet width with multiple students in the queue, and also confirmed the page still looks fine on mobile and desktop.

Suggested Fix / Resolution: No code change was needed for the queue page. After re-testing, I did not find any layout regression, such as overlap, clipping, or horizontal overflow, across mobile, tablet, or desktop widths. The following are the screenshots of the queue page at 768px and 430pm (mobile), respectively.

<img width="396" height="523" alt="Screenshot 2026-04-06 at 5 49 12 PM" src="https://github.com/user-attachments/assets/ca916db4-471d-4d51-8bea-761d633fcbe5" />

<img width="341" height="712" alt="Screenshot 2026-04-06 at 6 03 56 PM" src="https://github.com/user-attachments/assets/c31be630-f14d-4a78-8df8-f9d092a1b8ef" />

Closes #445 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

Manually tested in the browser at mobile, tablet, and desktop widths. Added before/after images in the description above to showcase the issue and suggested changes.

# Checklist:

- [x] I have performed a code review of my own code (under the "Files Changed" tab on github) to ensure nothing is committed that shouldn't be (e.g. leftover `console.log`s, leftover unused logic, or anything else that was accidentally committed)
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing tests pass *locally* with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [x] Any UI changes have been checked to work on desktop, tablet, and mobile
