### PR TITLE
Re-use refresh_token

### DIFF
--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -3804,6 +3804,12 @@ export type LMSPostResponseBody = {
   expires_in: number
   canvas_region?: string
 }
+export type LMSPostResponseRefreshTokenBody = {
+  access_token: string
+  token_type: string
+  user: { id: number; name: string }
+  expires_in: number
+}
 
 export class LMSToken {
   @IsInt()

--- a/packages/server/src/lmsIntegration/lmsIntegration.adapter.ts
+++ b/packages/server/src/lmsIntegration/lmsIntegration.adapter.ts
@@ -11,6 +11,7 @@ import {
   LMSPage,
   LMSPostAuthBody,
   LMSPostResponseBody,
+  LMSPostResponseRefreshTokenBody,
   LMSQuiz,
 } from '@koh/common';
 import { LMSUpload } from './lmsIntegration.service';
@@ -165,8 +166,12 @@ export abstract class AbstractLMSAdapter {
         );
       }
 
-      const raw = (await response.json()) as LMSPostResponseBody;
-      const updated = await accessToken.encryptToken(raw);
+      const raw = (await response.json()) as LMSPostResponseRefreshTokenBody;
+      const updated = await accessToken.encryptToken({
+        ...token, // old token
+        ...raw, // new token attributes (just in case anything changed. Also RefreshTokenBody is a subset of the regular POST body)
+        refresh_token: token.refresh_token, // just to be explicit: we must RE-USE existing refresh token according to canvas api docs https://developerdocs.instructure.com/services/canvas/oauth2/file.oauth_endpoints#post-login-oauth2-token
+      });
 
       return {
         accessToken: updated,


### PR DESCRIPTION
# Description

lti accessToken auth: re-use existing refresh_token since POST /login/oath2/token with grant: refresh_token does not return a new refresh token, you're expected to just re-use the existing one

Closes #538 , and maybe #483

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the production .env variables. These changes are below:
- [ ] This change requires developers to add new .env variables. The file and variables needed are below:
- [ ] This change requires a database query to update old data on production. This query is below:


# How Has This Been Tested?

I haven't tested it. Wee!

# Checklist:

- [x] I have performed a code review of my own code (under the "Files Changed" tab on github) to ensure nothing is committed that shouldn't be (e.g. leftover `console.log`s, leftover unused logic, or anything else that was accidentally committed)
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing tests pass *locally* with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [ ] Any UI changes have been checked to work on desktop, tablet, and mobile
