### PR TITLE
Seed LANTERN agent chatbot settings

### DIFF
--- a/packages/server/src/seed/seed-chatbot-agent-group.command.ts
+++ b/packages/server/src/seed/seed-chatbot-agent-group.command.ts
@@ -1,6 +1,8 @@
 import { SuperCoursePurpose } from '@koh/common';
 import { Injectable } from '@nestjs/common';
 import { Command } from 'nestjs-command';
+import { CourseChatbotSettingsModel } from 'chatbot/chatbot-infrastructure-models/course-chatbot-settings.entity';
+import { OrganizationChatbotSettingsModel } from 'chatbot/chatbot-infrastructure-models/organization-chatbot-settings.entity';
 import { CourseModel } from 'course/course.entity';
 import { CourseSettingsModel } from 'course/course_settings.entity';
 import { SuperCourseModel } from 'course/super-course.entity';
@@ -15,21 +17,29 @@ const agents = [
     name: 'Analyst',
     description:
       'Research foundations, statistics, research methods, terminology, philosophy of science, and critical appraisal.',
+    prompt:
+      'You are LANTERN Analyst, a research foundations coach for graduate students and researchers. Help with research methods, statistics, terminology, philosophy of science, and critical appraisal. Ask clarifying questions when useful, explain concepts plainly, and guide learners toward sound reasoning instead of doing their work for them.',
   },
   {
     name: 'Communicator',
     description:
       'Scholarly communication, literature synthesis, scientific writing, and oral presentations.',
+    prompt:
+      'You are LANTERN Communicator, a scholarly communication coach for graduate students and researchers. Help with literature synthesis, scientific writing, presentation structure, audience fit, and clear academic language. Offer concrete revision guidance while keeping the learner in control of their own argument.',
   },
   {
     name: 'Strategist',
     description:
       'Grantsmanship, funder alignment, grant structure, budget justification, project management, and reviewer perspective.',
+    prompt:
+      'You are LANTERN Strategist, a grants and project planning coach for graduate students and researchers. Help with funder alignment, proposal structure, budget justification, project planning, and reviewer expectations. Give practical, structured advice and flag assumptions that should be verified.',
   },
   {
     name: 'Thrive',
     description:
       'Academic culture, hidden curriculum, mentorship navigation, common challenges in academia, and career planning.',
+    prompt:
+      'You are LANTERN Thrive, an academic wellbeing and career navigation coach for graduate students and researchers. Help with academic culture, mentorship, hidden curriculum, common academic challenges, and career planning. Be supportive and practical, and encourage learners to use local human support for personal, health, or urgent concerns.',
   },
 ];
 const parentCourseName = 'LANTERN';
@@ -62,6 +72,8 @@ export class SeedChatbotAgentGroupCommand {
         semester.id,
         organization.id,
       );
+      const organizationChatbotSettings =
+        await this.getOrganizationChatbotSettings(manager, organization.id);
 
       await this.attachCourseToGroup(
         manager,
@@ -86,6 +98,12 @@ export class SeedChatbotAgentGroupCommand {
           superCourse,
           organization.id,
         );
+        await this.upsertAgentCourseChatbotSettings(
+          manager,
+          course.id,
+          agent.prompt,
+          organizationChatbotSettings,
+        );
       }
 
       console.log(
@@ -96,6 +114,27 @@ export class SeedChatbotAgentGroupCommand {
 
   private getAgentCourseName(agentName: string): string {
     return `${parentCourseName} ${agentName}`;
+  }
+
+  private async getOrganizationChatbotSettings(
+    manager: EntityManager,
+    organizationId: number,
+  ): Promise<OrganizationChatbotSettingsModel> {
+    const organizationChatbotSettings = await manager.findOne(
+      OrganizationChatbotSettingsModel,
+      {
+        where: { organizationId },
+        relations: { defaultProvider: true },
+      },
+    );
+
+    if (!organizationChatbotSettings?.defaultProvider?.defaultModelId) {
+      throw new Error(
+        `Cannot seed LANTERN chatbot settings for organization ${organizationId}: default chatbot provider/model is not configured.`,
+      );
+    }
+
+    return organizationChatbotSettings;
   }
 
   private async findOrCreateSuperCourse(
@@ -212,5 +251,29 @@ export class SeedChatbotAgentGroupCommand {
         }),
       );
     }
