### PR TITLE
Fix flaky test setups

### DIFF
--- a/packages/server/src/auth/auth.service.spec.ts
+++ b/packages/server/src/auth/auth.service.spec.ts
@@ -186,6 +186,7 @@ describe('AuthService', () => {
 
   let registrationParams: AccountRegistrationParams;
   let organization: OrganizationModel;
+  const expiredCreatedAt = (): Date => new Date(Date.now() - 1000);
 
   beforeEach(async () => {
     organization = await OrganizationFactory.create({
@@ -208,6 +209,7 @@ describe('AuthService', () => {
       const validAuthState = await AuthStateFactory.create({ organization });
       const invalidAuthState = await AuthStateFactory.create({
         organization,
+        createdAt: expiredCreatedAt(),
         expiresInSeconds: 0,
       });
 
@@ -535,6 +537,7 @@ describe('AuthService', () => {
       });
       const authState = await AuthStateFactory.create({
         organization: org,
+        createdAt: expiredCreatedAt(),
         expiresInSeconds: 0,
       });
       const res: any = new MockResponse() as any;
@@ -704,6 +707,7 @@ describe('AuthService', () => {
       const token = await UserTokenModel.save({
         user: user,
         token: crypto.randomBytes(32).toString('hex'),
+        createdAt: expiredCreatedAt(),
         expiresInSeconds: 0,
       });
       const res = new MockResponse() as any;

--- a/packages/server/src/lmsIntegration/lmsIntegration.service.spec.ts
+++ b/packages/server/src/lmsIntegration/lmsIntegration.service.spec.ts
@@ -65,6 +65,8 @@ Note:
   The only function that can be formally tested is the getAdapter() function.
 */
 describe('LMSIntegrationService', () => {
+  const expiredCreatedAt = (): Date => new Date(Date.now() - 1000);
+
   let service: LMSIntegrationService;
   let dataSource: DataSource;
 
@@ -120,6 +122,7 @@ describe('LMSIntegrationService', () => {
       const invalidAuthState = await LMSAuthStateFactory.create({
         organizationIntegration,
         user,
+        createdAt: expiredCreatedAt(),
         expiresInSeconds: 0,
       });
 

--- a/packages/server/test/lmsIntegration.integration.ts
+++ b/packages/server/test/lmsIntegration.integration.ts
@@ -41,6 +41,7 @@ import { LMSCourseIntegrationModel } from '../src/lmsIntegration/lmsCourseIntegr
 jest.setTimeout(10000);
 describe('Lms Integration Integrations', () => {
   const { supertest } = setupIntegrationTest(LmsIntegrationModule);
+  const expiredCreatedAt = (): Date => new Date(Date.now() - 1000);
 
   let prof: UserModel;
   let course: CourseModel;
@@ -1369,6 +1370,7 @@ describe('Lms Integration Integrations', () => {
       const expiredState = await LMSAuthStateFactory.create({
         user,
         organizationIntegration: orgInt,
+        createdAt: expiredCreatedAt(),
         expiresInSeconds: 0,
       });
       const params = new URLSearchParams({

--- a/packages/server/test/question.integration.ts
+++ b/packages/server/test/question.integration.ts
@@ -29,7 +29,6 @@ import {
   modifyMockNotifs,
   setupIntegrationTest,
 } from './util/testUtils';
-import { forEach } from 'lodash';
 import { QuestionTypeModel } from 'questionType/question-type.entity';
 import { StudentTaskProgressModel } from 'studentTaskProgress/studentTaskProgress.entity';
 
@@ -76,6 +75,19 @@ describe('Question Integration', () => {
   ];
 
   describe('POST /questions/:queueId', () => {
+    const createQuestionTypes = async (
+      cid: number,
+    ): Promise<QuestionTypeModel[]> =>
+      Promise.all(
+        QuestionTypes.map((questionType) =>
+          QuestionTypeFactory.create({
+            name: questionType.name,
+            color: questionType.color,
+            cid,
+          }),
+        ),
+      );
+
     const postQuestion = async (
       user: UserModel,
       queue: QueueModel,
@@ -199,25 +211,7 @@ describe('Question Integration', () => {
         queue,
         user: ta.user,
       });
-
-      const questionTypes = [];
-
-      forEach(QuestionTypes, async (questionType) => {
-        await QuestionTypeFactory.create({
-          name: questionType.name,
-          color: questionType.color,
-          cid: course.id,
-        });
-
-        const sendQuestionTypes = {
-          id: questionType.id,
-          cid: questionType.cid,
-          name: questionType.name,
-          color: questionType.color,
-          queueId: queue.id,
-        };
-        questionTypes.push(sendQuestionTypes);
-      });
+      const questionTypes = await createQuestionTypes(course.id);
 
       await TACourseFactory.create({ user, courseId: queue.courseId });
       expect(await QuestionModel.count({ where: { queueId: 1 } })).toEqual(0);
@@ -227,7 +221,7 @@ describe('Question Integration', () => {
     it('post question fails with non-existent queue', async () => {
       const course = await CourseFactory.create();
       const user = await UserFactory.create();
-      const ta = await TACourseFactory.create({
+      await TACourseFactory.create({
         course: course,
         user: await UserFactory.create(),
       });
@@ -265,15 +259,7 @@ describe('Question Integration', () => {
         user,
         course: course2,
       });
-      const questionTypes = [];
-      forEach(QuestionTypes, async (questionType) => {
-        const currentQuestionType = await QuestionTypeFactory.create({
-          name: questionType.name,
-          color: questionType.color,
-          cid: course2.id,
-        });
-        questionTypes.push(currentQuestionType);
-      });
+      const questionTypes = await createQuestionTypes(course2.id);
 
       const response = await postQuestion(user, queueImNotIn, questionTypes);
       expect(response.status).toBe(404);
@@ -287,15 +273,7 @@ describe('Question Integration', () => {
         allowQuestions: true,
         isDisabled: true,
       });
-      const questionTypes = [];
-      forEach(QuestionTypes, async (questionType) => {
-        const currentQuestionType = await QuestionTypeFactory.create({
-          name: questionType.name,
-          color: questionType.color,
-          cid: course.id,
-        });
-        questionTypes.push(currentQuestionType);
-      });
+      const questionTypes = await createQuestionTypes(course.id);
 
       const user = await UserFactory.create();
       await StudentCourseFactory.create({ user, courseId: queue.courseId });
@@ -369,15 +347,7 @@ describe('Question Integration', () => {
         status: OpenQuestionStatus.Drafting,
       });
 
-      const questionTypes = [];
-      forEach(QuestionTypes, async (questionType) => {
-        const currentQuestionType = await QuestionTypeFactory.create({
-          name: questionType.name,
-          color: questionType.color,
-          cid: course.id,
-        });
-        questionTypes.push(currentQuestionType);
-      });
+      const questionTypes = await createQuestionTypes(course.id);
 
       const response = await postQuestion(user, queue2, questionTypes);
 
@@ -709,15 +679,7 @@ describe('Question Integration', () => {
         queue: queue1,
         status: OpenQuestionStatus.Drafting,
       });
-      const questionTypes = [];
-      forEach(QuestionTypes, async (questionType) => {
-        const currentQuestionType = await QuestionTypeFactory.create({
-          name: questionType.name,
-          color: questionType.color,
-          cid: course2.id,
-        });
-        questionTypes.push(currentQuestionType);
-      });
+      const questionTypes = await createQuestionTypes(course2.id);
 
       const response = await postQuestion(user, queue2, questionTypes);
       expect(response.status).toBe(201);
@@ -750,15 +712,7 @@ describe('Question Integration', () => {
         creator: user,
         status: OpenQuestionStatus.Drafting,
       });
-      const questionTypes = [];
-      forEach(QuestionTypes, async (questionType) => {
-        const currentQuestionType = await QuestionTypeFactory.create({
-          name: questionType.name,
-          color: questionType.color,
-          cid: queue.courseId,
-        });
-        questionTypes.push(currentQuestionType);
-      });
+      const questionTypes = await createQuestionTypes(queue.courseId);
 
       const response = await postQuestion(user, queue, questionTypes);
       expect(response.status).toBe(201);
@@ -791,15 +745,7 @@ describe('Question Integration', () => {
         userId: user.id,
         courseId: queue.courseId,
       });
-      const questionTypes = [];
-      forEach(QuestionTypes, async (questionType) => {
-        const currentQuestionType = await QuestionTypeFactory.create({
-          name: questionType.name,
-          color: questionType.color,
-          cid: queue.courseId,
-        });
-        questionTypes.push(currentQuestionType);
-      });
+      const questionTypes = await createQuestionTypes(queue.courseId);
 
       const response = await postQuestion(user, queue, questionTypes);
       expect(response.status).toBe(201);
@@ -828,15 +774,7 @@ describe('Question Integration', () => {
         userId: user.id,
         courseId: queue.courseId,
       });
-      const questionTypes = [];
-      forEach(QuestionTypes, async (questionType) => {
-        const currentQuestionType = await QuestionTypeFactory.create({
-          name: questionType.name,
-          color: questionType.color,
-          cid: queue.courseId,
-        });
-        questionTypes.push(currentQuestionType);
-      });
+      const questionTypes = await createQuestionTypes(queue.courseId);
 
       const response = await postQuestion(user, queue, questionTypes);
       expect(response.status).toBe(201);


### PR DESCRIPTION
# Description

Fixes three sources of intermittent test failures, split out of #561 to keep that PR focused on the feature:

- `question.integration.ts`: question types were created with lodash `forEach` and an async callback, which does not await, so test setup raced the test body. Replaced with an awaited `Promise.all`.
- `auth.service.spec.ts`: tokens created with `expiresInSeconds: 0` only count as expired once the clock ticks past their creation instant, so fast runs could intermittently see them as still valid. Back-dating `createdAt` by one second makes expiry deterministic.
- LMS integration specs: same expiry fix for LMS auth states.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `yarn jest src/auth/auth.service.spec.ts src/lmsIntegration/lmsIntegration.service.spec.ts` (83 tests pass)
- [x] `yarn jest --config ./test/jest-integration.json -i question.integration lmsIntegration.integration` (218 tests pass)

# Checklist:

- [x] I have performed a code review of my own code
- [x] My changes generate no new warnings
- [x] I have checked that new and existing tests pass *locally* with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch