### PR TITLE
Changelog 1.9.0, Fix Queue Unresponsiveness, add anonymous/public options to Convert to Anytime modals, and more

### DIFF
--- a/docs/NEWDEVS_STARTHERE.md
+++ b/docs/NEWDEVS_STARTHERE.md
@@ -622,6 +622,10 @@ Some examples of where this is used:
 
 See https://orkhan.gitbook.io/typeorm/docs/listeners-and-subscribers for more info
 
+**Important Gotchas:**
+- For `afterUpdate`, if you're using a `.update()` statement, the subscriber's `entity` object will only contain what was passed into the `update()` statement. This is really important since you might not even have access to what entities were updated!
+- **VERY IMPORTANT**: TypeORM's entity listeners (afterUpdate, BeforeDelete, etc.) do not commit their transaction until the end of the event. This means it's ABSOLUTELY CRUCIAL that you perform any database operations using the event object's `queryRunner` or `manager` instance since otherwise you won't pull new data.
+
 
 ## Known Quirks when Developing
 

--- a/packages/frontend/app/(auth)/login/components/LoginPage.tsx
+++ b/packages/frontend/app/(auth)/login/components/LoginPage.tsx
@@ -171,7 +171,7 @@ const LoginPage: React.FC = () => {
     const response = await API.login.index(loginData).catch((err: any) => {
       switch (err.status) {
         case 401:
-          message.error(err.message)
+          message.error(getErrorMessage(err))
           break
         case 403:
           setAccountActiveResponse(false)

--- a/packages/frontend/app/(auth)/login/components/LoginPage.tsx
+++ b/packages/frontend/app/(auth)/login/components/LoginPage.tsx
@@ -452,12 +452,6 @@ const LoginPage: React.FC = () => {
                   initialValues={{ remember: true }}
                   onFinish={login}
                 >
-                  {/*
-                    In some environments, components which return Promises or arrays do not work.
-                    This is due to some changes to react and @types/react, and the component
-                    packages have not been updated to fix these issues.
-                  */}
-                  {/* @ts-expect-error Server Component */}
                   <ReCAPTCHA
                     ref={recaptchaRef}
                     size="invisible"

--- a/packages/frontend/app/(auth)/login/components/LoginPage.tsx
+++ b/packages/frontend/app/(auth)/login/components/LoginPage.tsx
@@ -501,7 +501,6 @@ const LoginPage: React.FC = () => {
 
                   <Form.Item>
                     <Button
-                      type="primary"
                       htmlType="submit"
                       className="h-auto w-full items-center justify-center rounded-lg border px-2 py-2 "
                     >

--- a/packages/frontend/app/(auth)/password/page.tsx
+++ b/packages/frontend/app/(auth)/password/page.tsx
@@ -81,7 +81,6 @@ export default function ForgetPassword() {
           form={form}
           onFinish={sendResetPasswordEmail}
         >
-          {/* @ts-expect-error Server Component */}
           <ReCAPTCHA
             ref={recaptchaRef}
             size="invisible"

--- a/packages/frontend/app/(auth)/register/page.tsx
+++ b/packages/frontend/app/(auth)/register/page.tsx
@@ -208,12 +208,6 @@ export default function RegisterPage(props: {
                 initialValues={{ remember: true }}
                 onFinish={createAccount}
               >
-                {/*
-              In some environments, components which return Promises or arrays do not work.
-              This is due to some changes to react and @types/react, and the component
-              packages have not been updated to fix these issues.
-              */}
-                {/* @ts-expect-error Server Component */}
                 <ReCAPTCHA
                   ref={recaptchaRef}
                   size="invisible"

--- a/packages/frontend/app/(auth)/register/page.tsx
+++ b/packages/frontend/app/(auth)/register/page.tsx
@@ -263,7 +263,11 @@ export default function RegisterPage(props: {
                   </Col>
                 </Row>
 
-                <Form.Item label="Name Pronunciation" name="namePronunciation">
+                <Form.Item
+                  label="Name Pronunciation"
+                  name="namePronunciation"
+                  tooltip="Lets course staff inside queues see how to pronounce your name. Use capital letters to indicate the primary stress (emphasis) of your name."
+                >
                   <Input allowClear={true} placeholder="Example: uh-LEE-shuh" />
                 </Form.Item>
 

--- a/packages/frontend/app/(dashboard)/components/CourseFeaturesForm.tsx
+++ b/packages/frontend/app/(dashboard)/components/CourseFeaturesForm.tsx
@@ -59,7 +59,7 @@ const CourseFeaturesForm: React.FC<CourseFeaturesFormProps> = ({
             featureName="scheduleOnFrontPage"
             className="ml-4 md:ml-6"
             defaultChecked={courseFeatures.scheduleOnFrontPage}
-            title="Schedule on Front/Home Course Page"
+            title="Schedule on Home Course Page"
             description="By default, a chatbot is displayed on the home course page. Enabling this will replace that chatbot with a preview of today's schedule and show a little 'Chatbot' widget for the chatbot like other pages. Choose this option if you think it is more valuable for students to see today's event schedule over a large chatbot component."
             courseId={courseId}
           />
@@ -83,7 +83,7 @@ const CourseFeaturesForm: React.FC<CourseFeaturesFormProps> = ({
             featureName="asyncQueueEnabled"
             defaultChecked={courseFeatures.asyncQueueEnabled}
             title="Anytime Question Hub"
-            description="This feature allows students to ask questions asynchronously (e.g. outside of office hours or labs) that can then be answered by the professor. It also features automatic AI-generated answers based on uploaded course content."
+            description="This feature will enable students question's to immediately get an AI answer when they ask it (on the Anytime Question Hub). From there, students can ask if they are satisfied or still need help with it, in which staff can then edit the answer or verify it. Utilizes the Course Chatbot and pairs great with it for Human In The Loop Support."
             courseId={courseId}
           />
 
@@ -92,7 +92,7 @@ const CourseFeaturesForm: React.FC<CourseFeaturesFormProps> = ({
             className="ml-4 md:ml-6"
             defaultChecked={courseFeatures.asyncCentreAIAnswers}
             title="AI Answers"
-            description="This feature will enable students question's to immediately get an AI answer when they ask it (on the Anytime Question Hub). From there, students can ask if they are satisfied or still need help with it, in which staff can then edit the answer or verify it."
+            description="When students first as an Anytime Question, they get an AI response from the Course Chatbot. You can choose to disable this if you don't want this AI feature."
             courseId={courseId}
           />
 

--- a/packages/frontend/app/(dashboard)/components/CourseFeaturesForm.tsx
+++ b/packages/frontend/app/(dashboard)/components/CourseFeaturesForm.tsx
@@ -101,7 +101,7 @@ const CourseFeaturesForm: React.FC<CourseFeaturesFormProps> = ({
             className="ml-4 md:ml-6"
             defaultChecked={courseFeatures.asyncCentreDefaultAnonymous}
             title="Questions Anonymous by Default"
-            description="By default, Anytime Question authors are anonymous when viewed by students. Toggling this will make new Anytime Questions be anonymous or non-anonymous by default. It will not change the anonymity of previously posted questions. Question authors decide whether their profile will be visible or not when editing or creating the question."
+            description="When creating an Anytime Question, by default the 'Appear Anonymous' checkbox will be checked. Disable this feature will make it so the checkbox will by default be unchecked. Most students will leave the checkbox to whatever the default value is."
             courseId={courseId}
           />
 

--- a/packages/frontend/app/(dashboard)/components/CourseInviteCode.tsx
+++ b/packages/frontend/app/(dashboard)/components/CourseInviteCode.tsx
@@ -104,7 +104,7 @@ const CourseInviteCode: React.FC<CourseInviteCodeProps> = ({
 
   return (
     <div className="space-y-3">
-      <div className="mb-2 flex flex-col justify-center gap-2 md:flex-row md:items-center">
+      <div className="mb-2 flex flex-col items-center justify-center gap-2 md:flex-row">
         {isEnabled ? <div>{inviteURL}</div> : <s>{inviteURL}</s>}
         <div className="flex gap-2">
           <Button

--- a/packages/frontend/app/(dashboard)/components/EditCourseForm.tsx
+++ b/packages/frontend/app/(dashboard)/components/EditCourseForm.tsx
@@ -4,7 +4,6 @@ import { API } from '@/app/api'
 import { getErrorMessage } from '@/app/utils/generalUtils'
 import { formatSemesterDate } from '@/app/utils/timeFormatUtils'
 import {
-  COURSE_TIMEZONES,
   GetOrganizationResponse,
   OrganizationCourseResponse,
   OrganizationProfessor,
@@ -14,6 +13,10 @@ import {
 import { Alert, Button, Card, Form, Input, message, Select } from 'antd'
 import { useEffect, useState } from 'react'
 import ProfessorSelector from './ProfessorSelector'
+import dayjs from 'dayjs'
+import relativeTime from 'dayjs/plugin/relativeTime'
+
+dayjs.extend(relativeTime)
 
 type EditCourseFormProps = {
   courseData: OrganizationCourseResponse
@@ -257,7 +260,7 @@ const EditCourseForm: React.FC<EditCourseFormProps> = ({
                         new Date(semester.endDate) < new Date('1971-01-01')
                       ) && (
                         <span style={{ color: 'red', marginLeft: 6 }}>
-                          (ended)
+                          (ended {dayjs(semester.endDate).fromNow()})
                         </span>
                       )}
                   </Select.Option>

--- a/packages/frontend/app/(dashboard)/components/EditCourseForm.tsx
+++ b/packages/frontend/app/(dashboard)/components/EditCourseForm.tsx
@@ -44,7 +44,7 @@ const EditCourseForm: React.FC<EditCourseFormProps> = ({
     const coordinatorEmailField = formValues.coordinatorEmail
     const sectionGroupNameField = formValues.sectionGroupName
     const zoomLinkField = formValues.zoomLink
-    const courseTimezoneField = formValues.courseTimezone
+    // const courseTimezoneField = formValues.courseTimezone
     const semesterIdField = formValues.semesterId
     const profIdsField = isAdmin ? formValues.professorsUserId : [user.id]
 
@@ -53,7 +53,7 @@ const EditCourseForm: React.FC<EditCourseFormProps> = ({
       coordinatorEmailField === courseData.course?.coordinator_email &&
       sectionGroupNameField === courseData.course?.sectionGroupName &&
       zoomLinkField === courseData.course?.zoomLink &&
-      courseTimezoneField === courseData.course?.timezone &&
+      // courseTimezoneField === courseData.course?.timezone &&
       semesterIdField === courseData.course?.semester?.id &&
       profIdsField === courseData.profIds
     ) {
@@ -74,10 +74,10 @@ const EditCourseForm: React.FC<EditCourseFormProps> = ({
       return
     }
 
-    if (courseData.course?.timezone && courseTimezoneField.length < 1) {
-      message.error('Course timezone cannot be empty')
-      return
-    }
+    // if (courseData.course?.timezone && courseTimezoneField.length < 1) {
+    //   message.error('Course timezone cannot be empty')
+    //   return
+    // }
 
     if (
       !Array.isArray(profIdsField) ||
@@ -98,7 +98,7 @@ const EditCourseForm: React.FC<EditCourseFormProps> = ({
         coordinator_email: coordinatorEmailField ?? '',
         sectionGroupName: sectionGroupNameField,
         zoomLink: zoomLinkField ?? '',
-        timezone: courseTimezoneField,
+        timezone: courseData.course?.timezone,
         semesterId: semesterIdField,
         profIds: profIdsField,
       })
@@ -145,7 +145,7 @@ const EditCourseForm: React.FC<EditCourseFormProps> = ({
             coordinatorEmail: courseData.course?.coordinator_email,
             sectionGroupName: courseData.course?.sectionGroupName,
             zoomLink: courseData.course?.zoomLink,
-            courseTimezone: courseData.course?.timezone,
+            // courseTimezone: courseData.course?.timezone,
             semesterId: courseData.course?.semester?.id ?? -1,
             professorsUserId: courseData.profIds,
           }}
@@ -220,7 +220,7 @@ const EditCourseForm: React.FC<EditCourseFormProps> = ({
           </div>
 
           <div className="flex flex-col md:flex-row md:space-x-3">
-            <Form.Item
+            {/* <Form.Item
               label="Course Timezone"
               name="courseTimezone"
               tooltip="Timezone of the course"
@@ -233,7 +233,7 @@ const EditCourseForm: React.FC<EditCourseFormProps> = ({
                   </Select.Option>
                 ))}
               </Select>
-            </Form.Item>
+            </Form.Item> */}
 
             <Form.Item
               label="Semester"

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_knowledge_base/page.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_knowledge_base/page.tsx
@@ -137,12 +137,6 @@ export default function ChatbotKnowledgeBase(
             prefetch={false}
             rel="noopener noreferrer"
           >
-            {/*
-              In some environments, components which return Promises or arrays do not work.
-              This is due to some changes to react and @types/react, and the component
-              packages have not been updated to fix these issues.
-            */}
-            {/* @ts-expect-error Server Component */}
             <Highlighter
               highlightStyle={{ backgroundColor: '#ffc069', padding: 0 }}
               searchWords={[search]}
@@ -159,12 +153,6 @@ export default function ChatbotKnowledgeBase(
       key: 'pageContent',
       render: (text: string) => (
         <ExpandableText maxRows={4}>
-          {/*
-              In some environments, components which return Promises or arrays do not work.
-              This is due to some changes to react and @types/react, and the component
-              packages have not been updated to fix these issues.
-            */}
-          {/* @ts-expect-error Server Component */}
           <Highlighter
             highlightStyle={{ backgroundColor: '#ffc069', padding: 0 }}
             searchWords={[search]}

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_questions/page.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_questions/page.tsx
@@ -133,12 +133,6 @@ export default function ChatbotQuestions(
       },
       render: (text: string) => (
         <ExpandableText maxRows={3}>
-          {/*
-              In some environments, components which return Promises or arrays do not work.
-              This is due to some changes to react and @types/react, and the component
-              packages have not been updated to fix these issues.
-            */}
-          {/* @ts-expect-error Server Component */}
           <Highlighter
             highlightStyle={{ backgroundColor: '#ffc069', padding: 0 }}
             searchWords={[search]}
@@ -177,12 +171,7 @@ export default function ChatbotQuestions(
                 </span>
               </Tooltip>
             )}
-            {/*
-              In some environments, components which return Promises or arrays do not work.
-              This is due to some changes to react and @types/react, and the component
-              packages have not been updated to fix these issues.
-            */}
-            {/* @ts-expect-error Server Component */}
+
             <Highlighter
               highlightStyle={{ backgroundColor: '#ffc069', padding: 0 }}
               searchWords={[search]}

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_settings/components/AddChatbotDocumentModal.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_settings/components/AddChatbotDocumentModal.tsx
@@ -120,8 +120,8 @@ const AddChatbotDocumentModal: React.FC<AddChatbotDocumentModalProps> = ({
         }
       },
       {
-        successMsg: `${file.name} uploaded and processed!`,
-        errorMsg: `Failed to upload/process ${file.name}`,
+        successMsg: `${file?.name || 'A file'} was uploaded and processed!`,
+        errorMsg: `Failed to upload/process ${file?.name || 'a file'}`,
         appendApiError: true,
         successDuration: 3500,
       },

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_settings/page.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/chatbot_settings/page.tsx
@@ -115,7 +115,7 @@ export default function ChatbotSettings(
           This is due to some changes to react and @types/react, and the component
           packages have not been updated to fix these issues.
         */}
-          {/* @ts-expect-error Server Component */}
+
           <Highlighter
             highlightStyle={{ backgroundColor: '#ffc069', padding: 0 }}
             searchWords={[search]}

--- a/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/edit_questions/page.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/(settings)/settings/edit_questions/page.tsx
@@ -333,12 +333,6 @@ const EditQuestionsPage: React.FC<EditQuestionsPageProps> = (props) => {
       } else {
         return searchedColumn === dataIndex ? (
           <>
-            {/*
-              In some environments, components which return Promises or arrays do not work.
-              This is due to some changes to react and @types/react, and the component
-              packages have not been updated to fix these issues.
-            */}
-            {/* @ts-expect-error Server Component */}
             <Highlighter
               highlightStyle={{ backgroundColor: '#ffc069', padding: 0 }}
               searchWords={[searchText]}

--- a/packages/frontend/app/(dashboard)/course/[cid]/async_centre/components/modals/ConvertChatbotQToAnytimeQModal.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/async_centre/components/modals/ConvertChatbotQToAnytimeQModal.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, useEffect } from 'react'
-import { Modal, Input, Form, message, Checkbox, Tooltip } from 'antd'
+import { Modal, Input, Form, message, Checkbox, Tooltip, Spin } from 'antd'
 import { useUserInfo } from '@/app/contexts/userContext'
 import { useQuestionTypes } from '@/app/hooks/useQuestionTypes'
 import { QuestionTagSelector } from '../../../components/QuestionTagElement'
@@ -16,6 +16,8 @@ interface FormValues {
   questionText: string
   questionTypesInput: number[]
   refreshAIAnswer: boolean
+  setVisible: boolean
+  setAnonymous: boolean
 }
 
 interface ConvertChatbotQToAnytimeQModalProps {
@@ -34,6 +36,7 @@ const ConvertChatbotQToAnytimeQModal: React.FC<
   const [form] = Form.useForm()
   const [isLoading, setIsLoading] = useState(false)
   const courseFeatures = useCourseFeatures(courseId)
+  const authorCanSetVisible = courseFeatures?.asyncCentreAuthorPublic ?? false
   const [isGeneratingAbstract, setIsGeneratingAbstract] = useState(false)
 
   const userQuestionText = useMemo(() => {
@@ -162,6 +165,8 @@ const ConvertChatbotQToAnytimeQModal: React.FC<
           answerText: aiAnswer,
           questionAbstract: values.QuestionAbstract,
           status: asyncQuestionStatus.AIAnsweredNeedsAttention,
+          isAnonymous: values.setAnonymous,
+          authorSetVisible: authorCanSetVisible ? values.setVisible : false,
         },
         courseId,
       )
@@ -215,6 +220,10 @@ const ConvertChatbotQToAnytimeQModal: React.FC<
           layout="vertical"
           form={form}
           name="form_in_modal"
+          initialValues={{
+            setVisible: false,
+            setAnonymous: courseFeatures?.asyncCentreDefaultAnonymous ?? true,
+          }}
           clearOnDestroy
           onFinish={(values) => onFinish(values)}
         >
@@ -267,6 +276,30 @@ const ConvertChatbotQToAnytimeQModal: React.FC<
           <QuestionTagSelector questionTags={questionTypes} />
         </Form.Item>
       )}
+      {authorCanSetVisible && (
+        <Form.Item
+          name="setVisible"
+          label="Show Publicly?"
+          tooltip={
+            'Allows other students to see your question, and maybe even give you help via comments. Note that Course Staff can make questions public or private regardless of this setting.'
+          }
+          valuePropName="checked"
+          layout="horizontal"
+        >
+          <Checkbox />
+        </Form.Item>
+      )}
+      <Form.Item
+        name="setAnonymous"
+        label="Appear Anonymous?"
+        tooltip={
+          'If toggled, your name and avatar will not be shown with the question. Staff members will still see who you are.'
+        }
+        layout="horizontal"
+        valuePropName="checked"
+      >
+        <Checkbox />
+      </Form.Item>
       {courseFeatures?.asyncCentreAIAnswers && (
         <Tooltip
           placement="topLeft"
@@ -287,11 +320,6 @@ const ConvertChatbotQToAnytimeQModal: React.FC<
           </Form.Item>
         </Tooltip>
       )}
-      <div className="text-gray-500">
-        Only you and faculty will be able to see your question unless a faculty
-        member chooses to mark it public, in which case it will appear fully
-        anonymous to other students.
-      </div>
     </Modal>
   )
 }

--- a/packages/frontend/app/(dashboard)/course/[cid]/async_centre/components/modals/ConvertQueueQToAnytimeQModal.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/async_centre/components/modals/ConvertQueueQToAnytimeQModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Form, Input, message, Modal, Spin, Tooltip } from 'antd'
+import { Checkbox, Form, Input, message, Modal, Spin, Tooltip } from 'antd'
 import { useUserInfo } from '@/app/contexts/userContext'
 import { useQuestionTypes } from '@/app/hooks/useQuestionTypes'
 import { QuestionTagSelector } from '../../../components/QuestionTagElement'
@@ -18,6 +18,8 @@ interface FormValues {
   questionText: string
   questionTypesInput: number[]
   refreshAIAnswer: boolean
+  setVisible: boolean
+  setAnonymous: boolean
 }
 
 interface ConvertQueueQToAnytimeQModalProps {
@@ -41,6 +43,7 @@ const ConvertQueueQToAnytimeQModal: React.FC<
 }) => {
   const { userInfo } = useUserInfo()
   const courseFeatures = useCourseFeatures(courseId)
+  const authorCanSetVisible = courseFeatures?.asyncCentreAuthorPublic ?? false
   const [form] = Form.useForm()
   const [isLoading, setIsLoading] = useState(false)
   const [initialLoading, setInitialLoading] = useState(false)
@@ -61,9 +64,17 @@ const ConvertQueueQToAnytimeQModal: React.FC<
       const fetchQuestion = async () => {
         setInitialLoading(true)
         try {
-          const myQuestion = await API.questions.update(queueQuestionId, {})
+          const myQuestion = await API.questions
+            .update(queueQuestionId, {})
+            .catch((err) => {
+              console.error(
+                'Failed to load queue question data: ' + getErrorMessage(err),
+              )
+              message.error(
+                'Failed to load queue question data: ' + getErrorMessage(err),
+              )
+            })
           if (!myQuestion?.text) {
-            message.error('Failed to load question data.')
             setInitialLoading(false)
             return
           }
@@ -147,6 +158,8 @@ const ConvertQueueQToAnytimeQModal: React.FC<
           questionText: values.questionText,
           questionAbstract: values.QuestionAbstract,
           status: asyncQuestionStatus.AIAnsweredNeedsAttention,
+          isAnonymous: values.setAnonymous,
+          authorSetVisible: authorCanSetVisible ? values.setVisible : false,
         },
         courseId,
       )
@@ -218,6 +231,10 @@ const ConvertQueueQToAnytimeQModal: React.FC<
           layout="vertical"
           form={form}
           name="form_in_modal"
+          initialValues={{
+            setVisible: false,
+            setAnonymous: courseFeatures?.asyncCentreDefaultAnonymous ?? true,
+          }}
           clearOnDestroy
           onFinish={(values) => onFinish(values)}
         >
@@ -274,11 +291,30 @@ const ConvertQueueQToAnytimeQModal: React.FC<
           <QuestionTagSelector questionTags={anytimeQuestionTypes} />
         </Form.Item>
       )}
-      <div className="text-gray-500">
-        Only you and faculty will be able to see your question unless a faculty
-        member chooses to mark it public, in which case it will appear fully
-        anonymous to other students.
-      </div>
+      {authorCanSetVisible && (
+        <Form.Item
+          name="setVisible"
+          label="Show Publicly?"
+          tooltip={
+            'Allows other students to see your question, and maybe even give you help via comments. Note that Course Staff can make questions public or private regardless of this setting.'
+          }
+          valuePropName="checked"
+          layout="horizontal"
+        >
+          <Checkbox />
+        </Form.Item>
+      )}
+      <Form.Item
+        name="setAnonymous"
+        label="Appear Anonymous?"
+        tooltip={
+          'If toggled, your name and avatar will not be shown with the question. Staff members will still see who you are.'
+        }
+        layout="horizontal"
+        valuePropName="checked"
+      >
+        <Checkbox />
+      </Form.Item>
     </Modal>
   )
 }

--- a/packages/frontend/app/(dashboard)/course/[cid]/async_centre/components/modals/CreateAsyncQuestionModal.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/async_centre/components/modals/CreateAsyncQuestionModal.tsx
@@ -360,7 +360,7 @@ const CreateAsyncQuestionModal: React.FC<CreateAsyncQuestionModalProps> = ({
           name="setVisible"
           label="Show Publicly?"
           tooltip={
-            'Let staff know whether you want your question to be visible to other students. Staff can make questions public regardless of this setting.'
+            'Allows other students to see your question, and maybe even give you help via comments. Note that Course Staff can make questions public or private regardless of this setting.'
           }
           valuePropName="checked"
           layout="horizontal"

--- a/packages/frontend/app/(dashboard)/course/[cid]/components/CreateQueueModal.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/components/CreateQueueModal.tsx
@@ -180,7 +180,7 @@ const CreateQueueModal: React.FC<CreateQueueModalProps> = ({
         label={
           <span>
             <span>
-              <span className="mr-1">Queue Config</span>
+              <span className="mr-1">Queue Config (Optional)</span>
               <Tooltip
                 title={
                   'Here you can specify a JSON config to automatically set up question tags, tasks, and other settings for the queue. For example, you can use this to set up a chemistry lab that requires certain tasks to be checked off (e.g. have the TA look at the experiment before continuing). You can also easily externally save this config and copy/paste this config to other queues and courses.'

--- a/packages/frontend/app/(dashboard)/course/[cid]/components/popularTimes/TimeGraph.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/components/popularTimes/TimeGraph.tsx
@@ -184,7 +184,6 @@ const TimeGraph: React.FC<TimeGraphProps> = ({
 
       {tooltipOpen && tooltipData && (
         <>
-          {/* @ts-expect-error Server Component */}
           <TooltipInPortal
             key={Math.random()} // update tooltip bounds each render
             top={tooltipTop}

--- a/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/page.tsx
+++ b/packages/frontend/app/(dashboard)/course/[cid]/queue/[qid]/page.tsx
@@ -937,10 +937,10 @@ export default function QueuePage(props: QueuePageProps): ReactElement {
               The reason there are filters here is because students need to be able to see these too
             */
             questionsGettingHelp={queueQuestions.questionsGettingHelp.filter(
-              (q) => q.status == 'Helping',
+              (q) => q.status == OpenQuestionStatus.Helping,
             )}
             pausedQuestions={queueQuestions.questionsGettingHelp.filter(
-              (q) => q.status == 'Paused',
+              (q) => q.status == OpenQuestionStatus.Paused,
             )}
             cid={cid}
             qid={qid}

--- a/packages/frontend/app/(dashboard)/organization/course/add/page.tsx
+++ b/packages/frontend/app/(dashboard)/organization/course/add/page.tsx
@@ -6,11 +6,14 @@ import {
   Card,
   Checkbox,
   Col,
+  Divider,
   Form,
   Input,
   message,
   Row,
+  Segmented,
   Select,
+  Tooltip,
 } from 'antd'
 import { ReactElement, useEffect, useState } from 'react'
 import {
@@ -31,6 +34,7 @@ import {
 import { formatSemesterDate } from '@/app/utils/timeFormatUtils'
 import { useOrganizationSettings } from '@/app/hooks/useOrganizationSettings'
 import ProfessorSelector from '@/app/(dashboard)/components/ProfessorSelector'
+import { useMediaQuery } from '@/app/hooks/useMediaQuery'
 
 interface FormValues {
   courseName: string
@@ -44,6 +48,7 @@ interface FormValues {
   queueEnabled: boolean
   asyncQueueEnabled: boolean
   asyncCentreAIAnswers: boolean
+  asyncCentreAuthorPublic: 'discussionBoard' | 'curatedListOfQuestions'
   scheduleOnFrontPage: boolean
 }
 
@@ -61,6 +66,12 @@ export default function AddCoursePage(): ReactElement {
     userInfo.organization?.orgId ?? -1,
   )
   const [isCourseNameTooLong, setIsCourseNameTooLong] = useState(false)
+
+  const isCertainlyNotMobile = useMediaQuery('(min-width: 992px)')
+  const [
+    isAnytimeQuestionsUseCaseDisabled,
+    setIsAnytimeQuestionsUseCaseDisabled,
+  ] = useState(false)
 
   const isAdmin =
     userInfo &&
@@ -130,6 +141,10 @@ export default function AddCoursePage(): ReactElement {
       { feature: 'queueEnabled', value: values.queueEnabled },
       { feature: 'asyncQueueEnabled', value: values.asyncQueueEnabled },
       { feature: 'asyncCentreAIAnswers', value: values.asyncCentreAIAnswers },
+      {
+        feature: 'asyncCentreAuthorPublic',
+        value: values.asyncCentreAuthorPublic !== 'curatedListOfQuestions',
+      },
       { feature: 'scheduleOnFrontPage', value: values.scheduleOnFrontPage },
     ]
 
@@ -193,12 +208,17 @@ export default function AddCoursePage(): ReactElement {
                   chatBotEnabled: true,
                   queueEnabled: true,
                   asyncQueueEnabled: true,
+                  asyncCentreAuthorPublic: 'discussionBoard',
                   asyncCentreAIAnswers: true,
                   scheduleOnFrontPage: false,
                 }}
                 onValuesChange={(changedValues) => {
                   if (changedValues.asyncQueueEnabled === false) {
+                    setIsAnytimeQuestionsUseCaseDisabled(true)
                     form.setFieldsValue({ asyncCentreAIAnswers: false })
+                  } else if (changedValues.asyncQueueEnabled === true) {
+                    setIsAnytimeQuestionsUseCaseDisabled(false)
+                    form.setFieldsValue({ asyncCentreAIAnswers: true })
                   }
                   if (changedValues.courseName) {
                     if (changedValues.courseName.length > 14) {
@@ -323,60 +343,150 @@ export default function AddCoursePage(): ReactElement {
                       </Form.Item>
                     )}
                   </Col>
-                  <Col xs={{ span: 24 }} sm={{ span: 12 }}>
-                    <div className="flex flex-wrap gap-x-4 md:gap-x-8">
-                      <Form.Item
-                        label="Chatbot"
-                        layout="horizontal"
-                        valuePropName="checked"
-                        name="chatBotEnabled"
-                        tooltip="This feature allows students to ask an AI chatbot questions that will answer their questions based on uploaded course content (located in course admin settings)"
-                      >
-                        <Checkbox />
-                      </Form.Item>
-                      <Form.Item
-                        label="Queues"
-                        valuePropName="checked"
-                        layout="horizontal"
-                        name="queueEnabled"
-                        tooltip="This feature allows students to ask questions in a queue that can then be answered by the professor or a TA. Suitable for online, hybrid, and in-person office hours and labs."
-                      >
-                        <Checkbox />
-                      </Form.Item>
-                      <Form.Item
-                        label="Anytime Question Hub"
-                        valuePropName="checked"
-                        layout="horizontal"
-                        name="asyncQueueEnabled"
-                        tooltip="This feature allows students to ask questions asynchronously (e.g. outside of office hours or labs) that can then be answered by the professor. It also features automatic AI-generated answers based on uploaded course content."
-                      >
-                        <Checkbox />
-                      </Form.Item>
-                      <Form.Item
-                        label="Anytime Question AI Answers"
-                        valuePropName="checked"
-                        layout="horizontal"
-                        name="asyncCentreAIAnswers"
-                        tooltip="This feature will enable students question's to immediately get an AI answer when they ask it (on the Anytime Question Hub). From there, students can ask if they are satisfied or still need help with it, in which staff can then edit the answer or verify it."
-                      >
-                        <Checkbox />
-                      </Form.Item>
-                      <Form.Item
-                        label="Schedule on Home Course Page"
-                        valuePropName="checked"
-                        layout="horizontal"
-                        name="scheduleOnFrontPage"
-                        tooltip="By default, a chatbot is displayed on the home course page. Enabling this will replace that chatbot with a preview of today's schedule and show a little 'chat now!' widget for the chatbot like other pages. Choose this option if you think it is more valuable for students to see today's event schedule over a large chatbot component."
-                      >
-                        <Checkbox />
-                      </Form.Item>
+                  <Col xs={{ span: 24 }} sm={{ span: 24 }}>
+                    <h3 className="text-lg font-semibold">Features</h3>
+                    <div className="flex min-w-full flex-col gap-2 md:min-w-[34rem]">
+                      <div className="w-full">
+                        <Form.Item
+                          labelCol={{ xs: 20, md: 18, lg: 12, xl: 6 }}
+                          wrapperCol={{ xs: 4, md: 6, lg: 12, xl: 18 }}
+                          label="Chatbot"
+                          layout="horizontal"
+                          valuePropName="checked"
+                          name="chatBotEnabled"
+                          tooltip="This feature allows students to ask an AI chatbot questions that will answer their questions based on uploaded course content (located in course admin settings)"
+                        >
+                          <Checkbox />
+                        </Form.Item>
+                        <Divider
+                          className="mx-auto w-1/2 min-w-40 border-gray-300 "
+                          size="small"
+                          variant="dashed"
+                        />
+                      </div>
+                      <div className="w-full">
+                        <Form.Item
+                          labelCol={{ xs: 20, md: 18, lg: 12, xl: 6 }}
+                          wrapperCol={{ xs: 4, md: 6, lg: 12, xl: 18 }}
+                          label="Queues"
+                          valuePropName="checked"
+                          className="mb-2"
+                          layout="horizontal"
+                          name="queueEnabled"
+                          tooltip="This feature allows students to ask questions in a queue that can then be answered by the professor or a TA. Suitable for online, hybrid, and in-person office hours and labs."
+                        >
+                          <Checkbox />
+                        </Form.Item>
+                        <Form.Item
+                          labelCol={{ xs: 20, md: 18, lg: 12, xl: 6 }}
+                          wrapperCol={{ xs: 4, md: 6, lg: 12, xl: 18 }}
+                          label={
+                            <span className="font-normal">
+                              Schedule on Home Course Page
+                            </span>
+                          }
+                          valuePropName="checked"
+                          layout="horizontal"
+                          name="scheduleOnFrontPage"
+                          tooltip="By default, a chatbot is displayed on the home course page. Enabling this will replace that chatbot with a preview of today's schedule and show a little 'Chatbot' widget for the chatbot like other pages. Choose this option if you think it is more valuable for students to see today's event schedule over a large chatbot component."
+                        >
+                          <Checkbox />
+                        </Form.Item>
+                        <Divider
+                          className="mx-auto w-1/2 min-w-40 border-gray-300 "
+                          size="small"
+                          variant="dashed"
+                        />
+                      </div>
+                      <div className="w-full">
+                        <Form.Item
+                          labelCol={{ xs: 20, md: 18, lg: 12, xl: 6 }}
+                          wrapperCol={{ xs: 4, md: 6, lg: 12, xl: 18 }}
+                          label="Anytime Question Hub"
+                          valuePropName="checked"
+                          layout="horizontal"
+                          className="mb-2"
+                          name="asyncQueueEnabled"
+                          tooltip="This feature will enable students question's to immediately get an AI answer when they ask it (on the Anytime Question Hub). From there, students can ask if they are satisfied or still need help with it, in which staff can then edit the answer or verify it. Utilizes the Course Chatbot and pairs great with it for Human In The Loop Support. All students are default anonymous to other students."
+                        >
+                          <Checkbox />
+                        </Form.Item>
+                        <Form.Item
+                          labelCol={{ xs: 20, md: 18, lg: 12, xl: 6 }}
+                          wrapperCol={{ xs: 4, md: 6, lg: 12, xl: 18 }}
+                          label={
+                            <span className="font-normal">AI Answers</span>
+                          }
+                          valuePropName="checked"
+                          layout="horizontal"
+                          className="mb-2"
+                          name="asyncCentreAIAnswers"
+                          tooltip="Anytime Questions first get an AI answer from the Course Chatbot. You can disable this feature if you want Anytime Questions to be a discussion board without AI."
+                        >
+                          <Checkbox />
+                        </Form.Item>
+                        <Form.Item
+                          labelCol={{ xs: 24, md: 24, lg: 10, xl: 6 }}
+                          wrapperCol={{ xs: 24, md: 24, lg: 14, xl: 18 }}
+                          label={<span className="font-normal">Use Case</span>}
+                          valuePropName="checked"
+                          layout={
+                            isCertainlyNotMobile ? 'horizontal' : 'vertical'
+                          }
+                          name="asyncCentreAuthorPublic"
+                          tooltip={
+                            <div className="flex flex-col gap-2">
+                              <p>
+                                This is if you want to have your Anytime
+                                Question Hub work more as a traditional
+                                discussion board vs a professor/TA curated list
+                                of questions. The only thing this changes is
+                                whether students are able to make their own
+                                questions visible to other students.
+                              </p>
+                              <p>
+                                Note that if you choose Discussion Board,
+                                don&apos;t forget to encourage your students to
+                                use it!
+                              </p>
+                            </div>
+                          }
+                        >
+                          <Segmented
+                            disabled={isAnytimeQuestionsUseCaseDisabled}
+                            options={[
+                              {
+                                label: (
+                                  <Tooltip title="Allow students to make their questions visible to other students, allowing them to help each other without involvement from course staff (default).">
+                                    Discussion Board
+                                  </Tooltip>
+                                ),
+                                value: 'discussionBoard',
+                              },
+                              {
+                                label: (
+                                  <Tooltip title="All questions start private. After verifying, course staff can choose to make questions visible to other students if they think it's a good question.">
+                                    Curated List of Questions
+                                  </Tooltip>
+                                ),
+                                value: 'curatedListOfQuestions',
+                              },
+                            ]}
+                          />
+                        </Form.Item>
+                        <Divider
+                          className="mx-auto w-1/2 min-w-40 border-gray-300 "
+                          size="small"
+                          variant="dashed"
+                        />
+                      </div>
                     </div>
                   </Col>
                 </Row>
                 <Row>
-                  <Col xs={{ span: 24 }} sm={{ span: 12 }}>
-                    <Form.Item>
-                      <Button type="primary" htmlType="submit">
+                  <Col xs={{ span: 24 }} sm={{ span: 24 }}>
+                    <Form.Item className="mb-0 mt-2 justify-self-center">
+                      <Button type="primary" htmlType="submit" size="large">
                         Add Course
                       </Button>
                     </Form.Item>

--- a/packages/frontend/app/(dashboard)/organization/course/add/page.tsx
+++ b/packages/frontend/app/(dashboard)/organization/course/add/page.tsx
@@ -14,7 +14,6 @@ import {
 } from 'antd'
 import { ReactElement, useEffect, useState } from 'react'
 import {
-  COURSE_TIMEZONES,
   GetOrganizationResponse,
   OrganizationProfessor,
   OrganizationRole,
@@ -123,7 +122,7 @@ export default function AddCoursePage(): ReactElement {
     const coordinatorEmailField = values.coordinatorEmail
     const sectionGroupNameField = values.sectionGroupName
     const zoomLinkField = values.zoomLink
-    const courseTimezoneField = values.courseTimezone
+    // const courseTimezoneField = values.courseTimezone
     const semesterIdField = values.semesterId
     const profIds = isAdmin ? values.professorsUserId : [userInfo.id]
     const courseFeatures = [
@@ -140,7 +139,7 @@ export default function AddCoursePage(): ReactElement {
         coordinator_email: coordinatorEmailField ?? '',
         sectionGroupName: sectionGroupNameField ?? '',
         zoomLink: zoomLinkField ?? '',
-        timezone: courseTimezoneField,
+        timezone: 'America/Los_Angeles', // courseTimezoneField
         semesterId: semesterIdField,
         profIds: profIds,
         courseSettings: courseFeatures,
@@ -190,7 +189,7 @@ export default function AddCoursePage(): ReactElement {
                 layout="vertical"
                 onFinish={(values) => onFinish(values)}
                 initialValues={{
-                  courseTimezone: 'America/Los_Angeles',
+                  // courseTimezone: 'America/Los_Angeles',
                   chatBotEnabled: true,
                   queueEnabled: true,
                   asyncQueueEnabled: true,
@@ -267,7 +266,7 @@ export default function AddCoursePage(): ReactElement {
                     </Form.Item>
                   </Col>
 
-                  <Col xs={{ span: 24 }} sm={{ span: 12 }}>
+                  {/* <Col xs={{ span: 24 }} sm={{ span: 12 }}>
                     <Form.Item
                       label="Course Timezone"
                       name="courseTimezone"
@@ -281,7 +280,7 @@ export default function AddCoursePage(): ReactElement {
                         ))}
                       </Select>
                     </Form.Item>
-                  </Col>
+                  </Col> */}
 
                   <Col xs={{ span: 24 }} sm={{ span: 12 }}>
                     <Form.Item

--- a/packages/frontend/app/(dashboard)/profile/components/EditProfile.tsx
+++ b/packages/frontend/app/(dashboard)/profile/components/EditProfile.tsx
@@ -173,7 +173,11 @@ const EditProfile: React.FC = () => {
 
             <Row gutter={{ xs: 8, sm: 16, md: 24, lg: 32 }}>
               <Col xs={{ span: 24 }} sm={{ span: 12 }}>
-                <Form.Item label="Name Pronunciation" name="namePronunciation">
+                <Form.Item
+                  label="Name Pronunciation"
+                  name="namePronunciation"
+                  tooltip="Lets course staff inside queues see how to pronounce your name. Use capital letters to indicate the primary stress (emphasis) of your name."
+                >
                   <Input placeholder="Example: uh-LEE-shuh" />
                 </Form.Item>
               </Col>

--- a/packages/frontend/app/components/Markdown.tsx
+++ b/packages/frontend/app/components/Markdown.tsx
@@ -54,12 +54,6 @@ const MarkdownCustom: React.FC<MarkdownCustomProps> = ({
           const match = /language-(\w+)/.exec(className || '')
           return !inline && match ? (
             <>
-              {/*
-              In some environments, components which return Promises or arrays do not work.
-              This is due to some changes to react and @types/react, and the component
-              packages have not been updated to fix these issues.
-            */}
-              {/* @ts-expect-error Server Component */}
               <SyntaxHighlighter
                 style={
                   variant === 'blue'

--- a/packages/frontend/app/globals.css
+++ b/packages/frontend/app/globals.css
@@ -307,8 +307,10 @@ It is used for displaying markdown nicely inside any <Markdown> components
   margin-left: 1.5em;
 }
 .childrenMarkdownFormatted p {
-  margin-bottom: 0.5em;
   margin-bottom: 0.75em;
+}
+.childrenMarkdownFormatted li p, .childrenMarkdownFormatted p:last-child {
+  margin-bottom: 0; 
 }
 .childrenMarkdownFormatted h1 {
   font-size: 1.5em;

--- a/packages/frontend/app/qi/[qid]/page.tsx
+++ b/packages/frontend/app/qi/[qid]/page.tsx
@@ -121,13 +121,13 @@ export default function QueueInvitePage(
   // if questions are enabled, dynamically set the queue size, otherwise set it to queueInvite.queueSize
   useEffect(() => {
     if (queueInviteInfo) {
-      if (queueInviteInfo.isQuestionsVisible && queue) {
-        setQueueSize(queue.queueSize)
+      if (queueInviteInfo.isQuestionsVisible) {
+        setQueueSize(queueQuestions?.questions.length ?? queue?.queueSize ?? 0)
       } else {
         setQueueSize(queueInviteInfo.queueSize)
       }
     }
-  }, [queue, queueInviteInfo])
+  }, [queue, queueInviteInfo, queueQuestions])
 
   const isHttps =
     (typeof window !== 'undefined' && window.location.protocol) === 'https:'

--- a/packages/frontend/public/actually_public/changelog.md
+++ b/packages/frontend/public/actually_public/changelog.md
@@ -1,19 +1,68 @@
-## Version 1.9.0 - 
+## Version 1.9.0 - New Landing Page, Weekly Summary Emails, Save to Chatbot, and More
 
-*April ..., 2026*
+*July 1st, 2026 - Happy Canada Day!*
 
 #### New Features
 
 - ***General***
-  - 
+  - Reworked the [landing page](https://coursehelp.ubc.ca/)
+	  - Now with a lot more information and screenshots
+  - Added an [About](https://coursehelp.ubc.ca/about) page
+	  - Has our Privacy Policy, Terms of Service, Changelog, an FAQ, our team, and more
+  - Course Staff can now "Endorse" Anytime Question Comments
+	  - Endorsed comments appear first
+	  - Useful if you have "Allow Anytime Question Authors to make their Questions Public" enabled under Course Settings and you encourage your students to help each other
+
 - ***Faculty-only***
-  - 
+  - Added Weekly Summary emails for professors
+	  - Includes activity, any pending Anytime Questions, and recommendations
+  - Added a "Save to Chatbot" feature when posting a response to an Anytime Question
+	  - Allows your Chatbot to keep getting better as it gets used
+  - Added a "Export Tool Usage to CSV" button under Course Settings → Export Data
+	  - Could be used to chart what tools (Chatbot, Anytime Questions, Queues) each student is using over time
+	  - Could be used to assign participation marks
+  - Added "Professor Invites"
+	  - Works as a regular course invite except it promotes the user to a professor right away
+	  - Useful if you are creating the course for a fellow professor
 
 #### Improvements
 
+- **Fixed the refresh_token: not found issue** (probably)
+	- You will need to re-create your Canvas integration one last time: Course Settings → LMS Integrations → Delete → Create LMS Integration with Canvas
+	- Let me know if you encounter any issues with it - Adam
+- Anytime Questions now shows "+X additional private question(s)" with improved text for when no questions have been posted
+	- Students naturally ask questions in areas with the most activity, and letting them know that other students have been asking Anytime questions should help increase activity 
+- Students may now specify how to pronounce their name under Profile Settings
+- Clarified a lot of the text around LMS integrations
+- Anytime Questions are now paginated
+- Added a "There are no queues in this course" in the Queues dropdown, with instructions for creating new queues for professors
+- TA Check In/Out Times page now shows when TAs mark themselves "Away" 
+- Changed the "Unhappy with your answer? Convert to an Anytime Question" text to "Discuss or verify this with your professor/TA: Convert to Anytime Question"
+	- Also added a "Continue Navigation" confirmation popup
+- Added the ability for professors to permanently delete their courses (as opposed to "archiving" them) - useful for accidentally created courses
+- Fixed an issue where users would not get redirected to their course invite after verifying their email
+- Added a button that lets you clear the cache for your backend profile (under Profile → Advanced), which might be helpful if you notice certain pieces of UI not updating when they should
+- Added a "Access denied" message when trying to access a course page you lack access to instead of an infinite spinner
 - Fixed an issue in the registration form where the "UBC email detected! Consider continuing with UBC" message would not appear
-
-
+- After creating a course, now receives a highlight to make it easier to see on My Courses page
+- Fixed an issue with Anytime Questions where the "Set question visible to all students" toggle would sometimes default to "Visible" despite showing "Hidden"
+- Added a feature for LLED courses for AI Assignment Feedback (under Course Settings → Scroll down to Advanced). See its help tooltip for more info.
+- Fixed an issue where the "Test Course" Semester would not show up when creating courses (and made it not show as "ended")
+- Re-arranged Course Features (under Course Settings) to be easier to digest
+- Added an "Advanced" divider to Course Settings, amongst other re-arrangements
+- Fixed the Profile → Course Preferences table from overflowing on mobile
+- Added a new "name" field when manually creating new chatbot knowledge base chunks (previously, all chunks were given the name "Manually Inserted Information" - this lets you customize it)
+- Fixed an issue where course professors that lacked the "Organization Professor" role could not create an LMS/Canvas integration for their course
+- Various improvements for Admins:
+	- Professor Selectors now show the user's email and the search now works
+	- Users Table now paginated
+	- Users Table now searches by email *or* name
+	- Courses Table now has more information and is sortable
+- Minor: started keeping track of when more things are created: enrollments, question types, queue invites, queues, semesters, organizations, users, and courses.
+- Fixed a minor issue where 'helping student in another course' was not working for queue invites
+- Fixed a minor issue where the Checkout button on the course page would only check you out of 1 queue instead of all
+- Various security improvements
+- Various small UI fixes and adjustments
 ***
 
 ## Version 1.8.0 - Canvas Chatbot Embed, Away Toggle

--- a/packages/frontend/public/actually_public/changelog.md
+++ b/packages/frontend/public/actually_public/changelog.md
@@ -65,6 +65,7 @@
 - Fixed a minor issue where the Checkout button on the course page would only check you out of 1 queue instead of all
 - Various security improvements
 - Various small UI fixes and adjustments
+
 ***
 
 ## Version 1.8.0 - Canvas Chatbot Embed, Away Toggle

--- a/packages/frontend/public/actually_public/changelog.md
+++ b/packages/frontend/public/actually_public/changelog.md
@@ -55,6 +55,9 @@
 - Fixed an issue where the "Test Course" Semester would not show up when creating courses (and made it not show as "ended")
 - Re-arranged Course Features (under Course Settings) to be easier to digest
 - Added an "Advanced" divider to Course Settings, amongst other re-arrangements
+- Removed the Course Timezone field when created/editing courses since it's unused
+- Re-arranged the features in the Add Course form
+- Edit Course Form Semester Selector now shows how long ago a semester ended
 - Fixed the Profile → Course Preferences table from overflowing on mobile
 - Added a new "name" field when manually creating new chatbot knowledge base chunks (previously, all chunks were given the name "Manually Inserted Information" - this lets you customize it)
 - Fixed an issue where course professors that lacked the "Organization Professor" role could not create an LMS/Canvas integration for their course

--- a/packages/frontend/public/actually_public/changelog.md
+++ b/packages/frontend/public/actually_public/changelog.md
@@ -60,6 +60,7 @@
   - Users Table now paginated
   - Users Table now searches by email *or* name
   - Courses Table now has more information and is sortable
+- Fixed issue where instead of "Wrong Password" it would say "Request failed with status code 401" when trying to login
 - Minor: started keeping track of when more things are created: enrollments, question types, queue invites, queues, semesters, organizations, users, and courses.
 - Fixed a minor issue where 'helping student in another course' was not working for queue invites
 - Fixed a minor issue where the Checkout button on the course page would only check you out of 1 queue instead of all

--- a/packages/frontend/public/actually_public/changelog.md
+++ b/packages/frontend/public/actually_public/changelog.md
@@ -5,40 +5,42 @@
 #### New Features
 
 - ***General***
-  - Reworked the [landing page](https://coursehelp.ubc.ca/)
-	  - Now with a lot more information and screenshots
-  - Added an [About](https://coursehelp.ubc.ca/about) page
-	  - Has our Privacy Policy, Terms of Service, Changelog, an FAQ, our team, and more
-  - Course Staff can now "Endorse" Anytime Question Comments
-	  - Endorsed comments appear first
-	  - Useful if you have "Allow Anytime Question Authors to make their Questions Public" enabled under Course Settings and you encourage your students to help each other
+  - Reworked the [landing page](https://coursehelp.ubc.ca/)
+    - Now with a lot more information and screenshots
+  - Added an [About](https://coursehelp.ubc.ca/about) page
+    - Has our Privacy Policy, Terms of Service, Changelog, an FAQ, our team, and more
+  - Course Staff can now "Endorse" Anytime Question Comments
+    - Endorsed comments appear first
+    - Useful if you have "Allow Anytime Question Authors to make their Questions Public" enabled under Course Settings and you encourage your students to help each other
+
 
 - ***Faculty-only***
   - Added Weekly Summary emails for professors
-	  - Includes activity, any pending Anytime Questions, and recommendations
-  - Added a "Save to Chatbot" feature when posting a response to an Anytime Question
-	  - Allows your Chatbot to keep getting better as it gets used
-  - Added a "Export Tool Usage to CSV" button under Course Settings → Export Data
-	  - Could be used to chart what tools (Chatbot, Anytime Questions, Queues) each student is using over time
-	  - Could be used to assign participation marks
-  - Added "Professor Invites"
-	  - Works as a regular course invite except it promotes the user to a professor right away
-	  - Useful if you are creating the course for a fellow professor
+    - Includes activity, any pending Anytime Questions, and recommendations
+  - Added a "Save to Chatbot" feature when posting a response to an Anytime Question
+    - Allows your Chatbot to keep getting better as it gets used
+  - Added a "Export Tool Usage to CSV" button under Course Settings → Export Data
+    - Could be used to chart what tools (Chatbot, Anytime Questions, Queues) each student is using over time
+    - Could be used to assign participation marks
+  - Added "Professor Invites"
+    - Works as a regular course invite except it promotes the user to a professor right away
+    - Useful if you are creating the course for a fellow professor
+
 
 #### Improvements
 
 - **Fixed the refresh_token: not found issue** (probably)
-	- You will need to re-create your Canvas integration one last time: Course Settings → LMS Integrations → Delete → Create LMS Integration with Canvas
-	- Let me know if you encounter any issues with it - Adam
+  - You will need to re-create your Canvas integration one last time: Course Settings → LMS Integrations → Delete → Create LMS Integration with Canvas
+  - Let me know if you encounter any issues with it - Adam
 - Anytime Questions now shows "+X additional private question(s)" with improved text for when no questions have been posted
-	- Students naturally ask questions in areas with the most activity, and letting them know that other students have been asking Anytime questions should help increase activity 
+  - Students naturally ask questions in areas with the most activity, and letting them know that other students have been asking Anytime questions should help increase activity 
 - Students may now specify how to pronounce their name under Profile Settings
 - Clarified a lot of the text around LMS integrations
 - Anytime Questions are now paginated
 - Added a "There are no queues in this course" in the Queues dropdown, with instructions for creating new queues for professors
 - TA Check In/Out Times page now shows when TAs mark themselves "Away" 
 - Changed the "Unhappy with your answer? Convert to an Anytime Question" text to "Discuss or verify this with your professor/TA: Convert to Anytime Question"
-	- Also added a "Continue Navigation" confirmation popup
+  - Also added a "Continue Navigation" confirmation popup
 - Added the ability for professors to permanently delete their courses (as opposed to "archiving" them) - useful for accidentally created courses
 - Fixed an issue where users would not get redirected to their course invite after verifying their email
 - Added a button that lets you clear the cache for your backend profile (under Profile → Advanced), which might be helpful if you notice certain pieces of UI not updating when they should
@@ -54,10 +56,10 @@
 - Added a new "name" field when manually creating new chatbot knowledge base chunks (previously, all chunks were given the name "Manually Inserted Information" - this lets you customize it)
 - Fixed an issue where course professors that lacked the "Organization Professor" role could not create an LMS/Canvas integration for their course
 - Various improvements for Admins:
-	- Professor Selectors now show the user's email and the search now works
-	- Users Table now paginated
-	- Users Table now searches by email *or* name
-	- Courses Table now has more information and is sortable
+  - Professor Selectors now show the user's email and the search now works
+  - Users Table now paginated
+  - Users Table now searches by email *or* name
+  - Courses Table now has more information and is sortable
 - Minor: started keeping track of when more things are created: enrollments, question types, queue invites, queues, semesters, organizations, users, and courses.
 - Fixed a minor issue where 'helping student in another course' was not working for queue invites
 - Fixed a minor issue where the Checkout button on the course page would only check you out of 1 queue instead of all

--- a/packages/frontend/public/actually_public/changelog.md
+++ b/packages/frontend/public/actually_public/changelog.md
@@ -32,6 +32,9 @@
 - **Fixed the refresh_token: not found issue** (probably)
   - You will need to re-create your Canvas integration one last time: Course Settings → LMS Integrations → Delete → Create LMS Integration with Canvas
   - Let me know if you encounter any issues with it - Adam
+- **Fixed an issue where queues would appear unresponsive or delayed**
+  - More specifically, any updates to the queue would always be 1 update behind
+  - This also fixes the "Rejoin Queue" button appearing to not work, or the "You are being helped now" popup from showing up right away, amongst other fixes
 - Anytime Questions now shows "+X additional private question(s)" with improved text for when no questions have been posted
   - Students naturally ask questions in areas with the most activity, and letting them know that other students have been asking Anytime questions should help increase activity 
 - Students may now specify how to pronounce their name under Profile Settings

--- a/packages/frontend/public/actually_public/changelog.md
+++ b/packages/frontend/public/actually_public/changelog.md
@@ -52,6 +52,7 @@
 - Fixed an issue with Anytime Questions where the "Set question visible to all students" toggle would sometimes default to "Visible" despite showing "Hidden"
 - Added a feature for LLED courses for AI Assignment Feedback (under Course Settings → Scroll down to Advanced). See its help tooltip for more info.
 - Fixed an issue where the "Test Course" Semester would not show up when creating courses (and made it not show as "ended")
+- Updated "Convert Chatbot/Queue Question to Anytime Question" modals to have "Appear Anonymous" or "Show Publicly" options (the latter only enabled if you have the corresponding setting enabled) 
 - Re-arranged Course Features (under Course Settings) to be easier to digest
 - Added an "Advanced" divider to Course Settings, amongst other re-arrangements
 - Removed the Course Timezone field when created/editing courses since it's unused
@@ -71,6 +72,7 @@
 - Fixed a minor issue where 'helping student in another course' was not working for queue invites
 - Fixed a minor issue where the Checkout button on the course page would only check you out of 1 queue instead of all
 - Various security improvements
+- Improved various help tooltips across the site
 - Various small UI fixes and adjustments
 
 ***

--- a/packages/frontend/public/actually_public/changelog.md
+++ b/packages/frontend/public/actually_public/changelog.md
@@ -44,7 +44,6 @@
 - TA Check In/Out Times page now shows when TAs mark themselves "Away" 
 - Changed the "Unhappy with your answer? Convert to an Anytime Question" text to "Discuss or verify this with your professor/TA: Convert to Anytime Question"
   - Also added a "Continue Navigation" confirmation popup
-- Added the ability for professors to permanently delete their courses (as opposed to "archiving" them) - useful for accidentally created courses
 - Fixed an issue where users would not get redirected to their course invite after verifying their email
 - Added a button that lets you clear the cache for your backend profile (under Profile → Advanced), which might be helpful if you notice certain pieces of UI not updating when they should
 - Added a "Access denied" message when trying to access a course page you lack access to instead of an infinite spinner
@@ -56,7 +55,7 @@
 - Re-arranged Course Features (under Course Settings) to be easier to digest
 - Added an "Advanced" divider to Course Settings, amongst other re-arrangements
 - Removed the Course Timezone field when created/editing courses since it's unused
-- Re-arranged the features in the Add Course form
+- Re-arranged the features in the Add Course form and added "Anytime Questions Use Case" which is only a fancy toggle for allowing students for making their own questions public. It was done this way so that professors can get an idea on what Anytime Questions is for.
 - Edit Course Form Semester Selector now shows how long ago a semester ended
 - Fixed the Profile → Course Preferences table from overflowing on mobile
 - Added a new "name" field when manually creating new chatbot knowledge base chunks (previously, all chunks were given the name "Manually Inserted Information" - this lets you customize it)
@@ -66,6 +65,7 @@
   - Users Table now paginated
   - Users Table now searches by email *or* name
   - Courses Table now has more information and is sortable
+  - Now have the option to fully delete courses (as opposed to just archiving them)
 - Fixed issue where instead of "Wrong Password" it would say "Request failed with status code 401" when trying to login
 - Minor: started keeping track of when more things are created: enrollments, question types, queue invites, queues, semesters, organizations, users, and courses.
 - Fixed a minor issue where 'helping student in another course' was not working for queue invites

--- a/packages/frontend/public/actually_public/changelog.md
+++ b/packages/frontend/public/actually_public/changelog.md
@@ -34,7 +34,7 @@
   - Let me know if you encounter any issues with it - Adam
 - **Fixed an issue where queues would appear unresponsive or delayed**
   - More specifically, any updates to the queue would always be 1 update behind
-  - This also fixes the "Rejoin Queue" button appearing to not work, or the "You are being helped now" popup from showing up right away, amongst other fixes
+  - This also fixes the "Rejoin Queue" button appearing to not work, or the "You are being helped now" popup from showing up right away, the Queue Invite page being unresponsive, amongst other fixes
 - Anytime Questions now shows "+X additional private question(s)" with improved text for when no questions have been posted
   - Students naturally ask questions in areas with the most activity, and letting them know that other students have been asking Anytime questions should help increase activity 
 - Students may now specify how to pronounce their name under Profile Settings

--- a/packages/server/src/alerts/alerts.service.ts
+++ b/packages/server/src/alerts/alerts.service.ts
@@ -10,6 +10,7 @@ import { Injectable } from '@nestjs/common';
 import { QuestionModel } from 'question/question.entity';
 import { QueueModel } from '../queue/queue.entity';
 import { AlertModel } from './alerts.entity';
+import { EntityManager } from 'typeorm';
 
 @Injectable()
 export class AlertsService {
@@ -88,9 +89,13 @@ export class AlertsService {
 
   async getUnresolvedRephraseQuestionAlert(
     queueId: number,
+    manager?: EntityManager,
   ): Promise<AlertModel[]> {
     const alertType = AlertType.REPHRASE_QUESTION;
-    return await AlertModel.createQueryBuilder('alert')
+    const alertQueryBuilder = manager
+      ? manager.getRepository(AlertModel).createQueryBuilder('alert')
+      : AlertModel.createQueryBuilder('alert');
+    return await alertQueryBuilder
       .where('alert.resolved IS NULL')
       .andWhere('alert.alertType = :alertType', { alertType })
       .andWhere("(alert.payload ->> 'queueId')::INTEGER = :queueId ", {

--- a/packages/server/src/auth/auth.service.ts
+++ b/packages/server/src/auth/auth.service.ts
@@ -395,6 +395,8 @@ export class AuthService {
     }
 
     if (password.trim().length < 6 || password.trim().length > 32) {
+      // we need to limit it since bcrpyt the max password length is 72 bytes
+      // Which with UTF-8 is between 18 and 36 characters long (ASCII-only passwords can be 72 chars)
       return res
         .status(HttpStatus.BAD_REQUEST)
         .send({ message: 'Password must be between 6 and 32 characters' });

--- a/packages/server/src/question/question.subscriber.ts
+++ b/packages/server/src/question/question.subscriber.ts
@@ -1,4 +1,4 @@
-import { ClosedQuestionStatus } from '@koh/common';
+import { ClosedQuestionStatus, StatusInQueue } from '@koh/common';
 import {
   DataSource,
   EntitySubscriberInterface,
@@ -36,12 +36,17 @@ export class QuestionSubscriber
   }
 
   async afterUpdate(event: UpdateEvent<QuestionModel>): Promise<void> {
-    if (!event.entity) {
-      // TODO: this is kinda janky maybe fix
+    if (!event.entity || !event.entity.queueId) {
+      console.error(
+        "WARNING in afterUpdate in question.subscriber.ts: There exists a .update() query somewhere that does not pass enough information (queueId) so users won't be notified of a queue update",
+      );
       return;
     }
 
-    await this.queueSSEService.updateQuestions(event.entity.queueId);
+    await this.queueSSEService.updateQuestions(
+      event.entity.queueId,
+      event.manager,
+    );
     // Send push notification to students when they are hit 3rd in line
     // if status updated to closed
     if (
@@ -66,16 +71,25 @@ export class QuestionSubscriber
   }
 
   async afterInsert(event: InsertEvent<QuestionModel>): Promise<void> {
-    const numberOfQuestions = await QuestionModel.waitingInQueue(
-      event.entity.queueId,
-    ).getCount();
+    const numberOfQuestions = await event.manager
+      .getRepository(QuestionModel)
+      .createQueryBuilder('question')
+      .where('question.queueId = :queueId', {
+        queueId: event.entity.queueId,
+      })
+      .andWhere('question.status IN (:...statuses)', {
+        statuses: StatusInQueue,
+      })
+      .getCount();
 
     if (numberOfQuestions === 0) {
-      const queueStaff = await QueueStaffModel.find({
-        where: {
-          queueId: event.entity.queueId,
-        },
-      });
+      const queueStaff = await event.manager
+        .getRepository(QueueStaffModel)
+        .find({
+          where: {
+            queueId: event.entity.queueId,
+          },
+        });
 
       queueStaff.forEach((staff) => {
         this.notifService.notifyUser(
@@ -86,14 +100,20 @@ export class QuestionSubscriber
     }
 
     // Send all listening clients an update
-    await this.queueSSEService.updateQuestions(event.entity.queueId);
+    await this.queueSSEService.updateQuestions(
+      event.entity.queueId,
+      event.manager,
+    );
   }
 
   async beforeRemove(event: RemoveEvent<QuestionModel>): Promise<void> {
     // due to cascades entity is not guaranteed to be loaded
     if (event.entity) {
       // Send all listening clients an update
-      await this.queueSSEService.updateQuestions(event.entity.queueId);
+      await this.queueSSEService.updateQuestions(
+        event.entity.queueId,
+        event.manager,
+      );
     }
   }
 }

--- a/packages/server/src/queue/queue-sse.service.ts
+++ b/packages/server/src/queue/queue-sse.service.ts
@@ -2,6 +2,7 @@ import { Role, SSEQueueResponse } from '@koh/common';
 import { Injectable, Inject, forwardRef } from '@nestjs/common';
 import { Response } from 'express';
 import { throttle } from 'lodash';
+import { EntityManager } from 'typeorm';
 import { SSEService } from 'sse/sse.service';
 import { QueueService } from './queue.service';
 import { QueueChatService } from 'queueChats/queue-chats.service';
@@ -36,8 +37,11 @@ export class QueueSSEService {
   }
 
   // Send event with new questions, but no more than once a second
-  updateQuestions = this.throttleUpdate(async (queueId) => {
-    const queueQuestions = await this.queueService.getQuestions(queueId);
+  updateQuestions = this.throttleUpdate(async (queueId, manager?) => {
+    const queueQuestions = await this.queueService.getQuestions(
+      queueId,
+      manager,
+    );
     if (queueQuestions) {
       await this.sendToRoom(queueId, async ({ role, userId }) => ({
         queueQuestions: await this.queueService.personalizeQuestions(
@@ -45,13 +49,14 @@ export class QueueSSEService {
           queueQuestions,
           userId,
           role,
+          manager,
         ),
       }));
     }
   });
 
-  updateQueue = this.throttleUpdate(async (queueId) => {
-    const queue = await this.queueService.getQueueFormatted(queueId);
+  updateQueue = this.throttleUpdate(async (queueId, manager?) => {
+    const queue = await this.queueService.getQueueFormatted(queueId, manager);
     if (queue) {
       await this.sendToRoom(queueId, async () => ({ queue }));
     }
@@ -86,11 +91,13 @@ export class QueueSSEService {
    * by the first time the function is called.
    * Set leading to false possibly in the future may be a good idea.
    */
-  private throttleUpdate(updateFunction: (queueId: number) => Promise<void>) {
+  private throttleUpdate(
+    updateFunction: (queueId: number, manager?: EntityManager) => Promise<void>,
+  ) {
     return throttle(
-      async (queueId: number) => {
+      async (queueId: number, manager?: EntityManager) => {
         try {
-          await updateFunction(queueId);
+          await updateFunction(queueId, manager);
         } catch (e) {}
       },
       150, // Don't make too high, since it can cause tests to fail as it will run updateFunction even after the endpoint is finished

--- a/packages/server/src/queue/queue.entity.ts
+++ b/packages/server/src/queue/queue.entity.ts
@@ -5,6 +5,7 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  EntityManager,
   JoinColumn,
   ManyToOne,
   OneToMany,
@@ -88,12 +89,19 @@ export class QueueModel extends BaseEntity {
   @Column({ default: 0 })
   queueSize: number;
 
-  async addQueueSize(): Promise<void> {
-    this.queueSize = await QuestionModel.inQueueWithStatus(this.id, [
+  async addQueueSize(manager?: EntityManager): Promise<void> {
+    const statuses = [
       ...StatusInQueue,
       OpenQuestionStatus.Helping,
       OpenQuestionStatus.Paused,
-    ]).getCount();
+    ];
+    const queryBuilder = manager
+      ? manager.getRepository(QuestionModel).createQueryBuilder('question')
+      : QuestionModel.createQueryBuilder('question');
+    this.queueSize = await queryBuilder
+      .where('question.queueId = :queueId', { queueId: this.id })
+      .andWhere('question.status IN (:...statuses)', { statuses })
+      .getCount();
   }
 
   @Column('json', { nullable: true })

--- a/packages/server/src/queue/queue.service.ts
+++ b/packages/server/src/queue/queue.service.ts
@@ -26,7 +26,7 @@ import {
 import { classToClass } from 'class-transformer';
 import { pick } from 'lodash';
 import { QuestionModel } from 'question/question.entity';
-import { DataSource, In } from 'typeorm';
+import { DataSource, EntityManager, In } from 'typeorm';
 import { QueueModel } from './queue.entity';
 import { AlertsService } from '../alerts/alerts.service';
 import { ApplicationConfigService } from '../config/application_config.service';
@@ -50,59 +50,76 @@ export class QueueService {
   Before returning the queue to frontend, use formatStaffListPropertyForFrontend() or getFormattedStaffList() to make sure the staff list is the right structure.
   (Since the stafflist our frontend uses is not the same structure as the backend)
   */
-  async getQueueRaw(queueId: number): Promise<QueueModel> {
-    const queue = await QueueModel.findOne({
-      where: {
-        id: queueId,
-      },
-      relations: {
-        queueStaff: {
-          user: {
-            courses: true,
-          },
-        },
-      },
-    });
-    await queue.addQueueSize();
+  async getQueueRaw(
+    queueId: number,
+    manager?: EntityManager,
+  ): Promise<QueueModel> {
+    const queue = manager
+      ? await manager.getRepository(QueueModel).findOne({
+          where: { id: queueId },
+          relations: { queueStaff: { user: { courses: true } } },
+        })
+      : await QueueModel.findOne({
+          where: { id: queueId },
+          relations: { queueStaff: { user: { courses: true } } },
+        });
+    await queue.addQueueSize(manager);
 
     return queue;
   }
 
   /* Queries for a QueueModel and formats it for the frontend */
-  async getQueueFormatted(queueId: number): Promise<GetQueueResponse> {
+  async getQueueFormatted(
+    queueId: number,
+    manager?: EntityManager,
+  ): Promise<GetQueueResponse> {
     return await this.queueStaffService.formatStaffListPropertyForFrontend(
-      await this.getQueueRaw(queueId),
+      await this.getQueueRaw(queueId, manager),
     );
   }
 
-  async getQuestions(queueId: number): Promise<ListQuestionsResponse> {
+  async getQuestions(
+    queueId: number,
+    manager?: EntityManager,
+  ): Promise<ListQuestionsResponse> {
     // todo: Make a student and a TA version of this function, and switch which one to use in the controller
     // for now, just return the student response
-    const queueSize = await QueueModel.count({
-      where: { id: queueId },
-    });
+    const queueSize = manager
+      ? await manager
+          .getRepository(QueueModel)
+          .count({ where: { id: queueId } })
+      : await QueueModel.count({ where: { id: queueId } });
     // Check that the queue exists
     if (queueSize === 0) {
       throw new NotFoundException();
     }
 
-    const questionsFromDb = await QuestionModel.inQueueWithStatus(
-      queueId,
-      [
-        ...StatusInPriorityQueue,
-        ...StatusInQueue,
-        OpenQuestionStatus.Helping,
-        OpenQuestionStatus.Paused,
-      ],
-      this.appConfig.get('max_questions_per_queue'),
-    )
+    const questionQueryBuilder = manager
+      ? manager.getRepository(QuestionModel).createQueryBuilder('question')
+      : QuestionModel.createQueryBuilder('question');
+
+    const questionsFromDb = await questionQueryBuilder
+      .where('question.queueId = :queueId', { queueId })
+      .andWhere('question.status IN (:...statuses)', {
+        statuses: [
+          ...StatusInPriorityQueue,
+          ...StatusInQueue,
+          OpenQuestionStatus.Helping,
+          OpenQuestionStatus.Paused,
+        ],
+      })
+      .limit(this.appConfig.get('max_questions_per_queue'))
+      .orderBy('question.createdAt', 'ASC')
       .leftJoinAndSelect('question.questionTypes', 'questionTypes')
       .leftJoinAndSelect('question.creator', 'creator')
       .leftJoinAndSelect('question.taHelped', 'taHelped')
       .getMany();
 
     const unresolvedRephraseQuestionAlerts =
-      await this.alertsService.getUnresolvedRephraseQuestionAlert(queueId);
+      await this.alertsService.getUnresolvedRephraseQuestionAlert(
+        queueId,
+        manager,
+      );
 
     const queueQuestions = new ListQuestionsResponse();
 
@@ -185,6 +202,7 @@ export class QueueService {
     queueQuestions: ListQuestionsResponse,
     userId: number,
     role: Role,
+    manager?: EntityManager,
   ): Promise<ListQuestionsResponse> {
     if (role === Role.STUDENT) {
       const newLQR = new ListQuestionsResponse();
@@ -218,14 +236,23 @@ export class QueueService {
         );
       }
 
-      newLQR.yourQuestions = await QuestionModel.find({
-        relations: ['creator', 'taHelped'],
-        where: {
-          creatorId: userId,
-          queueId: queueId,
-          status: In(StatusSentToCreator),
-        },
-      });
+      newLQR.yourQuestions = manager
+        ? await manager.getRepository(QuestionModel).find({
+            relations: { creator: true, taHelped: true },
+            where: {
+              creatorId: userId,
+              queueId: queueId,
+              status: In(StatusSentToCreator),
+            },
+          })
+        : await QuestionModel.find({
+            relations: { creator: true, taHelped: true },
+            where: {
+              creatorId: userId,
+              queueId: queueId,
+              status: In(StatusSentToCreator),
+            },
+          });
       newLQR.priorityQueue = [];
 
       if (newLQR.yourQuestions) {

--- a/packages/server/src/queue/queue.subscriber.ts
+++ b/packages/server/src/queue/queue.subscriber.ts
@@ -15,7 +15,7 @@ export class QueueSubscriber implements EntitySubscriberInterface<QueueModel> {
     dataSource.subscribers.push(this);
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+   
   listenTo() {
     return QueueModel;
   }
@@ -23,7 +23,7 @@ export class QueueSubscriber implements EntitySubscriberInterface<QueueModel> {
   async afterUpdate(event: UpdateEvent<QueueModel>): Promise<void> {
     if (event.entity) {
       // Send all listening clients an update
-      await this.queueSSEService.updateQueue(event.entity.id);
+      await this.queueSSEService.updateQueue(event.entity.id, event.manager);
     }
   }
 }


### PR DESCRIPTION



# Description

Changelog for 1.9.0 and comes with a bunch of fixes, including an old bug where the queue was always 1-step behind with its updates! It feels a LOT better now!

TODO: update prod env to also be on 1.9.0

Also re-did the Add Course form. Did the Segmented like that since it shows newer profs what you would use Anytime Questions for more than anything. All the Segmented does is toggle asnycCentreAuthorPublic (default is TRUE now despite what Ramon initially wanted since I think allowing students to help each other is ideal for learning)
<img width="1376" height="932" alt="image" src="https://github.com/user-attachments/assets/227c93de-d1cb-4b5a-82a9-36a4bb1b2767" />

Also I realised that the Convert to Anytime modals weren't updated to have isAnonymous and showPublicly options.
<img width="709" height="608" alt="image" src="https://github.com/user-attachments/assets/337196bb-ef58-4aa3-9708-c57132f8b22b" />


Closes #510 , partially fixes #432 but i haven't tested the Away toggle.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] This requires a run of `yarn install`
- [ ] This change requires an addition/change to the **production .env variables**. These changes are below:
- [ ] This change requires an addition/change to **developers' .env variables**. These changes are below:
- [ ] This change requires a database query to update old data on production that for some reason can't be done via migration. This query is below:


# How Has This Been Tested?

All manual, did lots of it too


# Checklist:

- [x] I have performed a code review of my own code (under the "Files Changed" tab on github) to ensure nothing is committed that shouldn't be (e.g. leftover `console.log`s, leftover unused logic, or anything else that was accidentally committed)
- [x] I have commented my code where needed 
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing tests pass *locally* with my changes
- [x] Any work that this PR is dependent on has been merged into the main branch
- [x] Any UI changes have been checked to work on desktop, tablet, and mobile