+  }
+
+  private async upsertAgentCourseChatbotSettings(
+    manager: EntityManager,
+    courseId: number,
+    prompt: string,
+    organizationChatbotSettings: OrganizationChatbotSettingsModel,
+  ): Promise<void> {
+    const existing = await manager.findOne(CourseChatbotSettingsModel, {
+      where: { courseId },
+    });
+    const defaults = CourseChatbotSettingsModel.getDefaults(manager);
+    const settings = manager.create(CourseChatbotSettingsModel, {
+      ...defaults,
+      ...existing,
+      courseId,
+      organizationSettingsId: organizationChatbotSettings.id,
+      llmId: organizationChatbotSettings.defaultProvider.defaultModelId,
+      prompt,
+      usingDefaultModel: true,
+      usingDefaultPrompt: false,
+    });
+
+    await manager.save(CourseChatbotSettingsModel, settings);
   }
 }

--- a/packages/server/test/seed.integration.ts
+++ b/packages/server/test/seed.integration.ts
@@ -1,10 +1,24 @@
+import { ChatbotServiceProvider } from '@koh/common';
+import { CourseModel } from '../../server/src/course/course.entity';
 import { QuestionModel } from '../../server/src/question/question.entity';
 import { SeedModule } from '../../server/src/seed/seed.module';
-import { CourseFactory, QuestionFactory, QueueFactory } from './util/factories';
+import { SeedChatbotAgentGroupCommand } from '../../server/src/seed/seed-chatbot-agent-group.command';
+import { CourseChatbotSettingsModel } from '../../server/src/chatbot/chatbot-infrastructure-models/course-chatbot-settings.entity';
+import {
+  ChatbotProviderFactory,
+  CourseFactory,
+  LLMTypeFactory,
+  OrganizationChatbotSettingsFactory,
+  OrganizationFactory,
+  QuestionFactory,
+  QueueFactory,
+  SemesterFactory,
+} from './util/factories';
 import { setupIntegrationTest } from './util/testUtils';
+import { In } from 'typeorm';
 
 describe('Seed Integration', () => {
-  const { supertest } = setupIntegrationTest(SeedModule);
+  const { supertest, getTestModule } = setupIntegrationTest(SeedModule);
   it('GET /seeds/delete', async () => {
     const course = await CourseFactory.create({});
 
@@ -30,5 +44,70 @@ describe('Seed Integration', () => {
 
     const numQuestions = await QuestionModel.count();
     expect(numQuestions).toBe(4);
+  });
+
+  it('seed:chatbot-agent-group creates DB-backed prompts for LANTERN agent courses', async () => {
+    const organization = await OrganizationFactory.create({ name: 'UBC' });
+    await SemesterFactory.create({
+      name: '2026S Both Terms',
+      organization,
+    });
+    const organizationChatbotSettings =
+      await OrganizationChatbotSettingsFactory.create({ organization });
+    const provider = await ChatbotProviderFactory.create({
+      organizationChatbotSettings,
+      providerType: ChatbotServiceProvider.Ollama,
+    });
+    const defaultModel = await LLMTypeFactory.create({
+      provider,
+      modelName: 'model1',
+      isText: true,
+      isVision: false,
+      isThinking: false,
+    });
+    provider.defaultModelId = defaultModel.id;
+    await provider.save();
+    organizationChatbotSettings.defaultProviderId = provider.id;
+    await organizationChatbotSettings.save();
+
+    const command = getTestModule().get(SeedChatbotAgentGroupCommand);
+    await command.createLanternAgentGroup();
+
+    const agentCourses = await CourseModel.find({
+      where: {
+        name: In([
+          'LANTERN Analyst',
+          'LANTERN Communicator',
+          'LANTERN Strategist',
+          'LANTERN Thrive',
+        ]),
+      },
+    });
+    const courseSettings = await CourseChatbotSettingsModel.find({
+      where: { courseId: In(agentCourses.map((course) => course.id)) },
+      relations: { course: true },
+      order: { courseId: 'ASC' },
+    });
+
+    expect(courseSettings).toHaveLength(4);
+    expect(
+      courseSettings.map((settings) => settings.course.name).sort(),
+    ).toEqual([
+      'LANTERN Analyst',
+      'LANTERN Communicator',
+      'LANTERN Strategist',
+      'LANTERN Thrive',
+    ]);
+    courseSettings.forEach((settings) => {
+      expect(settings.organizationSettingsId).toBe(
+        organizationChatbotSettings.id,
+      );
+      expect(settings.llmId).toBe(defaultModel.id);
+      expect(settings.usingDefaultModel).toBe(true);
+      expect(settings.usingDefaultPrompt).toBe(false);
+      expect(settings.prompt).toContain(
+        `You are LANTERN ${settings.course.chatbotAgentName}`,
+      );
+    });
   });
 });


### PR DESCRIPTION
## What changed
- Seeded each LANTERN agent course with a CourseChatbotSettings row.
- Stored each agent prompt directly in the existing chatbot settings table.
- Added an integration test for the seed command.

## Validation
- yarn jest --config ./test/jest-integration.json -i seed.integration.ts
- yarn tsc --noEmit
