### PR TITLE
Page-Level Horizontal Overflow Fix at Tablet/Mobile Widths

### DIFF
--- a/packages/frontend/app/(dashboard)/course/[cid]/(insights)/components/InsightCard.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(insights)/components/InsightCard.tsx
@@ -12,10 +12,10 @@ const InsightCard: React.FC<InsightCardProps> = ({
   description,
 }) => {
   return (
-    <div className="border-b-helpmeblue-light hover:border-b-helpmeblue flex flex-auto flex-col rounded-lg border-b-2 bg-gray-50 p-8 drop-shadow-md transition-all">
+    <div className="border-b-helpmeblue-light hover:border-b-helpmeblue flex min-w-0 flex-auto flex-col rounded-lg border-b-2 bg-gray-50 p-8 drop-shadow-md transition-all">
       <b className={'text-xl'}>{title}</b>
       <p>{description}</p>
-      <div className={'w-full'}>{children}</div>
+      <div className={'w-full min-w-0'}>{children}</div>
     </div>
   )
 }

--- a/packages/frontend/app/(dashboard)/course/[cid]/(insights)/components/InsightsPageMenu.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(insights)/components/InsightsPageMenu.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React from 'react'
-import { Menu, MenuProps } from 'antd'
+import { Menu, MenuProps, Select } from 'antd'
 import {
   AreaChartOutlined,
   DashboardOutlined,
@@ -60,10 +60,19 @@ const InsightsMenu: React.FC<InsightsMenuProps> = ({
 
   return (
     <div className="mt-2">
+      <Select
+        value={category}
+        onChange={(value) => setCategory(value)}
+        className="w-full lg:hidden"
+        options={insightsMenuItems.map((item) => ({
+          value: item?.key as InsightCategory,
+          label: item?.label as string,
+        }))}
+      />
       <Menu
-        defaultSelectedKeys={[category]}
+        selectedKeys={[category]}
         onClick={(item) => handleInsightsClick(item)}
-        className="bg-[#f8f9fb]"
+        className="hidden bg-[#f8f9fb] lg:block"
         items={insightsMenuItems}
       />
     </div>

--- a/packages/frontend/app/(dashboard)/course/[cid]/(insights)/components/InsightsPageMenu.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(insights)/components/InsightsPageMenu.tsx
@@ -64,9 +64,9 @@ const InsightsMenu: React.FC<InsightsMenuProps> = ({
         value={category}
         onChange={(value) => setCategory(value)}
         className="w-full lg:hidden"
-        options={insightsMenuItems.map((item) => ({
-          value: item?.key as InsightCategory,
-          label: item?.label as string,
+        options={InsightCategories.map((item) => ({
+          value: item,
+          label: item.replace(/_/g, ' '),
         }))}
       />
       <Menu

--- a/packages/frontend/app/(dashboard)/course/[cid]/(insights)/components/filters/FilterWrapper.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(insights)/components/filters/FilterWrapper.tsx
@@ -4,7 +4,7 @@ const FilterWrapper: React.FC<{ title: string; children: React.ReactNode }> = ({
   children,
 }) => {
   return (
-    <div className="flex flex-col items-center">
+    <div className="flex min-w-0 flex-col items-center">
       <b>{title}</b>
       {children}
     </div>

--- a/packages/frontend/app/(dashboard)/course/[cid]/(insights)/components/filters/QueueFilter.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(insights)/components/filters/QueueFilter.tsx
@@ -79,9 +79,11 @@ const QueueFilter: React.FC<QueueFilterProps> = ({
           </div>
         </Modal>
         <FilterWrapper title={'Filter Queues'}>
-          <Button onClick={() => setModalOpen(true)}>
-            Selected Queues (
-            {selectedQueues.length == 0 ? 'All' : selectedQueues.length})
+          <Button className="max-w-full" onClick={() => setModalOpen(true)}>
+            <span className="block truncate">
+              Selected Queues (
+              {selectedQueues.length == 0 ? 'All' : selectedQueues.length})
+            </span>
             <DownOutlined color={'@White 65%'} />
           </Button>
         </FilterWrapper>

--- a/packages/frontend/app/(dashboard)/course/[cid]/(insights)/components/filters/StaffFilter.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(insights)/components/filters/StaffFilter.tsx
@@ -88,9 +88,11 @@ const StaffFilter: React.FC<StaffFilterProps> = ({
           </div>
         </Modal>
         <FilterWrapper title={'Filter Staff'}>
-          <Button onClick={() => setModalOpen(true)}>
-            Selected Staff (
-            {selectedStaff.length == 0 ? 'All' : selectedStaff.length})
+          <Button className="max-w-full" onClick={() => setModalOpen(true)}>
+            <span className="block truncate">
+              Selected Staff (
+              {selectedStaff.length == 0 ? 'All' : selectedStaff.length})
+            </span>
             <DownOutlined color={'@White 65%'} />
           </Button>
         </FilterWrapper>

--- a/packages/frontend/app/(dashboard)/course/[cid]/(insights)/components/outputComponents/InsightChartComponent.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(insights)/components/outputComponents/InsightChartComponent.tsx
@@ -89,7 +89,7 @@ const InsightChartComponent: React.FC<
     <InsightCard title={insight.title} description={insight.description}>
       {filterContent}
       {chartData.length > 0 ? (
-        <div className={'mt-4 w-full p-4'}>{chartRender}</div>
+        <div className={'mt-4 w-full overflow-x-auto p-4'}>{chartRender}</div>
       ) : (
         <div className="mx-auto mt-8 w-full p-4">
           <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />

--- a/packages/frontend/app/(dashboard)/course/[cid]/(insights)/components/outputComponents/InsightComponent.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(insights)/components/outputComponents/InsightComponent.tsx
@@ -156,7 +156,7 @@ const InsightComponent: React.FC<InsightComponentProps> = ({
 
     return (
       filterOptions.length > 0 && (
-        <div className="mt-2 flex flex-row justify-end gap-4">
+        <div className="mt-2 grid w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:flex lg:flex-row lg:justify-end">
           {filterOptions}
         </div>
       )
@@ -222,7 +222,7 @@ const InsightComponent: React.FC<InsightComponentProps> = ({
               0 ? (
                 <div
                   className={
-                    'grid w-full grid-cols-3 items-center justify-center gap-2'
+                    'grid w-full grid-cols-1 items-center justify-center gap-2 lg:grid-cols-3'
                   }
                 >
                   {(insightOutput.output as MultipleGanttChartOutputType).map(

--- a/packages/frontend/app/(dashboard)/course/[cid]/(insights)/components/outputComponents/InsightGanttChartComponent.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(insights)/components/outputComponents/InsightGanttChartComponent.tsx
@@ -90,7 +90,7 @@ const InsightGanttChartComponent: React.FC<InsightGanttChartComponentProps> = ({
         <div className={'text-md font-bold md:text-lg'}>{insight.title}</div>
         {filterContent}
         {chartData.length > 0 ? (
-          <div className={'mt-4 p-4'}>{chartRender}</div>
+          <div className={'mt-4 overflow-x-auto p-4'}>{chartRender}</div>
         ) : (
           <div className="mx-auto mt-8 w-full p-4">
             <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
@@ -103,7 +103,7 @@ const InsightGanttChartComponent: React.FC<InsightGanttChartComponentProps> = ({
     <InsightCard title={insight.title} description={insight.description}>
       {filterContent}
       {chartData.length > 0 ? (
-        <div className={'mt-4 p-4'}>{chartRender}</div>
+        <div className={'mt-4 overflow-x-auto p-4'}>{chartRender}</div>
       ) : (
         <div className="mx-auto mt-8 w-full p-4">
           <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />

--- a/packages/frontend/app/(dashboard)/course/[cid]/(insights)/insights/page.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(insights)/insights/page.tsx
@@ -139,7 +139,7 @@ export default function InsightsPage() {
     <>
       <InsightsPageMenu category={category} setCategory={setCategory} />
       <InsightContextProvider courseId={courseId}>
-        <div className="flex-1">
+        <div className="min-w-0 flex-1">
           {category == 'Dashboard' && (
             <DashboardPresetComponent
               courseId={courseId}
@@ -151,12 +151,12 @@ export default function InsightsPage() {
             />
           )}
           <div
-            className={'flex flex-1 p-5'}
+            className={'flex min-w-0 flex-1 p-5'}
             style={{
               paddingTop: category == 'Dashboard' ? '2.25rem' : undefined,
             }}
           >
-            <div className={'flex flex-1 flex-row flex-wrap gap-4'}>
+            <div className={'flex min-w-0 flex-1 flex-row flex-wrap gap-4'}>
               {category == 'Dashboard' ? (
                 <>
                   {(dashboardInsights != undefined &&

--- a/packages/frontend/app/(dashboard)/course/[cid]/(insights)/layout.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(insights)/layout.tsx
@@ -29,7 +29,9 @@ export default async function Layout(props: {
       <div className="mt-2 flex flex-col">
         <title>HelpMe | Course Insights</title>
         <h1 className="mb-2 hidden md:block">Course Insights</h1>
-        <div className="flex flex-1 flex-row">{children}</div>
+        <div className="flex min-w-0 flex-1 flex-col lg:flex-row">
+          {children}
+        </div>
       </div>
     </AddChatbot>
   )

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/layout.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/layout.tsx
@@ -36,7 +36,7 @@ export default async function Layout(props: {
           courseId={cid}
         />
       </div>
-      <div className="mt-3 flex flex-col md:mt-0 md:flex-row md:space-x-3">
+      <div className="mt-3 flex min-w-0 flex-col md:mt-0 md:flex-row md:space-x-3">
         <div className="hidden md:block">
           <CourseSettingsMenu
             courseRole={courseRole}
@@ -45,7 +45,7 @@ export default async function Layout(props: {
           />
         </div>
         <AddChatbot courseId={cid}>
-          <div className="flex-1">{children}</div>
+          <div className="min-w-0 flex-1">{children}</div>
         </AddChatbot>
       </div>
     </div>

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_questions/page.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_questions/page.tsx
@@ -484,8 +484,8 @@ export default function ChatbotQuestions(
           deleteQuestion={deleteQuestion}
         />
       )}
-      <div className="flex w-full items-center justify-between">
-        <div className="flex-1">
+      <div className="flex w-full flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="min-w-0 flex-1">
           <h3 className="m-0 p-0 text-4xl font-bold text-gray-900">
             View Chatbot Questions
           </h3>
@@ -493,10 +493,10 @@ export default function ChatbotQuestions(
             View and manage the questions being asked of your chatbot
           </h4>
         </div>
-        <div className="flex flex-grow flex-col items-center gap-2 md:flex-row">
+        <div className="flex w-full min-w-0 flex-col items-center gap-2 md:flex-row lg:w-auto">
           <ChatbotHelpTooltip forPage="edit_chatbot_questions" />
           <Input
-            className="flex-1"
+            className="w-full lg:min-w-64"
             placeholder={'Search question or answer...'}
             value={search}
             onChange={(e) => {
@@ -509,19 +509,42 @@ export default function ChatbotQuestions(
         </div>
       </div>
       <Divider className="my-3" />
-      <Table
-        columns={columns}
-        bordered
-        size="small"
-        dataSource={filteredQuestions}
-        loading={filteredQuestions.length === 0 && dataLoading}
-        expandable={{
-          expandedRowKeys: expandedRowKeys,
-          expandIcon: ({ expanded, record }) =>
-            !record.children ? null : !record.children[0].children ? (
-              expanded ? (
+      <div className="max-w-full overflow-x-auto">
+        <Table
+          columns={columns}
+          bordered
+          size="small"
+          dataSource={filteredQuestions}
+          loading={filteredQuestions.length === 0 && dataLoading}
+          scroll={{ x: 'max-content' }}
+          expandable={{
+            expandedRowKeys: expandedRowKeys,
+            expandIcon: ({ expanded, record }) =>
+              !record.children ? null : !record.children[0].children ? (
+                expanded ? (
+                  <button
+                    className=" ant-table-row-expand-icon ant-table-row-expand-icon-expanded bg-sky-100"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      handleRowExpand(record)
+                    }}
+                    aria-expanded="true"
+                  />
+                ) : (
+                  <Tooltip title="Show the full conversation the student had">
+                    <button
+                      className="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed bg-sky-100"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        handleRowExpand(record)
+                      }}
+                      aria-expanded="false"
+                    />
+                  </Tooltip>
+                )
+              ) : expanded ? (
                 <button
-                  className=" ant-table-row-expand-icon ant-table-row-expand-icon-expanded bg-sky-100"
+                  className="ant-table-row-expand-icon ant-table-row-expand-icon-expanded bg-sky-200"
                   onClick={(e) => {
                     e.stopPropagation()
                     handleRowExpand(record)
@@ -529,9 +552,9 @@ export default function ChatbotQuestions(
                   aria-expanded="true"
                 />
               ) : (
-                <Tooltip title="Show the full conversation the student had">
+                <Tooltip title="Show all conversations of 2 or more messages that have this question">
                   <button
-                    className="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed bg-sky-100"
+                    className="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed bg-sky-200"
                     onClick={(e) => {
                       e.stopPropagation()
                       handleRowExpand(record)
@@ -539,30 +562,10 @@ export default function ChatbotQuestions(
                     aria-expanded="false"
                   />
                 </Tooltip>
-              )
-            ) : expanded ? (
-              <button
-                className="ant-table-row-expand-icon ant-table-row-expand-icon-expanded bg-sky-200"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  handleRowExpand(record)
-                }}
-                aria-expanded="true"
-              />
-            ) : (
-              <Tooltip title="Show all conversations of 2 or more messages that have this question">
-                <button
-                  className="ant-table-row-expand-icon ant-table-row-expand-icon-collapsed bg-sky-200"
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    handleRowExpand(record)
-                  }}
-                  aria-expanded="false"
-                />
-              </Tooltip>
-            ),
-        }}
-      />
+              ),
+          }}
+        />
+      </div>
     </div>
   )
 }

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_questions/page.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_questions/page.tsx
@@ -509,7 +509,7 @@ export default function ChatbotQuestions(
         </div>
       </div>
       <Divider className="my-3" />
-      <div className="max-w-full overflow-x-auto">
+      <div className="max-w-[calc(100vw-2rem)] overflow-x-auto md:max-w-[calc(100vw-18rem)]">
         <Table
           columns={columns}
           bordered

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/edit_questions/page.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/edit_questions/page.tsx
@@ -490,7 +490,7 @@ const EditQuestionsPage: React.FC<EditQuestionsPageProps> = (props) => {
 
   return (
     <Form form={form} component={false}>
-      <div className="max-w-full overflow-x-auto">
+      <div className="max-w-[calc(100vw-2rem)] overflow-x-auto md:max-w-[calc(100vw-18rem)]">
         <Table
           components={{
             body: {

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/edit_questions/page.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/edit_questions/page.tsx
@@ -338,7 +338,6 @@ const EditQuestionsPage: React.FC<EditQuestionsPageProps> = (props) => {
               This is due to some changes to react and @types/react, and the component
               packages have not been updated to fix these issues.
             */}
-            {/* @ts-expect-error Server Component */}
             <Highlighter
               highlightStyle={{ backgroundColor: '#ffc069', padding: 0 }}
               searchWords={[searchText]}

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/edit_questions/page.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/edit_questions/page.tsx
@@ -491,22 +491,24 @@ const EditQuestionsPage: React.FC<EditQuestionsPageProps> = (props) => {
 
   return (
     <Form form={form} component={false}>
-      <Table
-        components={{
-          body: {
-            cell: EditableCell,
-          },
-        }}
-        bordered
-        dataSource={data}
-        size="small"
-        columns={mergedColumns}
-        rowClassName="editable-row"
-        pagination={{
-          onChange: cancelEdit,
-          pageSize: 20,
-        }}
-      />
+      <div className="max-w-full overflow-x-auto">
+        <Table
+          components={{
+            body: {
+              cell: EditableCell,
+            },
+          }}
+          bordered
+          dataSource={data}
+          size="small"
+          columns={mergedColumns}
+          rowClassName="editable-row"
+          pagination={{
+            onChange: cancelEdit,
+            pageSize: 20,
+          }}
+        />
+      </div>
     </Form>
   )
 }

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/queue_invites/page.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/queue_invites/page.tsx
@@ -123,9 +123,9 @@ export default function QueueInvitesPage(
     return (
       <div className="md:mt-3">
         <title>{`HelpMe | Editing ${course.name} Queue Invites`}</title>
-        <div className="flex flex-col items-center justify-between gap-2 lg:flex-row">
+        <div className="flex min-w-0 flex-col items-center justify-between gap-2 xl:flex-row">
           <h1>Queue Invites</h1>
-          <div className="flex w-full flex-col items-center justify-center gap-2 rounded bg-white p-3 shadow-sm sm:w-auto lg:flex-row">
+          <div className="flex w-full min-w-0 flex-col items-center justify-center gap-2 rounded bg-white p-3 shadow-sm sm:w-auto xl:flex-row">
             {course.queues && course.queues.length > 0 && (
               <>
                 <Select

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/queue_invites/page.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/queue_invites/page.tsx
@@ -123,9 +123,9 @@ export default function QueueInvitesPage(
     return (
       <div className="md:mt-3">
         <title>{`HelpMe | Editing ${course.name} Queue Invites`}</title>
-        <div className="flex flex-col items-center justify-between md:flex-row">
+        <div className="flex flex-col items-center justify-between gap-2 lg:flex-row">
           <h1>Queue Invites</h1>
-          <div className="flex flex-col items-center justify-center gap-2 rounded bg-white p-3 shadow-sm md:flex-row">
+          <div className="flex w-full flex-col items-center justify-center gap-2 rounded bg-white p-3 shadow-sm sm:w-auto lg:flex-row">
             {course.queues && course.queues.length > 0 && (
               <>
                 <Select
@@ -139,7 +139,7 @@ export default function QueueInvitesPage(
                         : undefined
                   }
                   disabled={selectableQueues.length === 0}
-                  className="w-80"
+                  className="w-full sm:w-80"
                   onChange={(value) => setSelectedQueueId(value)}
                   options={selectableQueues.map((queue) => ({
                     value: queue.id.toString(),
@@ -150,7 +150,7 @@ export default function QueueInvitesPage(
                 <Select
                   placeholder="Preset"
                   value={selectedPreset}
-                  className="w-36"
+                  className="w-full sm:w-36"
                   onChange={(value) => setSelectedPreset(value)}
                   options={[
                     { value: 'Default', label: 'Default Preset' },

--- a/packages/frontend/app/(dashboard)/course/[cid]/async_centre/components/AsyncCentreInfoColumn.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/async_centre/components/AsyncCentreInfoColumn.tsx
@@ -10,8 +10,8 @@ const AsyncCentreInfoColumn: React.FC<AsyncCentreInfoColumnProps> = ({
   buttons,
 }) => {
   return (
-    <div className="relative flex flex-shrink-0 flex-col pb-3 md:mt-8 md:w-72 md:pb-7">
-      <h1 className="mb-4 flex justify-center overflow-visible whitespace-nowrap text-2xl font-bold text-[#212934] md:mb-8">
+    <div className="relative flex flex-shrink-0 flex-col pb-3 lg:mt-8 lg:w-72 lg:pb-7">
+      <h1 className="mb-4 flex justify-center overflow-visible text-center text-2xl font-bold text-[#212934] lg:mb-8 lg:whitespace-nowrap">
         Anytime Question Hub
         <Tooltip
           title={

--- a/packages/frontend/app/(dashboard)/course/[cid]/async_centre/components/AsyncCentreInfoColumn.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/async_centre/components/AsyncCentreInfoColumn.tsx
@@ -10,8 +10,8 @@ const AsyncCentreInfoColumn: React.FC<AsyncCentreInfoColumnProps> = ({
   buttons,
 }) => {
   return (
-    <div className="relative flex flex-shrink-0 flex-col pb-3 lg:mt-8 lg:w-72 lg:pb-7">
-      <h1 className="mb-4 flex justify-center overflow-visible text-center text-2xl font-bold text-[#212934] lg:mb-8 lg:whitespace-nowrap">
+    <div className="relative flex flex-shrink-0 flex-col pb-3 xl:mt-8 xl:w-72 xl:pb-7">
+      <h1 className="mb-4 flex justify-center overflow-visible text-center text-2xl font-bold text-[#212934] xl:mb-8 xl:whitespace-nowrap">
         Anytime Question Hub
         <Tooltip
           title={

--- a/packages/frontend/app/(dashboard)/course/[cid]/async_centre/page.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/async_centre/page.tsx
@@ -359,7 +359,7 @@ export default function AsyncCentrePage(
     return <CenteredSpinner tip="Loading Questions..." />
   } else {
     return (
-      <div className="flex h-full flex-1 flex-col md:flex-row">
+      <div className="flex h-full flex-1 flex-col lg:flex-row">
         <title>{`HelpMe | ${userInfo.courses.find((e) => e.course.id === courseId)?.course.name ?? ''} - Anytime Questions`}</title>
         <AsyncCentreInfoColumn
           buttons={
@@ -372,7 +372,7 @@ export default function AsyncCentrePage(
                     Settings
                   </EditQueueButton>
                   <Checkbox
-                    className="text-lg md:mb-4 md:mt-2"
+                    className="text-lg lg:mb-4 lg:mt-2"
                     checked={showStudents}
                     onChange={(e) => setShowStudents(e.target.checked)}
                   >
@@ -404,13 +404,13 @@ export default function AsyncCentrePage(
           }
         />
         <VerticalDivider />
-        <div className="flex flex-grow flex-col md:mt-4">
+        <div className="flex min-w-0 flex-grow flex-col lg:mt-4">
           {/* Filters on DESKTOP ONLY */}
-          <div className="mb-4 hidden items-center gap-x-4 md:flex">
-            <h3 className="hidden flex-shrink-0 text-lg font-bold md:block">
+          <div className="mb-4 hidden items-center gap-x-4 lg:flex">
+            <h3 className="hidden flex-shrink-0 text-lg font-bold lg:block">
               Filter Questions
             </h3>
-            <div className="hidden flex-grow items-center gap-x-4 md:flex">
+            <div className="hidden min-w-0 flex-grow items-center gap-x-4 lg:flex">
               <RenderQuestionStatusFilter />
               {isStaff && <RenderVisibleFilter />}
               {!isStaff && <RenderCreatorFilter />}
@@ -433,7 +433,7 @@ export default function AsyncCentrePage(
             {/* Filters on MOBILE ONLY */}
             <Popover
               title="Filter Questions"
-              className="md:hidden"
+              className="lg:hidden"
               content={
                 <div className="flex flex-col gap-y-3">
                   <RenderQuestionStatusFilter />

--- a/packages/frontend/app/(dashboard)/course/[cid]/async_centre/page.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/async_centre/page.tsx
@@ -359,7 +359,7 @@ export default function AsyncCentrePage(
     return <CenteredSpinner tip="Loading Questions..." />
   } else {
     return (
-      <div className="flex h-full flex-1 flex-col lg:flex-row">
+      <div className="flex h-full min-w-0 flex-1 flex-col xl:flex-row">
         <title>{`HelpMe | ${userInfo.courses.find((e) => e.course.id === courseId)?.course.name ?? ''} - Anytime Questions`}</title>
         <AsyncCentreInfoColumn
           buttons={
@@ -372,7 +372,7 @@ export default function AsyncCentrePage(
                     Settings
                   </EditQueueButton>
                   <Checkbox
-                    className="text-lg lg:mb-4 lg:mt-2"
+                    className="text-lg xl:mb-4 xl:mt-2"
                     checked={showStudents}
                     onChange={(e) => setShowStudents(e.target.checked)}
                   >
@@ -403,14 +403,16 @@ export default function AsyncCentrePage(
             </>
           }
         />
-        <VerticalDivider />
-        <div className="flex min-w-0 flex-grow flex-col lg:mt-4">
+        <div className="hidden xl:block">
+          <VerticalDivider />
+        </div>
+        <div className="flex min-w-0 flex-grow flex-col xl:mt-4">
           {/* Filters on DESKTOP ONLY */}
-          <div className="mb-4 hidden items-center gap-x-4 lg:flex">
-            <h3 className="hidden flex-shrink-0 text-lg font-bold lg:block">
+          <div className="mb-4 hidden items-center gap-x-4 xl:flex">
+            <h3 className="hidden flex-shrink-0 text-lg font-bold xl:block">
               Filter Questions
             </h3>
-            <div className="hidden min-w-0 flex-grow items-center gap-x-4 lg:flex">
+            <div className="hidden min-w-0 flex-grow items-center gap-x-4 xl:flex">
               <RenderQuestionStatusFilter />
               {isStaff && <RenderVisibleFilter />}
               {!isStaff && <RenderCreatorFilter />}
@@ -433,7 +435,7 @@ export default function AsyncCentrePage(
             {/* Filters on MOBILE ONLY */}
             <Popover
               title="Filter Questions"
-              className="lg:hidden"
+              className="xl:hidden"
               content={
                 <div className="flex flex-col gap-y-3">
                   <RenderQuestionStatusFilter />


### PR DESCRIPTION
# Description

This PR fixes page-level horizontal overflow that appears at tablet and some mobile widths after the earlier “Better Tablet UI in General” work.

The affected pages were causing a horizontal scroll across the entire page, which also made the fixed header/navigation bar and the bottom feedback/footer bar appear shorter than the viewport. The fixes keep overflow contained within the specific page components that need it instead of allowing the full page shell to scroll horizontally.

Fixed pages:

- Anytime Qs
- Queue Invites
- Edit Queue Questions
- Course Insights
- Edit Chatbot Questions

Summary of changes:

- Updated tablet breakpoints so pages do not switch to cramped desktop layouts too early.
- Added layout containment so wide content does not stretch the whole page.
- Kept horizontal scrolling inside wide tables instead of on the full page.
- Updated Course Insights filters/charts so they wrap or scroll within their own section.

No new dependencies are required.

Closes #534 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

Manually tested the affected pages at mobile, tablet, and desktop widths.

Tested widths included: Mobile width, Around `768px`, Around `820px`, Around `1024px`, Around `1280px`

Confirmed that:

- Page-level horizontal scrolling is removed.
- Wide tables scroll inside the table area instead of the full page.
- Header/navigation bar no longer appears shorter due to page overflow.
- Bottom feedback/footer bar no longer appears shorter due to page overflow.
- Desktop views still render normally.

# Checklist:

- [x] I have performed a code review of my own code (under the "Files Changed" tab on github) to ensure nothing is committed that shouldn't be (e.g. leftover `console.log`s, leftover unused logic, or anything else that was accidentally committed)
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing tests pass *locally* with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [x] Any UI changes have been checked to work on desktop, tablet, and mobile
